### PR TITLE
feat: without noop option

### DIFF
--- a/client.go
+++ b/client.go
@@ -96,6 +96,9 @@ type Client struct {
 	// enc indicates if a Client connection is encrypted or not
 	enc bool
 
+	// noNoop indicates the Noop is to be skipped
+	noNoop bool
+
 	// HELO/EHLO string for the greeting the target SMTP server
 	helo string
 
@@ -366,6 +369,15 @@ func WithDSNRcptNotifyType(rno ...DSNRcptNotifyOption) Option {
 	}
 }
 
+// WithoutNoop disables the Client Noop check during connections. This is primarily for servers which delay responses
+// to SMTP commands that are not the AUTH command. For example Microsoft Exchange's Tarpit.
+func WithoutNoop() Option {
+	return func(c *Client) error {
+		c.noNoop = true
+		return nil
+	}
+}
+
 // TLSPolicy returns the currently set TLSPolicy as string
 func (c *Client) TLSPolicy() string {
 	return c.tlspolicy.String()
@@ -515,9 +527,13 @@ func (c *Client) checkConn() error {
 	if c.co == nil {
 		return ErrNoActiveConnection
 	}
-	if err := c.sc.Noop(); err != nil {
-		return ErrNoActiveConnection
+
+	if !c.noNoop {
+		if err := c.sc.Noop(); err != nil {
+			return ErrNoActiveConnection
+		}
 	}
+
 	if err := c.co.SetDeadline(time.Now().Add(c.cto)); err != nil {
 		return ErrDeadlineExtendFailed
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -103,6 +103,8 @@ func TestNewClientWithOptions(t *testing.T) {
 		{"WithDSNMailReturnType() wrong option", WithDSNMailReturnType("FAIL"), true},
 		{"WithDSNRcptNotifyType()", WithDSNRcptNotifyType(DSNRcptNotifySuccess), false},
 		{"WithDSNRcptNotifyType() wrong option", WithDSNRcptNotifyType("FAIL"), true},
+		{"WithoutNoop()", WithoutNoop(), false},
+
 		{
 			"WithDSNRcptNotifyType() NEVER combination",
 			WithDSNRcptNotifyType(DSNRcptNotifySuccess, DSNRcptNotifyNever), true,
@@ -458,6 +460,27 @@ func TestWithDSNRcptNotifyType(t *testing.T) {
 				t.Errorf("WithDSNRcptNotifyType failed. Expected %s, got: %s", tt.want, c.dsnrntype[0])
 			}
 		})
+	}
+}
+
+// TestWithoutNoop tests the WithoutNoop method for the Client object
+func TestWithoutNoop(t *testing.T) {
+	c, err := NewClient(DefaultHost, WithoutNoop())
+	if err != nil {
+		t.Errorf("failed to create new client: %s", err)
+		return
+	}
+	if !c.noNoop {
+		t.Errorf("WithoutNoop failed. c.noNoop expected to be: %t, got: %t", true, c.noNoop)
+	}
+
+	c, err = NewClient(DefaultHost)
+	if err != nil {
+		t.Errorf("failed to create new client: %s", err)
+		return
+	}
+	if c.noNoop {
+		t.Errorf("WithoutNoop failed. c.noNoop expected to be: %t, got: %t", false, c.noNoop)
 	}
 }
 


### PR DESCRIPTION
This allows disabling the Noop command during the dial. This is useful for servers which delay potentially unwanted clients when they perform commands other than AUTH.