### PR TITLE
fix: tls config unused with dialer

### DIFF
--- a/client.go
+++ b/client.go
@@ -431,9 +431,11 @@ func (c *Client) DialWithContext(pc context.Context) error {
 	defer cfn()
 
 	nd := net.Dialer{}
-	td := tls.Dialer{}
+
 	var err error
 	if c.ssl {
+		td := tls.Dialer{NetDialer: &nd, Config: c.tlsconfig}
+
 		c.enc = true
 		c.co, err = td.DialContext(ctx, "tcp", c.ServerAddr())
 	}


### PR DESCRIPTION
This ensures the configured tls.Config is used with the tls.Dialer.