### PR TITLE
Introducing MiddlewareType and WriteToSkipMiddleware

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -722,7 +722,7 @@ func (m *Msg) WriteTo(w io.Writer) (int64, error) {
 // the io.WriteTo interface but will skip the given Middleware
 func (m *Msg) WriteToSkipMiddleware(w io.Writer, mt MiddlewareType) (int64, error) {
 	var omwl, mwl []Middleware
-	copy(omwl, m.middlewares)
+	omwl = m.middlewares
 	for i := range m.middlewares {
 		if m.middlewares[i].Type() == mt {
 			continue

--- a/msg.go
+++ b/msg.go
@@ -42,9 +42,14 @@ const (
 	errParseMailAddr = "failed to parse mail address %q: %w"
 )
 
+// MiddlewareType is the type description of the Middleware and needs to be returned
+// in the Middleware interface by the Type method
+type MiddlewareType string
+
 // Middleware is an interface to define a function to apply to Msg before sending
 type Middleware interface {
 	Handle(*Msg) *Msg
+	Type() MiddlewareType
 }
 
 // Msg is the mail message struct
@@ -710,6 +715,24 @@ func (m *Msg) applyMiddlewares(ms *Msg) *Msg {
 func (m *Msg) WriteTo(w io.Writer) (int64, error) {
 	mw := &msgWriter{w: w, c: m.charset, en: m.encoder}
 	mw.writeMsg(m.applyMiddlewares(m))
+	return mw.n, mw.err
+}
+
+// WriteToSkipMiddleware writes the formated Msg into a give io.Writer and satisfies
+// the io.WriteTo interface but will skip the given Middleware
+func (m *Msg) WriteToSkipMiddleware(w io.Writer, mt MiddlewareType) (int64, error) {
+	var omwl, mwl []Middleware
+	copy(omwl, m.middlewares)
+	for i := range m.middlewares {
+		if m.middlewares[i].Type() == mt {
+			continue
+		}
+		mwl = append(mwl, m.middlewares[i])
+	}
+	m.middlewares = mwl
+	mw := &msgWriter{w: w, c: m.charset, en: m.encoder}
+	mw.writeMsg(m.applyMiddlewares(m))
+	m.middlewares = omwl
 	return mw.n, mw.err
 }
 

--- a/msg_test.go
+++ b/msg_test.go
@@ -189,6 +189,10 @@ func (mw uppercaseMiddleware) Handle(m *Msg) *Msg {
 	return m
 }
 
+func (mw uppercaseMiddleware) Type() MiddlewareType {
+	return "uppercase"
+}
+
 type encodeMiddleware struct{}
 
 func (mw encodeMiddleware) Handle(m *Msg) *Msg {
@@ -198,6 +202,10 @@ func (mw encodeMiddleware) Handle(m *Msg) *Msg {
 	}
 	m.Subject(strings.Replace(s[0], "a", "@", -1))
 	return m
+}
+
+func (mw encodeMiddleware) Type() MiddlewareType {
+	return "encode"
 }
 
 // TestNewMsgWithMiddleware tests WithMiddleware
@@ -1581,6 +1589,25 @@ func TestMsg_WriteTo(t *testing.T) {
 	}
 	if n != int64(wbuf.Len()) {
 		t.Errorf("WriteTo() failed: expected written byte length: %d, got: %d", n, wbuf.Len())
+	}
+}
+
+// TestMsg_WriteTo tests the WriteTo() method of the Msg
+func TestMsg_WriteToSkipMiddleware(t *testing.T) {
+	m := NewMsg(WithMiddleware(encodeMiddleware{}), WithMiddleware(uppercaseMiddleware{}))
+	m.Subject("This is a test")
+	m.SetBodyString(TypeTextPlain, "Plain")
+	wbuf := bytes.Buffer{}
+	n, err := m.WriteToSkipMiddleware(&wbuf, "uppercase")
+	if err != nil {
+		t.Errorf("WriteTo() failed: %s", err)
+		return
+	}
+	if n != int64(wbuf.Len()) {
+		t.Errorf("WriteTo() failed: expected written byte length: %d, got: %d", n, wbuf.Len())
+	}
+	if !strings.Contains(wbuf.String(), "Subject: This is @ test") {
+		t.Errorf("WriteToSkipMiddleware failed. Unable to find encoded subject")
 	}
 }
 

--- a/msg_test.go
+++ b/msg_test.go
@@ -1600,14 +1600,27 @@ func TestMsg_WriteToSkipMiddleware(t *testing.T) {
 	wbuf := bytes.Buffer{}
 	n, err := m.WriteToSkipMiddleware(&wbuf, "uppercase")
 	if err != nil {
-		t.Errorf("WriteTo() failed: %s", err)
+		t.Errorf("WriteToSkipMiddleware() failed: %s", err)
 		return
 	}
 	if n != int64(wbuf.Len()) {
-		t.Errorf("WriteTo() failed: expected written byte length: %d, got: %d", n, wbuf.Len())
+		t.Errorf("WriteToSkipMiddleware() failed: expected written byte length: %d, got: %d", n, wbuf.Len())
 	}
 	if !strings.Contains(wbuf.String(), "Subject: This is @ test") {
 		t.Errorf("WriteToSkipMiddleware failed. Unable to find encoded subject")
+	}
+
+	wbuf2 := bytes.Buffer{}
+	n, err = m.WriteTo(&wbuf2)
+	if err != nil {
+		t.Errorf("WriteTo() failed: %s", err)
+		return
+	}
+	if n != int64(wbuf2.Len()) {
+		t.Errorf("WriteTo() failed: expected written byte length: %d, got: %d", n, wbuf2.Len())
+	}
+	if !strings.Contains(wbuf2.String(), "Subject: THIS IS @ TEST") {
+		t.Errorf("WriteToSkipMiddleware failed. Unable to find encoded and upperchase subject")
 	}
 }
 


### PR DESCRIPTION
For middlewares to be able to access the fully written mail message, we need a way to execute WriteTo without the calling middleware to be handled, otherwise we end up in an infinite loop

Therefore, this PR introduces the MiddlewareType and the corresponding change of the Middleware interface. We now require to return the MiddlewareType when the Type() method on the interface is called

This way we can also introduce the WriteToSkipMiddleware method which takes a MiddlewareType as argument. This will allow us to use a WriteTo call with the initiating Middleware to be skipped