### PR TITLE
New Reader type

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -807,6 +807,26 @@ func (m *Msg) WriteToSendmailWithContext(ctx context.Context, sp string, a ...st
 	return nil
 }
 
+// NewReader returns a Msg reader that satisfies the io.Reader interface.
+// **Please note:** when creating a new reader, the current state of the Msg is taken, as
+// basis for the reader. If you perform changes on Msg after creating the reader, you need
+// to perform a call to Msg.UpdateReader first
+func (m *Msg) NewReader() io.Reader {
+	wbuf := bytes.Buffer{}
+	_, _ = m.Write(&wbuf)
+	r := &reader{buf: wbuf.Bytes()}
+	return r
+}
+
+// UpdateReader will update a reader with the content of the current Msg and reset the reader position
+// to the start
+func (m *Msg) UpdateReader(r *reader) {
+	wbuf := bytes.Buffer{}
+	_, _ = m.Write(&wbuf)
+	r.Reset()
+	r.buf = wbuf.Bytes()
+}
+
 // Read outputs the length of p into p to satisfy the io.Reader interface
 func (m *Msg) Read(p []byte) (int, error) {
 	wbuf := bytes.Buffer{}

--- a/msg.go
+++ b/msg.go
@@ -181,6 +181,9 @@ func (m *Msg) Charset() string {
 
 // SetHeader sets a generic header field of the Msg
 func (m *Msg) SetHeader(h Header, v ...string) {
+	if m.genHeader == nil {
+		m.genHeader = make(map[Header][]string)
+	}
 	for i, hv := range v {
 		v[i] = m.encodeString(hv)
 	}
@@ -189,6 +192,9 @@ func (m *Msg) SetHeader(h Header, v ...string) {
 
 // SetAddrHeader sets an address related header field of the Msg
 func (m *Msg) SetAddrHeader(h AddrHeader, v ...string) error {
+	if m.addrHeader == nil {
+		m.addrHeader = make(map[AddrHeader][]*mail.Address)
+	}
 	var al []*mail.Address
 	for _, av := range v {
 		a, err := mail.ParseAddress(av)

--- a/msg.go
+++ b/msg.go
@@ -840,16 +840,6 @@ func (m *Msg) UpdateReader(r *Reader) {
 	r.err = err
 }
 
-// Read outputs the length of p into p to satisfy the io.Reader interface
-func (m *Msg) Read(p []byte) (int, error) {
-	wbuf := bytes.Buffer{}
-	_, err := m.WriteTo(&wbuf)
-	if err != nil {
-		return 0, fmt.Errorf("failed to write message to internal write buffer: %w", err)
-	}
-	return wbuf.Read(p)
-}
-
 // encodeString encodes a string based on the configured message encoder and the corresponding
 // charset for the Msg
 func (m *Msg) encodeString(s string) string {

--- a/reader.go
+++ b/reader.go
@@ -15,6 +15,11 @@ type Reader struct {
 	err error  // initalization error
 }
 
+// Error returns an error if the Reader err field is not nil
+func (r *Reader) Error() error {
+	return r.err
+}
+
 // Read reads the length of p of the Msg buffer to satisfy the io.Reader interface
 func (r *Reader) Read(p []byte) (n int, err error) {
 	if r.err != nil {

--- a/reader.go
+++ b/reader.go
@@ -4,16 +4,22 @@
 
 package mail
 
-import "io"
+import (
+	"io"
+)
 
-// reader is a type that implements the io.Reader interface for a Msg
-type reader struct {
+// Reader is a type that implements the io.Reader interface for a Msg
+type Reader struct {
 	buf []byte // contents are the bytes buf[off : len(buf)]
 	off int    // read at &buf[off], write at &buf[len(buf)]
+	err error  // initalization error
 }
 
 // Read reads the length of p of the Msg buffer to satisfy the io.Reader interface
-func (r *reader) Read(p []byte) (n int, err error) {
+func (r *Reader) Read(p []byte) (n int, err error) {
+	if r.err != nil {
+		return 0, r.err
+	}
 	if r.empty() {
 		r.Reset()
 		if len(p) == 0 {
@@ -23,15 +29,15 @@ func (r *reader) Read(p []byte) (n int, err error) {
 	}
 	n = copy(p, r.buf[r.off:])
 	r.off += n
-	return n, nil
+	return n, err
 }
 
 // Reset resets the Reader buffer to be empty, but it retains the underlying storage
 // for use by future writes.
-func (r *reader) Reset() {
+func (r *Reader) Reset() {
 	r.buf = r.buf[:0]
 	r.off = 0
 }
 
 // empty reports whether the unread portion of the Reader buffer is empty.
-func (r *reader) empty() bool { return len(r.buf) <= r.off }
+func (r *Reader) empty() bool { return len(r.buf) <= r.off }

--- a/reader.go
+++ b/reader.go
@@ -1,0 +1,33 @@
+package mail
+
+import "io"
+
+// reader is a type that implements the io.Reader interface for a Msg
+type reader struct {
+	buf []byte // contents are the bytes buf[off : len(buf)]
+	off int    // read at &buf[off], write at &buf[len(buf)]
+}
+
+// Read reads the length of p of the Msg buffer to satisfy the io.Reader interface
+func (r *reader) Read(p []byte) (n int, err error) {
+	if r.empty() {
+		r.Reset()
+		if len(p) == 0 {
+			return 0, nil
+		}
+		return 0, io.EOF
+	}
+	n = copy(p, r.buf[r.off:])
+	r.off += n
+	return n, nil
+}
+
+// Reset resets the Reader buffer to be empty, but it retains the underlying storage
+// for use by future writes.
+func (r *reader) Reset() {
+	r.buf = r.buf[:0]
+	r.off = 0
+}
+
+// empty reports whether the unread portion of the Reader buffer is empty.
+func (r *reader) empty() bool { return len(r.buf) <= r.off }

--- a/reader.go
+++ b/reader.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2022 Winni Neessen <winni@neessen.dev>
+//
+// SPDX-License-Identifier: MIT
+
 package mail
 
 import "io"

--- a/reader_test.go
+++ b/reader_test.go
@@ -1,0 +1,68 @@
+package mail
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+// TestReader_Read tests the Reader.Read method that implements the io.Reader interface
+func TestReader_Read(t *testing.T) {
+	tests := []struct {
+		name string
+		plen int
+	}{
+		{"P length is bigger than the mail", 3200000},
+		{"P length is smaller than the mail", 128},
+	}
+
+	m := NewMsg()
+	m.SetBodyString(TypeTextPlain, "TEST123")
+	wbuf := bytes.Buffer{}
+	_, err := m.Write(&wbuf)
+	if err != nil {
+		t.Errorf("failed to write message into temporary buffer: %s", err)
+	}
+	elen := wbuf.Len()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := make([]byte, tt.plen)
+			mr := m.NewReader()
+			n, err := mr.Read(p)
+			if err != nil {
+				t.Errorf("failed to Read(): %s", err)
+			}
+			if n == 0 {
+				t.Errorf("failed to Read() - received 0 bytes of data")
+			}
+			if tt.plen >= elen && n != elen {
+				t.Errorf("failed to Read() - not all data received. Expected: %d, got: %d", elen, n)
+			}
+			if tt.plen < elen && n != tt.plen {
+				t.Errorf("failed to Read() - full length of p wasn't filled with data. Expected: %d, got: %d",
+					tt.plen, n)
+			}
+		})
+	}
+}
+
+// TestReader_Read_error tests the Reader.Read method with an intentional error
+func TestReader_Read_error(t *testing.T) {
+	r := Reader{err: fmt.Errorf("FAILED")}
+	var p []byte
+	_, err := r.Read(p)
+	if err == nil {
+		t.Errorf("Reader was supposed to fail, but didn't")
+	}
+}
+
+// TestReader_Read_empty tests the Reader.Read method with an empty buffer
+func TestReader_Read_empty(t *testing.T) {
+	r := Reader{buf: []byte{}}
+	var p []byte
+	_, err := r.Read(p)
+	if err != nil {
+		t.Errorf("Reader failed: %s", err)
+	}
+}

--- a/reader_test.go
+++ b/reader_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2022 Winni Neessen <winni@neessen.dev>
+//
+// SPDX-License-Identifier: MIT
+
 package mail
 
 import (


### PR DESCRIPTION
Initially the Msg implemented a io.Reader interface by providing a Read() methods. Unfortunately the method chosen for this method was very naive. It works fine for smaller messages but could result in wrong data returned for larger messages or i. e. used in a bufio.Reader with non consecutive reads. Since we did not track the position and state of the reading operation, duplicate data might be returned to the caller eventually even leading into infinite loops.

This PR fixes the issue be introducing a new `Reader` type. The `Reader` type satisfies the `io.Reader` interface and returns the data properly as well as returns `EOF` in case the end of data is reached.

The initial `Read()` method has been removed from the `Msg` type which and instead a `NewReader()` method has been introduced that returns the `Reader` type. 

**BREAKING CHANGE**: Since we remove the `Read` method from the `Msg` the `Msg` does not satisfy the `io.Reader` interface anymore, which is considered a breaking change. But given that the returned data of the original implementation might return duplicate or wrong data, this breaking change is considered as the right decision.