### PR TITLE
Introduction of new error type for sending errors

### DIFF
--- a/client_119.go
+++ b/client_119.go
@@ -108,12 +108,8 @@ func (c *Client) Send(ml ...*Msg) error {
 		if len(errs) > 1 {
 			re := &SendError{Reason: ErrAmbiguous}
 			for i := range errs {
-				for _, e := range errs[i].errlist {
-					re.errlist = append(re.errlist, e)
-				}
-				for _, r := range errs[i].rcpt {
-					re.rcpt = append(re.rcpt, r)
-				}
+				re.errlist = append(re.errlist, errs[i].errlist...)
+				re.rcpt = append(re.rcpt, errs[i].rcpt...)
 			}
 
 			// We assume that the isTemp flage from the last error we received should be the

--- a/client_119.go
+++ b/client_119.go
@@ -18,6 +18,7 @@ func (c *Client) Send(ml ...*Msg) error {
 		return fmt.Errorf("failed to send mail: %w", err)
 	}
 	for _, m := range ml {
+		m.sendError = nil
 		if m.encoding == NoEncoding {
 			if ok, _ := c.sc.Extension("8BITMIME"); !ok {
 				errs = append(errs, ErrServerNoUnencoded)

--- a/client_119.go
+++ b/client_119.go
@@ -7,44 +7,44 @@
 
 package mail
 
-import (
-	"fmt"
-)
-
 // Send sends out the mail message
 func (c *Client) Send(ml ...*Msg) error {
-	var errs []error
-	if err := c.checkConn(); err != nil {
-		return fmt.Errorf("failed to send mail: %w", err)
+	if cerr := c.checkConn(); cerr != nil {
+		return &SendError{Reason: ErrConnCheck, errlist: []error{cerr}, isTemp: isTempError(cerr)}
 	}
+	var errs []*SendError
 	for _, m := range ml {
 		m.sendError = nil
 		if m.encoding == NoEncoding {
 			if ok, _ := c.sc.Extension("8BITMIME"); !ok {
-				errs = append(errs, ErrServerNoUnencoded)
-				m.sendError = &SendError{Reason: ErrNoUnencoded, isTemp: false}
+				se := &SendError{Reason: ErrNoUnencoded, isTemp: false}
+				m.sendError = se
+				errs = append(errs, se)
 				continue
 			}
 		}
 		f, err := m.GetSender(false)
 		if err != nil {
-			errs = append(errs, err)
-			m.sendError = &SendError{Reason: ErrGetSender, errlist: []error{err}, isTemp: isTempError(err)}
+			se := &SendError{Reason: ErrGetSender, errlist: []error{err}, isTemp: isTempError(err)}
+			m.sendError = se
+			errs = append(errs, se)
 			continue
 		}
 		rl, err := m.GetRecipients()
 		if err != nil {
-			m.sendError = &SendError{Reason: ErrGetRcpts, errlist: []error{err}, isTemp: isTempError(err)}
-			errs = append(errs, err)
+			se := &SendError{Reason: ErrGetRcpts, errlist: []error{err}, isTemp: isTempError(err)}
+			m.sendError = se
+			errs = append(errs, se)
 			continue
 		}
 
 		if err := c.mail(f); err != nil {
-			errs = append(errs, fmt.Errorf("sending MAIL FROM command failed: %w", err))
-			m.sendError = &SendError{Reason: ErrSMTPMailFrom, errlist: []error{err}, isTemp: isTempError(err)}
+			se := &SendError{Reason: ErrSMTPMailFrom, errlist: []error{err}, isTemp: isTempError(err)}
 			if reserr := c.sc.Reset(); reserr != nil {
-				errs = append(errs, reserr)
+				se.errlist = append(se.errlist, reserr)
 			}
+			m.sendError = se
+			errs = append(errs, se)
 			continue
 		}
 		failed := false
@@ -53,7 +53,6 @@ func (c *Client) Send(ml ...*Msg) error {
 		rse.rcpt = make([]string, 0)
 		for _, r := range rl {
 			if err := c.rcpt(r); err != nil {
-				errs = append(errs, fmt.Errorf("sending RCPT TO command failed: %w", err))
 				rse.Reason = ErrSMTPRcptTo
 				rse.errlist = append(rse.errlist, err)
 				rse.rcpt = append(rse.rcpt, r)
@@ -63,51 +62,67 @@ func (c *Client) Send(ml ...*Msg) error {
 		}
 		if failed {
 			if reserr := c.sc.Reset(); reserr != nil {
-				errs = append(errs, reserr)
+				rse.errlist = append(rse.errlist, err)
 			}
 			m.sendError = rse
+			errs = append(errs, rse)
 			continue
 		}
 		w, err := c.sc.Data()
 		if err != nil {
-			errs = append(errs, fmt.Errorf("sending DATA command failed: %w", err))
-			m.sendError = &SendError{Reason: ErrSMTPData, errlist: []error{err}, isTemp: isTempError(err)}
+			se := &SendError{Reason: ErrSMTPData, errlist: []error{err}, isTemp: isTempError(err)}
+			m.sendError = se
+			errs = append(errs, se)
 			continue
 		}
 		_, err = m.WriteTo(w)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("sending mail content failed: %w", err))
-			m.sendError = &SendError{Reason: ErrWriteContent, errlist: []error{err}, isTemp: isTempError(err)}
+			se := &SendError{Reason: ErrWriteContent, errlist: []error{err}, isTemp: isTempError(err)}
+			m.sendError = se
+			errs = append(errs, se)
 			continue
 		}
 
 		if err := w.Close(); err != nil {
-			errs = append(errs, fmt.Errorf("failed to close DATA writer: %w", err))
-			m.sendError = &SendError{Reason: ErrSMTPDataClose, errlist: []error{err}, isTemp: isTempError(err)}
+			se := &SendError{Reason: ErrSMTPDataClose, errlist: []error{err}, isTemp: isTempError(err)}
+			m.sendError = se
+			errs = append(errs, se)
 			continue
 		}
 
 		if err := c.Reset(); err != nil {
-			errs = append(errs, fmt.Errorf("sending RSET command failed: %w", err))
-			m.sendError = &SendError{Reason: ErrSMTPReset, errlist: []error{err}, isTemp: isTempError(err)}
+			se := &SendError{Reason: ErrSMTPReset, errlist: []error{err}, isTemp: isTempError(err)}
+			m.sendError = se
+			errs = append(errs, se)
 			continue
 		}
 		if err := c.checkConn(); err != nil {
-			errs = append(errs, fmt.Errorf("failed to check server connection: %w", err))
-			m.sendError = &SendError{Reason: ErrConnCheck, errlist: []error{err}, isTemp: isTempError(err)}
+			se := &SendError{Reason: ErrConnCheck, errlist: []error{err}, isTemp: isTempError(err)}
+			m.sendError = se
+			errs = append(errs, se)
 			continue
 		}
 	}
 
 	if len(errs) > 0 {
-		errtxt := ""
-		for i := range errs {
-			errtxt += fmt.Sprintf("%s", errs[i])
-			if i < len(errs) {
-				errtxt += "\n"
+		if len(errs) > 1 {
+			re := &SendError{Reason: ErrAmbiguous}
+			for i := range errs {
+				for _, e := range errs[i].errlist {
+					re.errlist = append(re.errlist, e)
+				}
+				for _, r := range errs[i].rcpt {
+					re.rcpt = append(re.rcpt, r)
+				}
 			}
+
+			// We assume that the isTemp flage from the last error we received should be the
+			// indicator for the returned isTemp flag as well
+			re.isTemp = errs[len(errs)-1].isTemp
+
+			return re
 		}
-		return fmt.Errorf("%s", errtxt)
+		return errs[0]
 	}
 	return nil
 }

--- a/client_119.go
+++ b/client_119.go
@@ -112,7 +112,7 @@ func (c *Client) Send(ml ...*Msg) error {
 				re.rcpt = append(re.rcpt, errs[i].rcpt...)
 			}
 
-			// We assume that the isTemp flage from the last error we received should be the
+			// We assume that the isTemp flag from the last error we received should be the
 			// indicator for the returned isTemp flag as well
 			re.isTemp = errs[len(errs)-1].isTemp
 

--- a/client_119.go
+++ b/client_119.go
@@ -21,31 +21,41 @@ func (c *Client) Send(ml ...*Msg) error {
 		if m.encoding == NoEncoding {
 			if ok, _ := c.sc.Extension("8BITMIME"); !ok {
 				errs = append(errs, ErrServerNoUnencoded)
+				m.sendError = SendError{Err: ErrServerNoUnencoded}
 				continue
 			}
 		}
 		f, err := m.GetSender(false)
 		if err != nil {
 			errs = append(errs, err)
+			m.sendError = SendError{Err: ErrGetSender, details: []error{err}}
 			continue
 		}
 		rl, err := m.GetRecipients()
 		if err != nil {
+			m.sendError = SendError{Err: ErrGetRcpts, details: []error{err}}
 			errs = append(errs, err)
 			continue
 		}
 
 		if err := c.mail(f); err != nil {
 			errs = append(errs, fmt.Errorf("sending MAIL FROM command failed: %w", err))
+			m.sendError = SendError{Err: ErrSMTPMailFrom, details: []error{err}}
 			if reserr := c.sc.Reset(); reserr != nil {
 				errs = append(errs, reserr)
 			}
 			continue
 		}
 		failed := false
+		rse := SendError{}
+		rse.details = make([]error, 0)
+		rse.rcpt = make([]string, 0)
 		for _, r := range rl {
 			if err := c.rcpt(r); err != nil {
 				errs = append(errs, fmt.Errorf("sending RCPT TO command failed: %w", err))
+				rse.Err = ErrSMTPRcptTo
+				rse.details = append(rse.details, err)
+				rse.rcpt = append(rse.rcpt, r)
 				failed = true
 			}
 		}
@@ -53,30 +63,36 @@ func (c *Client) Send(ml ...*Msg) error {
 			if reserr := c.sc.Reset(); reserr != nil {
 				errs = append(errs, reserr)
 			}
+			m.sendError = rse
 			continue
 		}
 		w, err := c.sc.Data()
 		if err != nil {
 			errs = append(errs, fmt.Errorf("sending DATA command failed: %w", err))
+			m.sendError = SendError{Err: ErrSMTPData, details: []error{err}}
 			continue
 		}
 		_, err = m.WriteTo(w)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("sending mail content failed: %w", err))
+			m.sendError = SendError{Err: ErrWriteContent, details: []error{err}}
 			continue
 		}
 
 		if err := w.Close(); err != nil {
 			errs = append(errs, fmt.Errorf("failed to close DATA writer: %w", err))
+			m.sendError = SendError{Err: ErrSMTPDataClose, details: []error{err}}
 			continue
 		}
 
 		if err := c.Reset(); err != nil {
 			errs = append(errs, fmt.Errorf("sending RSET command failed: %w", err))
+			m.sendError = SendError{Err: ErrSMTPReset, details: []error{err}}
 			continue
 		}
 		if err := c.checkConn(); err != nil {
 			errs = append(errs, fmt.Errorf("failed to check server connection: %w", err))
+			m.sendError = SendError{Err: ErrConnCheck, details: []error{err}}
 			continue
 		}
 	}

--- a/client_120.go
+++ b/client_120.go
@@ -22,31 +22,41 @@ func (c *Client) Send(ml ...*Msg) (rerr error) {
 		if m.encoding == NoEncoding {
 			if ok, _ := c.sc.Extension("8BITMIME"); !ok {
 				rerr = errors.Join(rerr, ErrServerNoUnencoded)
+				m.sendError = SendError{Err: ErrServerNoUnencoded}
 				continue
 			}
 		}
 		f, err := m.GetSender(false)
 		if err != nil {
 			rerr = errors.Join(rerr, err)
+			m.sendError = SendError{Err: ErrGetSender, details: []error{err}}
 			continue
 		}
 		rl, err := m.GetRecipients()
 		if err != nil {
 			rerr = errors.Join(rerr, err)
+			m.sendError = SendError{Err: ErrGetRcpts, details: []error{err}}
 			continue
 		}
 
 		if err := c.mail(f); err != nil {
 			rerr = errors.Join(rerr, fmt.Errorf("sending MAIL FROM command failed: %w", err))
+			m.sendError = SendError{Err: ErrSMTPMailFrom, details: []error{err}}
 			if reserr := c.sc.Reset(); reserr != nil {
 				rerr = errors.Join(rerr, reserr)
 			}
 			continue
 		}
 		failed := false
+		rse := SendError{}
+		rse.details = make([]error, 0)
+		rse.rcpt = make([]string, 0)
 		for _, r := range rl {
 			if err := c.rcpt(r); err != nil {
 				rerr = errors.Join(rerr, fmt.Errorf("sending RCPT TO command failed: %w", err))
+				rse.Err = ErrSMTPRcptTo
+				rse.details = append(rse.details, err)
+				rse.rcpt = append(rse.rcpt, r)
 				failed = true
 			}
 		}
@@ -54,30 +64,36 @@ func (c *Client) Send(ml ...*Msg) (rerr error) {
 			if reserr := c.sc.Reset(); reserr != nil {
 				rerr = errors.Join(rerr, reserr)
 			}
+			m.sendError = rse
 			continue
 		}
 		w, err := c.sc.Data()
 		if err != nil {
 			rerr = errors.Join(rerr, fmt.Errorf("sending DATA command failed: %w", err))
+			m.sendError = SendError{Err: ErrSMTPData, details: []error{err}}
 			continue
 		}
 		_, err = m.WriteTo(w)
 		if err != nil {
 			rerr = errors.Join(rerr, fmt.Errorf("sending mail content failed: %w", err))
+			m.sendError = SendError{Err: ErrWriteContent, details: []error{err}}
 			continue
 		}
 
 		if err := w.Close(); err != nil {
 			rerr = errors.Join(rerr, fmt.Errorf("failed to close DATA writer: %w", err))
+			m.sendError = SendError{Err: ErrSMTPDataClose, details: []error{err}}
 			continue
 		}
 
 		if err := c.Reset(); err != nil {
 			rerr = errors.Join(rerr, fmt.Errorf("sending RSET command failed: %w", err))
+			m.sendError = SendError{Err: ErrSMTPReset, details: []error{err}}
 			continue
 		}
 		if err := c.checkConn(); err != nil {
 			rerr = errors.Join(rerr, fmt.Errorf("failed to check server connection: %w", err))
+			m.sendError = SendError{Err: ErrConnCheck, details: []error{err}}
 		}
 	}
 

--- a/client_120.go
+++ b/client_120.go
@@ -9,40 +9,39 @@ package mail
 
 import (
 	"errors"
-	"fmt"
 )
 
 // Send sends out the mail message
 func (c *Client) Send(ml ...*Msg) (rerr error) {
 	if err := c.checkConn(); err != nil {
-		rerr = fmt.Errorf("failed to send mail: %w", err)
+		rerr = &SendError{Reason: ErrConnCheck, errlist: []error{err}, isTemp: isTempError(err)}
 		return
 	}
 	for _, m := range ml {
 		m.sendError = nil
 		if m.encoding == NoEncoding {
 			if ok, _ := c.sc.Extension("8BITMIME"); !ok {
-				rerr = errors.Join(rerr, ErrServerNoUnencoded)
 				m.sendError = &SendError{Reason: ErrNoUnencoded, isTemp: false}
+				rerr = errors.Join(rerr, m.sendError)
 				continue
 			}
 		}
 		f, err := m.GetSender(false)
 		if err != nil {
-			rerr = errors.Join(rerr, err)
 			m.sendError = &SendError{Reason: ErrGetSender, errlist: []error{err}, isTemp: isTempError(err)}
+			rerr = errors.Join(rerr, m.sendError)
 			continue
 		}
 		rl, err := m.GetRecipients()
 		if err != nil {
-			rerr = errors.Join(rerr, err)
 			m.sendError = &SendError{Reason: ErrGetRcpts, errlist: []error{err}, isTemp: isTempError(err)}
+			rerr = errors.Join(rerr, m.sendError)
 			continue
 		}
 
 		if err := c.mail(f); err != nil {
-			rerr = errors.Join(rerr, fmt.Errorf("sending MAIL FROM command failed: %w", err))
 			m.sendError = &SendError{Reason: ErrSMTPMailFrom, errlist: []error{err}, isTemp: isTempError(err)}
+			rerr = errors.Join(rerr, m.sendError)
 			if reserr := c.sc.Reset(); reserr != nil {
 				rerr = errors.Join(rerr, reserr)
 			}
@@ -54,7 +53,6 @@ func (c *Client) Send(ml ...*Msg) (rerr error) {
 		rse.rcpt = make([]string, 0)
 		for _, r := range rl {
 			if err := c.rcpt(r); err != nil {
-				rerr = errors.Join(rerr, fmt.Errorf("sending RCPT TO command failed: %w", err))
 				rse.Reason = ErrSMTPRcptTo
 				rse.errlist = append(rse.errlist, err)
 				rse.rcpt = append(rse.rcpt, r)
@@ -67,35 +65,36 @@ func (c *Client) Send(ml ...*Msg) (rerr error) {
 				rerr = errors.Join(rerr, reserr)
 			}
 			m.sendError = rse
+			rerr = errors.Join(rerr, m.sendError)
 			continue
 		}
 		w, err := c.sc.Data()
 		if err != nil {
-			rerr = errors.Join(rerr, fmt.Errorf("sending DATA command failed: %w", err))
 			m.sendError = &SendError{Reason: ErrSMTPData, errlist: []error{err}, isTemp: isTempError(err)}
+			rerr = errors.Join(rerr, m.sendError)
 			continue
 		}
 		_, err = m.WriteTo(w)
 		if err != nil {
-			rerr = errors.Join(rerr, fmt.Errorf("sending mail content failed: %w", err))
 			m.sendError = &SendError{Reason: ErrWriteContent, errlist: []error{err}, isTemp: isTempError(err)}
+			rerr = errors.Join(rerr, m.sendError)
 			continue
 		}
 
 		if err := w.Close(); err != nil {
-			rerr = errors.Join(rerr, fmt.Errorf("failed to close DATA writer: %w", err))
 			m.sendError = &SendError{Reason: ErrSMTPDataClose, errlist: []error{err}, isTemp: isTempError(err)}
+			rerr = errors.Join(rerr, m.sendError)
 			continue
 		}
 
 		if err := c.Reset(); err != nil {
-			rerr = errors.Join(rerr, fmt.Errorf("sending RSET command failed: %w", err))
 			m.sendError = &SendError{Reason: ErrSMTPReset, errlist: []error{err}, isTemp: isTempError(err)}
+			rerr = errors.Join(rerr, m.sendError)
 			continue
 		}
 		if err := c.checkConn(); err != nil {
-			rerr = errors.Join(rerr, fmt.Errorf("failed to check server connection: %w", err))
 			m.sendError = &SendError{Reason: ErrConnCheck, errlist: []error{err}, isTemp: isTempError(err)}
+			rerr = errors.Join(rerr, m.sendError)
 		}
 	}
 

--- a/client_120.go
+++ b/client_120.go
@@ -23,41 +23,42 @@ func (c *Client) Send(ml ...*Msg) (rerr error) {
 		if m.encoding == NoEncoding {
 			if ok, _ := c.sc.Extension("8BITMIME"); !ok {
 				rerr = errors.Join(rerr, ErrServerNoUnencoded)
-				m.sendError = SendError{Err: ErrServerNoUnencoded}
+				m.sendError = &SendError{Reason: ErrNoUnencoded, isTemp: false}
 				continue
 			}
 		}
 		f, err := m.GetSender(false)
 		if err != nil {
 			rerr = errors.Join(rerr, err)
-			m.sendError = SendError{Err: ErrGetSender, details: []error{err}}
+			m.sendError = &SendError{Reason: ErrGetSender, errlist: []error{err}, isTemp: isTempError(err)}
 			continue
 		}
 		rl, err := m.GetRecipients()
 		if err != nil {
 			rerr = errors.Join(rerr, err)
-			m.sendError = SendError{Err: ErrGetRcpts, details: []error{err}}
+			m.sendError = &SendError{Reason: ErrGetRcpts, errlist: []error{err}, isTemp: isTempError(err)}
 			continue
 		}
 
 		if err := c.mail(f); err != nil {
 			rerr = errors.Join(rerr, fmt.Errorf("sending MAIL FROM command failed: %w", err))
-			m.sendError = SendError{Err: ErrSMTPMailFrom, details: []error{err}}
+			m.sendError = &SendError{Reason: ErrSMTPMailFrom, errlist: []error{err}, isTemp: isTempError(err)}
 			if reserr := c.sc.Reset(); reserr != nil {
 				rerr = errors.Join(rerr, reserr)
 			}
 			continue
 		}
 		failed := false
-		rse := SendError{}
-		rse.details = make([]error, 0)
+		rse := &SendError{}
+		rse.errlist = make([]error, 0)
 		rse.rcpt = make([]string, 0)
 		for _, r := range rl {
 			if err := c.rcpt(r); err != nil {
 				rerr = errors.Join(rerr, fmt.Errorf("sending RCPT TO command failed: %w", err))
-				rse.Err = ErrSMTPRcptTo
-				rse.details = append(rse.details, err)
+				rse.Reason = ErrSMTPRcptTo
+				rse.errlist = append(rse.errlist, err)
 				rse.rcpt = append(rse.rcpt, r)
+				rse.isTemp = isTempError(err)
 				failed = true
 			}
 		}
@@ -71,30 +72,30 @@ func (c *Client) Send(ml ...*Msg) (rerr error) {
 		w, err := c.sc.Data()
 		if err != nil {
 			rerr = errors.Join(rerr, fmt.Errorf("sending DATA command failed: %w", err))
-			m.sendError = SendError{Err: ErrSMTPData, details: []error{err}}
+			m.sendError = &SendError{Reason: ErrSMTPData, errlist: []error{err}, isTemp: isTempError(err)}
 			continue
 		}
 		_, err = m.WriteTo(w)
 		if err != nil {
 			rerr = errors.Join(rerr, fmt.Errorf("sending mail content failed: %w", err))
-			m.sendError = SendError{Err: ErrWriteContent, details: []error{err}}
+			m.sendError = &SendError{Reason: ErrWriteContent, errlist: []error{err}, isTemp: isTempError(err)}
 			continue
 		}
 
 		if err := w.Close(); err != nil {
 			rerr = errors.Join(rerr, fmt.Errorf("failed to close DATA writer: %w", err))
-			m.sendError = SendError{Err: ErrSMTPDataClose, details: []error{err}}
+			m.sendError = &SendError{Reason: ErrSMTPDataClose, errlist: []error{err}, isTemp: isTempError(err)}
 			continue
 		}
 
 		if err := c.Reset(); err != nil {
 			rerr = errors.Join(rerr, fmt.Errorf("sending RSET command failed: %w", err))
-			m.sendError = SendError{Err: ErrSMTPReset, details: []error{err}}
+			m.sendError = &SendError{Reason: ErrSMTPReset, errlist: []error{err}, isTemp: isTempError(err)}
 			continue
 		}
 		if err := c.checkConn(); err != nil {
 			rerr = errors.Join(rerr, fmt.Errorf("failed to check server connection: %w", err))
-			m.sendError = SendError{Err: ErrConnCheck, details: []error{err}}
+			m.sendError = &SendError{Reason: ErrConnCheck, errlist: []error{err}, isTemp: isTempError(err)}
 		}
 	}
 

--- a/client_120.go
+++ b/client_120.go
@@ -19,6 +19,7 @@ func (c *Client) Send(ml ...*Msg) (rerr error) {
 		return
 	}
 	for _, m := range ml {
+		m.sendError = nil
 		if m.encoding == NoEncoding {
 			if ok, _ := c.sc.Extension("8BITMIME"); !ok {
 				rerr = errors.Join(rerr, ErrServerNoUnencoded)

--- a/client_test.go
+++ b/client_test.go
@@ -1030,9 +1030,12 @@ func TestClient_Send_MsgSendError(t *testing.T) {
 		if !m.HasSendError() {
 			t.Errorf("message was expected to have a send error, but didn't")
 		}
-		se := SendError{Err: ErrSMTPRcptTo}
-		if !errors.As(m.SendError(), &se) {
-			t.Errorf("message with broken recipient was expected to return a ErrSMTPRcptTo error, but didn't")
+		se := &SendError{Reason: ErrSMTPRcptTo}
+		if !errors.Is(m.SendError(), se) {
+			t.Errorf("error mismatch, expected: %s, got: %s", se, m.SendError())
+		}
+		if m.SendErrorIsTemp() {
+			t.Errorf("message was not expected to be a temporary error, but reported as such")
 		}
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -7,6 +7,7 @@ package mail
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/smtp"
 	"os"
@@ -986,6 +987,53 @@ func TestValidateLine(t *testing.T) {
 				t.Errorf("validateLine failed: %s", err)
 			}
 		})
+	}
+}
+
+// TestClient_Send_MsgSendError tests the Send() method of Client with a broken and verifies
+// that the SendError type works properly
+func TestClient_Send_MsgSendError(t *testing.T) {
+	if os.Getenv("TEST_ALLOW_SEND") == "" {
+		t.Skipf("TEST_ALLOW_SEND is not set. Skipping mail sending test")
+	}
+	var msgs []*Msg
+	rcpts := []string{"invalid@domain.tld", "invalid@address.invalid"}
+	for _, rcpt := range rcpts {
+		m := NewMsg()
+		_ = m.FromFormat("go-mail Test Mailer", os.Getenv("TEST_FROM"))
+		_ = m.To(rcpt)
+		m.Subject(fmt.Sprintf("This is a test mail from go-mail/v%s", VERSION))
+		m.SetBulk()
+		m.SetDate()
+		m.SetMessageID()
+		m.SetBodyString(TypeTextPlain, "This is a test mail from the go-mail library")
+		msgs = append(msgs, m)
+	}
+
+	c, err := getTestConnection(true)
+	if err != nil {
+		t.Skipf("failed to create test client: %s. Skipping tests", err)
+	}
+
+	ctx, cfn := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cfn()
+	if err := c.DialWithContext(ctx); err != nil {
+		t.Errorf("failed to dial to sending server: %s", err)
+	}
+	if err := c.Send(msgs...); err == nil {
+		t.Errorf("sending messages with broken recipients was supposed to fail but didn't")
+	}
+	if err := c.Close(); err != nil {
+		t.Errorf("failed to close client connection: %s", err)
+	}
+	for _, m := range msgs {
+		if !m.HasSendError() {
+			t.Errorf("message was expected to have a send error, but didn't")
+		}
+		se := SendError{Err: ErrSMTPRcptTo}
+		if !errors.As(m.SendError(), &se) {
+			t.Errorf("message with broken recipient was expected to return a ErrSMTPRcptTo error, but didn't")
+		}
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -1040,6 +1040,43 @@ func TestClient_Send_MsgSendError(t *testing.T) {
 	}
 }
 
+// TestClient_DialAndSendWithContext_withSendError tests the Client.DialAndSendWithContext method
+// with a broken recipient to make sure that the returned error satisfies the Msg.SendError type
+func TestClient_DialAndSendWithContext_withSendError(t *testing.T) {
+	if os.Getenv("TEST_ALLOW_SEND") == "" {
+		t.Skipf("TEST_ALLOW_SEND is not set. Skipping mail sending test")
+	}
+	m := NewMsg()
+	_ = m.FromFormat("go-mail Test Mailer", os.Getenv("TEST_FROM"))
+	_ = m.To("invalid@domain.tld")
+	m.Subject(fmt.Sprintf("This is a test mail from go-mail/v%s", VERSION))
+	m.SetBulk()
+	m.SetDate()
+	m.SetMessageID()
+	m.SetBodyString(TypeTextPlain, "This is a test mail from the go-mail library")
+
+	c, err := getTestConnection(true)
+	if err != nil {
+		t.Skipf("failed to create test client: %s. Skipping tests", err)
+	}
+	ctx, cfn := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cfn()
+	err = c.DialAndSendWithContext(ctx, m)
+	if err == nil {
+		t.Errorf("expected DialAndSendWithContext with broken mail recipient to fail, but didn't")
+		return
+	}
+	var se *SendError
+	if !errors.As(err, &se) {
+		t.Errorf("expected *SendError type as returned error, but didn't")
+		return
+	}
+	if se.IsTemp() {
+		t.Errorf("expected permanent error but IsTemp() returned true")
+		return
+	}
+}
+
 // getTestConnection takes environment variables to establish a connection to a real
 // SMTP server to test all functionality that requires a connection
 func getTestConnection(auth bool) (*Client, error) {

--- a/client_test.go
+++ b/client_test.go
@@ -990,7 +990,7 @@ func TestValidateLine(t *testing.T) {
 	}
 }
 
-// TestClient_Send_MsgSendError tests the Send() method of Client with a broken and verifies
+// TestClient_Send_MsgSendError tests the Client.Send method with a broken recipient and verifies
 // that the SendError type works properly
 func TestClient_Send_MsgSendError(t *testing.T) {
 	if os.Getenv("TEST_ALLOW_SEND") == "" {

--- a/doc.go
+++ b/doc.go
@@ -6,4 +6,4 @@
 package mail
 
 // VERSION is used in the default user agent string
-const VERSION = "0.3.6"
+const VERSION = "0.3.7"

--- a/msg.go
+++ b/msg.go
@@ -90,6 +90,9 @@ type Msg struct {
 
 	// middlewares is the list of middlewares to apply to the Msg before sending in FIFO order
 	middlewares []Middleware
+
+	// sendError holds the SendError in case a Msg could not be delivered during the Client.Send operation
+	sendError error
 }
 
 // SendmailPath is the default system path to the sendmail binary
@@ -955,6 +958,17 @@ func (m *Msg) UpdateReader(r *Reader) {
 	r.Reset()
 	r.buf = wbuf.Bytes()
 	r.err = err
+}
+
+// HasSendError returns true if the Msg experienced an error during the message delivery and the
+// senderror field of the Msg is not nil
+func (m *Msg) HasSendError() bool {
+	return m.sendError != nil
+}
+
+// SendError returns the senderror field of the Msg
+func (m *Msg) SendError() error {
+	return m.sendError
 }
 
 // encodeString encodes a string based on the configured message encoder and the corresponding

--- a/msg.go
+++ b/msg.go
@@ -961,7 +961,7 @@ func (m *Msg) UpdateReader(r *Reader) {
 }
 
 // HasSendError returns true if the Msg experienced an error during the message delivery and the
-// senderror field of the Msg is not nil
+// sendError field of the Msg is not nil
 func (m *Msg) HasSendError() bool {
 	return m.sendError != nil
 }

--- a/msg.go
+++ b/msg.go
@@ -966,6 +966,16 @@ func (m *Msg) HasSendError() bool {
 	return m.sendError != nil
 }
 
+// SendErrorIsTemp returns true if the Msg experienced an error during the message delivery and the
+// corresponding error was of temporary nature and should be retried later
+func (m *Msg) SendErrorIsTemp() bool {
+	e, ok := m.sendError.(*SendError)
+	if !ok {
+		return false
+	}
+	return e.isTemp
+}
+
 // SendError returns the senderror field of the Msg
 func (m *Msg) SendError() error {
 	return m.sendError

--- a/msg.go
+++ b/msg.go
@@ -976,7 +976,7 @@ func (m *Msg) SendErrorIsTemp() bool {
 	return false
 }
 
-// SendError returns the senderror field of the Msg
+// SendError returns the sendError field of the Msg
 func (m *Msg) SendError() error {
 	return m.sendError
 }

--- a/msg.go
+++ b/msg.go
@@ -969,11 +969,11 @@ func (m *Msg) HasSendError() bool {
 // SendErrorIsTemp returns true if the Msg experienced an error during the message delivery and the
 // corresponding error was of temporary nature and should be retried later
 func (m *Msg) SendErrorIsTemp() bool {
-	e, ok := m.sendError.(*SendError)
-	if !ok {
-		return false
+	var e *SendError
+	if errors.As(m.sendError, &e) {
+		return e.isTemp
 	}
-	return e.isTemp
+	return false
 }
 
 // SendError returns the senderror field of the Msg

--- a/senderror.go
+++ b/senderror.go
@@ -68,7 +68,7 @@ type SendErrReason int
 // Error implements the error interface for the SendError type
 func (e *SendError) Error() string {
 	if e.Reason > 10 {
-		return "client_send: unknown error"
+		return "unknown reason"
 	}
 
 	var em strings.Builder

--- a/senderror.go
+++ b/senderror.go
@@ -6,7 +6,6 @@ package mail
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 )
 

--- a/senderror.go
+++ b/senderror.go
@@ -1,0 +1,68 @@
+package mail
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// List of SendError errors
+var (
+	// ErrGetSender is returned if the Msg.GetSender method fails during a Client.Send
+	ErrGetSender = errors.New("getting sender address")
+
+	// ErrGetRcpts is returned if the Msg.GetRecipients method fails during a Client.Send
+	ErrGetRcpts = errors.New("getting recipient addresses")
+
+	// ErrSMTPMailFrom is returned if the Msg delivery failed when sending the MAIL FROM command
+	// to the sending SMTP server
+	ErrSMTPMailFrom = errors.New("sending SMTP MAIL FROM command")
+
+	// ErrSMTPRcptTo is returned if the Msg delivery failed when sending the RCPT TO command
+	// to the sending SMTP server
+	ErrSMTPRcptTo = errors.New("sending SMTP RCPT TO command")
+
+	// ErrSMTPData is returned if the Msg delivery failed when sending the DATA command
+	// to the sending SMTP server
+	ErrSMTPData = errors.New("sending SMTP DATA command")
+
+	// ErrSMTPDataClose is returned if the Msg delivery failed when trying to close the
+	// Client data writer
+	ErrSMTPDataClose = errors.New("closing SMTP DATA writer")
+
+	// ErrSMTPReset is returned if the Msg delivery failed when sending the RSET command
+	// to the sending SMTP server
+	ErrSMTPReset = errors.New("sending SMTP RESET command")
+
+	// ErrWriteContent is returned if the Msg delivery failed when sending Msg content
+	// to the Client writer
+	ErrWriteContent = errors.New("sending message content")
+
+	// ErrConnCheck is returned if the Msg delivery failed when checking if the SMTP
+	// server connection is still working
+	ErrConnCheck = errors.New("checking SMTP connection")
+)
+
+// SendError is an error wrapper for delivery errors of the Msg
+type SendError struct {
+	Err     error
+	details []error
+	rcpt    []string
+}
+
+// Error implements the error interface for the SendError type
+func (e SendError) Error() string {
+	var em strings.Builder
+	_, _ = fmt.Fprintf(&em, "client_send: %s", e.Err)
+	if len(e.details) > 0 {
+		for i := range e.details {
+			em.WriteString(fmt.Sprintf(", error_details: %s", e.details[i]))
+		}
+	}
+	if len(e.rcpt) > 0 {
+		for i := range e.rcpt {
+			em.WriteString(fmt.Sprintf(", rcpt: %s", e.rcpt[i]))
+		}
+	}
+	return em.String()
+}

--- a/senderror.go
+++ b/senderror.go
@@ -5,6 +5,7 @@
 package mail
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -94,11 +95,11 @@ func (e *SendError) Error() string {
 
 // Is implements the errors.Is functionality and compares the SendErrReason
 func (e *SendError) Is(et error) bool {
-	t, ok := et.(*SendError)
-	if !ok {
-		return false
+	var t *SendError
+	if errors.As(et, &t) {
+		return e.Reason == t.Reason && e.isTemp == t.isTemp
 	}
-	return e.Reason == t.Reason && e.isTemp == t.isTemp
+	return false
 }
 
 // String implements the Stringer interface for the SendErrReason

--- a/senderror.go
+++ b/senderror.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2022 Winni Neessen <winni@neessen.dev>
+//
+// SPDX-License-Identifier: MIT
+
 package mail
 
 import (

--- a/senderror_test.go
+++ b/senderror_test.go
@@ -1,0 +1,55 @@
+package mail
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestSendError_Error tests the SendError and SendErrReason error handling methods
+func TestSendError_Error(t *testing.T) {
+	tl := []struct {
+		n  string
+		r  SendErrReason
+		te bool
+	}{
+		{"ErrGetSender/temp", ErrGetSender, true},
+		{"ErrGetSender/perm", ErrGetSender, false},
+		{"ErrGetRcpts/temp", ErrGetRcpts, true},
+		{"ErrGetRcpts/perm", ErrGetRcpts, false},
+		{"ErrSMTPMailFrom/temp", ErrSMTPMailFrom, true},
+		{"ErrSMTPMailFrom/perm", ErrSMTPMailFrom, false},
+		{"ErrSMTPRcptTo/temp", ErrSMTPRcptTo, true},
+		{"ErrSMTPRcptTo/perm", ErrSMTPRcptTo, false},
+		{"ErrSMTPData/temp", ErrSMTPData, true},
+		{"ErrSMTPData/perm", ErrSMTPData, false},
+		{"ErrSMTPDataClose/temp", ErrSMTPDataClose, true},
+		{"ErrSMTPDataClose/perm", ErrSMTPDataClose, false},
+		{"ErrSMTPReset/temp", ErrSMTPReset, true},
+		{"ErrSMTPReset/perm", ErrSMTPReset, false},
+		{"ErrWriteContent/temp", ErrWriteContent, true},
+		{"ErrWriteContent/perm", ErrWriteContent, false},
+		{"ErrConnCheck/temp", ErrConnCheck, true},
+		{"ErrConnCheck/perm", ErrConnCheck, false},
+		{"ErrNoUnencoded/temp", ErrNoUnencoded, true},
+		{"ErrNoUnencoded/perm", ErrNoUnencoded, false},
+		{"Unknown/temp", 9999, true},
+		{"Unknown/perm", 9999, false},
+	}
+
+	for _, tt := range tl {
+		t.Run(tt.n, func(t *testing.T) {
+			if err := returnSendError(tt.r, tt.te); err != nil {
+				exp := &SendError{Reason: tt.r, isTemp: tt.te}
+				if !errors.Is(err, exp) {
+					t.Errorf("error mismatch, expected: %s (temp: %t), got: %s (temp: %t)", tt.r, tt.te,
+						exp.Error(), exp.isTemp)
+				}
+			}
+		})
+	}
+}
+
+// returnSendError is a helper method to retunr a SendError with a specific reason
+func returnSendError(r SendErrReason, t bool) error {
+	return &SendError{Reason: r, isTemp: t}
+}

--- a/senderror_test.go
+++ b/senderror_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2022 Winni Neessen <winni@neessen.dev>
+//
+// SPDX-License-Identifier: MIT
+
 package mail
 
 import (


### PR DESCRIPTION
This PR introduces the `SendError` type which implements the error interface as solution for #90.

A new `senderror` field has been added to the `Msg` as well, so introduce this type to it.

I've also added different error variables that indicate the different things that can go wrong during mail delivery. These variables can be checked for, for each `Msg` using the `errors.Is` and `errors.As` methods. Additionally, the `SendError` has a `isTemp` field that indicates if the delivery error is of temporary nature and can be accessed via the `SendError.IsTemp()` method.

The `Error()` method of `SendError` will return a detailed error string on why the `Msg` could not be delivered.

Additionally, `HasSendError()`, `SendErrorIsTemp()` and `SendError()` methods have been added to `Msg`. While `HasSendError()` simply returns a bool in case a `Msg` failed during delivery and `SendErrorIsTemp()` returns true if it's a temporary error, the `SendError()` will return the full `SendError` error interface.

As proposed by @iwittkau the `SendError` type has a `IsTemp()` method as well indicating to the user if the delivery error is retryable or not.

As suggested, we want to use it in the error response from the Client functions like `Send` or `DialAndSend` we need to return the `SendError` type not only as part of the `*Msg` but also as return value for these methods. Hence, the changes made for #85 have been overhauled to return the new error type instead. In the pre Go1.20 version of the `Send()` method we need to return an accumulated version of the `SendError` type, since we don't have `errors.Join()` and therefore, if more than one error occurred during the delivery we return an ambiguous error reason since we can't tell which of the captured errors is main error. For more details the user can always check the `*Msg.SendError`