### PR TITLE
Fixes bug with attachment encoding

### DIFF
--- a/base64_writer.go
+++ b/base64_writer.go
@@ -1,0 +1,56 @@
+package mail
+
+import "io"
+
+// Base64LineBreaker is a io.WriteCloser that writes Base64 encoded data streams
+// with line breaks at a given line length
+type Base64LineBreaker struct {
+	line [MaxBodyLength]byte
+	used int
+	out  io.Writer
+}
+
+var nl = []byte(SingleNewLine)
+
+// Write writes the data stream and inserts a SingleNewLine when the maximum
+// line length is reached
+func (l *Base64LineBreaker) Write(b []byte) (n int, err error) {
+	if l.used+len(b) < MaxBodyLength {
+		copy(l.line[l.used:], b)
+		l.used += len(b)
+		return len(b), nil
+	}
+
+	n, err = l.out.Write(l.line[0:l.used])
+	if err != nil {
+		return
+	}
+	excess := MaxBodyLength - l.used
+	l.used = 0
+
+	n, err = l.out.Write(b[0:excess])
+	if err != nil {
+		return
+	}
+
+	n, err = l.out.Write(nl)
+	if err != nil {
+		return
+	}
+
+	return l.Write(b[excess:])
+}
+
+// Close closes the Base64LineBreaker and writes any access data that is still
+// unwritten in memory
+func (l *Base64LineBreaker) Close() (err error) {
+	if l.used > 0 {
+		_, err = l.out.Write(l.line[0:l.used])
+		if err != nil {
+			return
+		}
+		_, err = l.out.Write(nl)
+	}
+
+	return
+}

--- a/base64_writer.go
+++ b/base64_writer.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2022 Winni Neessen <winni@neessen.dev>
+//
+// SPDX-License-Identifier: MIT
+
 package mail
 
 import "io"


### PR DESCRIPTION
Hopefully addresses #37 too.

By default, the encoding/base64 in Go does not add line breaks to its output. This patch introduces the Base64LineBreaker which satisfies the io.WriteCloser interface. Attachments are now correctly broken up into maximum of 76 chars. This hopefully satisfies the requirements of more strict mail servers, that do not allow lines longer than 78 chars (SHOULD)/998 chars(MUST) - see: https://www.rfc-editor.org/rfc/rfc5322#section-2.1.1