### PR TITLE
Add GetGenHeader to Msg

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -478,6 +478,11 @@ func (m *Msg) GetRecipients() ([]string, error) {
 	return rl, nil
 }
 
+// GetGenHeader returns the content of the requested generic header of the Msg
+func (m *Msg) GetGenHeader(h Header) []string {
+	return m.genHeader[h]
+}
+
 // SetBodyString sets the body of the message.
 func (m *Msg) SetBodyString(ct ContentType, b string, o ...PartOption) {
 	buf := bytes.NewBufferString(b)

--- a/msg_test.go
+++ b/msg_test.go
@@ -2105,3 +2105,20 @@ func TestMsg_WriteToFile(t *testing.T) {
 		t.Errorf("output file is expected to contain data but its size is zero")
 	}
 }
+
+// TestMsg_GetGenHeader will test the GetGenHeader method of the Msg
+func TestMsg_GetGenHeader(t *testing.T) {
+	m := NewMsg()
+	m.Subject("this is a test")
+	sa := m.GetGenHeader(HeaderSubject)
+	if len(sa) <= 0 {
+		t.Errorf("GetGenHeader on subject failed. Got empty slice")
+		return
+	}
+	if sa[0] == "" {
+		t.Errorf("GetGenHeader on subject failed. Got empty value")
+	}
+	if sa[0] != "this is a test" {
+		t.Errorf("GetGenHeader on subject failed. Expected: %q, got: %q", "this is a test", sa[0])
+	}
+}


### PR DESCRIPTION
For Middlware to act on generic headers, we need to provide a way to access them. `Msg.GetGenHeader()` returns the value of the requested header of the Msg.