### PR TITLE
Template attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Some of the features of this library:
 * [X] Support for different encodings
 * [X] Support sending mails via a local sendmail command
 * [X] Message object satisfies `io.WriteTo` and `io.Reader` interfaces
+* [X] Support for Go's `html/template` and `text/template` (as message body, alternative part or attachment/emebed)
 
 go-mail works like a programatic email client and provides lots of methods and functionalities you would consider
 standard in a MUA.

--- a/doc.go
+++ b/doc.go
@@ -2,4 +2,4 @@
 package mail
 
 // VERSION is used in the default user agent string
-const VERSION = "0.1.9"
+const VERSION = "0.2.2"

--- a/msg.go
+++ b/msg.go
@@ -488,7 +488,7 @@ func (m *Msg) WriteTo(w io.Writer) (int64, error) {
 	return mw.n, mw.err
 }
 
-// Write is an alias method to WriteTo due to compatiblity reasons
+// Write is an alias method to WriteTo due to compatibility reasons
 func (m *Msg) Write(w io.Writer) (int64, error) {
 	return m.WriteTo(w)
 }

--- a/msg.go
+++ b/msg.go
@@ -405,6 +405,9 @@ func (m *Msg) SetBodyWriter(ct ContentType, w func(io.Writer) (int64, error), o 
 // SetBodyHTMLTemplate sets the body of the message from a given html/template.Template pointer
 // The content type will be set to text/html automatically
 func (m *Msg) SetBodyHTMLTemplate(t *ht.Template, d interface{}, o ...PartOption) error {
+	if t == nil {
+		return fmt.Errorf("template pointer is nil")
+	}
 	buf := bytes.Buffer{}
 	if err := t.Execute(&buf, d); err != nil {
 		return fmt.Errorf("failed to execute template: %w", err)
@@ -417,6 +420,9 @@ func (m *Msg) SetBodyHTMLTemplate(t *ht.Template, d interface{}, o ...PartOption
 // SetBodyTextTemplate sets the body of the message from a given text/template.Template pointer
 // The content type will be set to text/plain automatically
 func (m *Msg) SetBodyTextTemplate(t *tt.Template, d interface{}, o ...PartOption) error {
+	if t == nil {
+		return fmt.Errorf("template pointer is nil")
+	}
 	buf := bytes.Buffer{}
 	if err := t.Execute(&buf, d); err != nil {
 		return fmt.Errorf("failed to execute template: %w", err)
@@ -443,6 +449,9 @@ func (m *Msg) AddAlternativeWriter(ct ContentType, w func(io.Writer) (int64, err
 // AddAlternativeHTMLTemplate sets the alternative body of the message to a html/template.Template output
 // The content type will be set to text/html automatically
 func (m *Msg) AddAlternativeHTMLTemplate(t *ht.Template, d interface{}, o ...PartOption) error {
+	if t == nil {
+		return fmt.Errorf("template pointer is nil")
+	}
 	buf := bytes.Buffer{}
 	if err := t.Execute(&buf, d); err != nil {
 		return fmt.Errorf("failed to execute template: %w", err)
@@ -455,6 +464,9 @@ func (m *Msg) AddAlternativeHTMLTemplate(t *ht.Template, d interface{}, o ...Par
 // AddAlternativeTextTemplate sets the alternative body of the message to a text/template.Template output
 // The content type will be set to text/plain automatically
 func (m *Msg) AddAlternativeTextTemplate(t *tt.Template, d interface{}, o ...PartOption) error {
+	if t == nil {
+		return fmt.Errorf("template pointer is nil")
+	}
 	buf := bytes.Buffer{}
 	if err := t.Execute(&buf, d); err != nil {
 		return fmt.Errorf("failed to execute template: %w", err)
@@ -754,6 +766,9 @@ func fileFromReader(n string, r io.Reader) *File {
 
 // fileFromHTMLTemplate returns a File pointer form a given html/template.Template
 func fileFromHTMLTemplate(n string, t *ht.Template, d interface{}) (*File, error) {
+	if t == nil {
+		return nil, fmt.Errorf("template pointer is nil")
+	}
 	buf := bytes.Buffer{}
 	if err := t.Execute(&buf, d); err != nil {
 		return nil, fmt.Errorf("failed to execute template: %w", err)
@@ -764,6 +779,9 @@ func fileFromHTMLTemplate(n string, t *ht.Template, d interface{}) (*File, error
 
 // fileFromTextTemplate returns a File pointer form a given text/template.Template
 func fileFromTextTemplate(n string, t *tt.Template, d interface{}) (*File, error) {
+	if t == nil {
+		return nil, fmt.Errorf("template pointer is nil")
+	}
 	buf := bytes.Buffer{}
 	if err := t.Execute(&buf, d); err != nil {
 		return nil, fmt.Errorf("failed to execute template: %w", err)


### PR DESCRIPTION
This PR implements full support for html/template and text/template. It will allow to set the message body, alternative body as well as attachments/embeds using the Go template engine.