### PR TITLE
Add support for storing mail messages in files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/wneessen/go-mail
 
-go 1.17
+go 1.16

--- a/msg.go
+++ b/msg.go
@@ -593,6 +593,21 @@ func (m *Msg) appendFile(c []*File, f *File, o ...FileOption) []*File {
 	return append(c, f)
 }
 
+// WriteToFile stores the Msg as file on disk. It will try to create the given filename
+// Already existing files will be overwritten
+func (m *Msg) WriteToFile(n string) error {
+	f, err := os.Create(n)
+	if err != nil {
+		return fmt.Errorf("failed to create output file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	_, err = m.WriteTo(f)
+	if err != nil {
+		return fmt.Errorf("failed to write to output file: %w", err)
+	}
+	return f.Close()
+}
+
 // WriteToSendmail returns WriteToSendmailWithCommand with a default sendmail path
 func (m *Msg) WriteToSendmail() error {
 	return m.WriteToSendmailWithCommand(SendmailPath)

--- a/msg_test.go
+++ b/msg_test.go
@@ -7,6 +7,7 @@ import (
 	htpl "html/template"
 	"io"
 	"net/mail"
+	"os"
 	"strings"
 	"testing"
 	ttpl "text/template"
@@ -1698,5 +1699,45 @@ func TestMsg_EmbedHTMLTemplate(t *testing.T) {
 			}
 			m.Reset()
 		})
+	}
+}
+
+// TestMsg_WriteToTempFile will test the output to temporary files
+func TestMsg_WriteToTempFile(t *testing.T) {
+	m := NewMsg()
+	_ = m.From("Toni Tester <tester@example.com>")
+	_ = m.To("Ellenor Tester <ellinor@example.com>")
+	m.SetBodyString(TypeTextPlain, "This is a test")
+	f, err := m.WriteToTempFile()
+	if err != nil {
+		t.Errorf("failed to write message to temporary output file: %s", err)
+	}
+	_ = os.Remove(f)
+}
+
+// TestMsg_WriteToFile will test the output to a file
+func TestMsg_WriteToFile(t *testing.T) {
+	f, err := os.CreateTemp("", "go-mail-test_*.eml")
+	if err != nil {
+		t.Errorf("failed to create temporary output file: %s", err)
+	}
+	defer func() {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+	}()
+
+	m := NewMsg()
+	_ = m.From("Toni Tester <tester@example.com>")
+	_ = m.To("Ellenor Tester <ellinor@example.com>")
+	m.SetBodyString(TypeTextPlain, "This is a test")
+	if err := m.WriteToFile(f.Name()); err != nil {
+		t.Errorf("failed to write to output file: %s", err)
+	}
+	fi, err := os.Stat(f.Name())
+	if err != nil {
+		t.Errorf("failed to stat output file: %s", err)
+	}
+	if fi.Size() <= 0 {
+		t.Errorf("output file is expected to contain data but its size is zero")
 	}
 }

--- a/msg_totmpfile.go
+++ b/msg_totmpfile.go
@@ -8,9 +8,9 @@ import (
 	"os"
 )
 
-// WriteToTempfile will create a temporary file and output the Msg to this file
+// WriteToTempFile will create a temporary file and output the Msg to this file
 // The method will return the filename of the temporary file
-func (m *Msg) WriteToTempfile() (string, error) {
+func (m *Msg) WriteToTempFile() (string, error) {
 	f, err := os.CreateTemp("", "go-mail_*.eml")
 	if err != nil {
 		return "", fmt.Errorf("failed to create output file: %w", err)

--- a/msg_totmpfile.go
+++ b/msg_totmpfile.go
@@ -1,0 +1,20 @@
+//go:build go1.17
+// +build go1.17
+
+package mail
+
+import (
+	"fmt"
+	"os"
+)
+
+// WriteToTempfile will create a temporary file and output the Msg to this file
+// The method will return the filename of the temporary file
+func (m *Msg) WriteToTempfile() (string, error) {
+	f, err := os.CreateTemp("", "go-mail_*.eml")
+	if err != nil {
+		return "", fmt.Errorf("failed to create output file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	return f.Name(), m.WriteToFile(f.Name())
+}

--- a/msg_totmpfile_116.go
+++ b/msg_totmpfile_116.go
@@ -1,0 +1,20 @@
+//go:build !go1.17
+// +build !go1.17
+
+package mail
+
+import (
+	"fmt"
+	"io/ioutil"
+)
+
+// WriteToTempfile will create a temporary file and output the Msg to this file
+// The method will return the filename of the temporary file
+func (m *Msg) WriteToTempfile() (string, error) {
+	f, err := ioutil.TempFile("", "go-mail_*.eml")
+	if err != nil {
+		return "", fmt.Errorf("failed to create output file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	return f.Name(), m.WriteToFile(f.Name())
+}

--- a/msg_totmpfile_116.go
+++ b/msg_totmpfile_116.go
@@ -8,9 +8,9 @@ import (
 	"io/ioutil"
 )
 
-// WriteToTempfile will create a temporary file and output the Msg to this file
+// WriteToTempFile will create a temporary file and output the Msg to this file
 // The method will return the filename of the temporary file
-func (m *Msg) WriteToTempfile() (string, error) {
+func (m *Msg) WriteToTempFile() (string, error) {
 	f, err := ioutil.TempFile("", "go-mail_*.eml")
 	if err != nil {
 		return "", fmt.Errorf("failed to create output file: %w", err)


### PR DESCRIPTION
This PR adds support for storing the output of a `Msg` into a file. Either an automatically generated temp file using `Msg.WriteToTempFile` or by providing ones own file name using `Msg.WriteToFile`.

Closes #18 