### PR TITLE
Fix SMTP AUTH LOGIN method for servers with uncommon success messages

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -22,10 +22,10 @@ func TestAuth(t *testing.T) {
 	authTests := []authTest{
 		{
 			LoginAuth("user", "pass", "testserver"),
-			[]string{"Username:", "Password:", "2.7.0 Authentication successful", "Invalid:"},
+			[]string{"Username:", "Password:", "Invalid:"},
 			"LOGIN",
-			[]string{"", "user", "pass", "", ""},
-			[]bool{false, false, false, true},
+			[]string{"", "user", "pass", ""},
+			[]bool{false, false, true},
 		},
 	}
 

--- a/auth/login.go
+++ b/auth/login.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"net/smtp"
-	"strings"
 )
 
 type loginAuth struct {
@@ -23,10 +22,6 @@ const (
 
 	// ServerRespPassword represents the "Password:" response by the SMTP server
 	ServerRespPassword = "Password:"
-
-	// ServerRespAuthSuccess represents the "Authentication successful:" response that is
-	// by sent by some SMTP servers
-	ServerRespAuthSuccess = "Authentication successful"
 )
 
 // LoginAuth returns an Auth that implements the LOGIN authentication
@@ -70,10 +65,9 @@ func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 			return []byte(a.username), nil
 		case ServerRespPassword:
 			return []byte(a.password), nil
+		default:
+			return nil, fmt.Errorf("unexpected server response: %s", string(fromServer))
 		}
 	}
-	if strings.HasSuffix(string(fromServer), ServerRespAuthSuccess) {
-		return nil, nil
-	}
-	return nil, fmt.Errorf("unexpected server response: %s", string(fromServer))
+	return nil, nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/smtp"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1087,10 +1088,22 @@ func getTestConnection(auth bool) (*Client, error) {
 	if th == "" {
 		return nil, fmt.Errorf("no TEST_HOST set")
 	}
-	c, err := NewClient(th)
+	tp := 25
+	if tps := os.Getenv("TEST_PORT"); tps != "" {
+		tpi, err := strconv.Atoi(tps)
+		if err == nil {
+			tp = tpi
+		}
+	}
+	sv := false
+	if sve := os.Getenv("TEST_TLS_SKIP_VERIFY"); sve != "" {
+		sv = true
+	}
+	c, err := NewClient(th, WithPort(tp))
 	if err != nil {
 		return c, err
 	}
+	c.tlsconfig.InsecureSkipVerify = sv
 	if auth {
 		st := os.Getenv("TEST_SMTPAUTH_TYPE")
 		if st != "" {


### PR DESCRIPTION
This fixes #94 and basically reverts d0f0435. As James points out correctly in #94, we should not assume specific responses from the server. As long as the spec is followed and the server returns the correct SMTP code, we should not do our own magic.

I've also extended the `getTestConnection` method in client_test.go, so that we can specify more test environment options like `TEST_PORT` and `TEST_TLS_SKIP_VERIFY`. This was needed for testing with the ProtonMail Bridge which listens on a different port and has non-trusted certificates.