### PR TITLE
Fix codecov Go version setup

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -37,16 +37,17 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@master
-    
+    - name: Setup go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go }}
     - name: Install sendmail
       if: matrix.go == 1.19 && matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get -y install sendmail; which sendmail
-        
     - name: Run Tests
       run: |
         go test -v -race --coverprofile=coverage.coverprofile --covermode=atomic ./...
-    
     - name: Upload coverage to Codecov
       if: success() && matrix.go == 1.19 && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
           
       - name: Setup Go
-        uses: actions/setup-go@v2.1.3
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
           


### PR DESCRIPTION
The different Go version usages in the codecov workflow were missing the actual go setup set, which caused all tests to always run with Go 1.17. This PR fixes this