### PR TITLE
Implement SMTP client debug logging

### DIFF
--- a/client.go
+++ b/client.go
@@ -410,8 +410,11 @@ func (c *Client) SetSSL(s bool) {
 }
 
 // SetDebugLog tells the Client whether debug logging is enabled or not
-func (c *Client) SetDebugLog(s bool) {
-	c.dl = s
+func (c *Client) SetDebugLog(v bool) {
+	c.dl = v
+	if c.sc != nil {
+		c.sc.SetDebugLog(v)
+	}
 }
 
 // SetTLSConfig overrides the current *tls.Config with the given *tls.Config value
@@ -479,7 +482,7 @@ func (c *Client) DialWithContext(pc context.Context) error {
 		return err
 	}
 	if c.dl {
-		c.sc.SetDebugLog()
+		c.sc.SetDebugLog(true)
 	}
 	if err := c.sc.Hello(c.helo); err != nil {
 		return err

--- a/client.go
+++ b/client.go
@@ -130,6 +130,9 @@ type Client struct {
 
 	// user is the SMTP AUTH username
 	user string
+
+	// dl enables the debug logging on the SMTP client
+	dl bool
 }
 
 // Option returns a function that can be used for grouping Client options
@@ -236,6 +239,15 @@ func WithTimeout(t time.Duration) Option {
 func WithSSL() Option {
 	return func(c *Client) error {
 		c.ssl = true
+		return nil
+	}
+}
+
+// WithDebugLog tells the client to log incoming and outgoing messages of the SMTP client
+// to StdErr
+func WithDebugLog() Option {
+	return func(c *Client) error {
+		c.dl = true
 		return nil
 	}
 }
@@ -397,6 +409,11 @@ func (c *Client) SetSSL(s bool) {
 	c.ssl = s
 }
 
+// SetDebugLog tells the Client whether debug logging is enabled or not
+func (c *Client) SetDebugLog(s bool) {
+	c.dl = s
+}
+
 // SetTLSConfig overrides the current *tls.Config with the given *tls.Config value
 func (c *Client) SetTLSConfig(co *tls.Config) error {
 	if co == nil {
@@ -460,6 +477,9 @@ func (c *Client) DialWithContext(pc context.Context) error {
 	c.sc, err = smtp.NewClient(c.co, c.host)
 	if err != nil {
 		return err
+	}
+	if c.dl {
+		c.sc.SetDebugLog()
 	}
 	if err := c.sc.Hello(c.helo); err != nil {
 		return err

--- a/client_test.go
+++ b/client_test.go
@@ -546,11 +546,10 @@ func TestClient_DialWithContext(t *testing.T) {
 // TestClient_DialWithContext_Debug tests the DialWithContext method for the Client object with debug
 // logging enabled on the SMTP client
 func TestClient_DialWithContext_Debug(t *testing.T) {
-	c, err := getTestConnection(true)
+	c, err := getTestClient(true)
 	if err != nil {
 		t.Skipf("failed to create test client: %s. Skipping tests", err)
 	}
-	c.SetDebugLog(true)
 	ctx := context.Background()
 	if err := c.DialWithContext(ctx); err != nil {
 		t.Errorf("failed to dial with context: %s", err)
@@ -562,6 +561,7 @@ func TestClient_DialWithContext_Debug(t *testing.T) {
 	if c.sc == nil {
 		t.Errorf("DialWithContext didn't fail but no SMTP client found.")
 	}
+	c.SetDebugLog(true)
 	if err := c.Close(); err != nil {
 		t.Errorf("failed to close connection: %s", err)
 	}
@@ -1141,12 +1141,59 @@ func getTestConnection(auth bool) (*Client, error) {
 		if p != "" {
 			c.SetPassword(p)
 		}
+		// We don't want to log authentication data in tests
+		c.SetDebugLog(false)
 	}
 	if err := c.DialWithContext(context.Background()); err != nil {
 		return c, fmt.Errorf("connection to test server failed: %w", err)
 	}
 	if err := c.Close(); err != nil {
 		return c, fmt.Errorf("disconnect from test server failed: %w", err)
+	}
+	return c, nil
+}
+
+// getTestClient takes environment variables to establish a client without connecting
+// to the SMTP server
+func getTestClient(auth bool) (*Client, error) {
+	if os.Getenv("TEST_SKIP_ONLINE") != "" {
+		return nil, fmt.Errorf("env variable TEST_SKIP_ONLINE is set. Skipping online tests")
+	}
+	th := os.Getenv("TEST_HOST")
+	if th == "" {
+		return nil, fmt.Errorf("no TEST_HOST set")
+	}
+	tp := 25
+	if tps := os.Getenv("TEST_PORT"); tps != "" {
+		tpi, err := strconv.Atoi(tps)
+		if err == nil {
+			tp = tpi
+		}
+	}
+	sv := false
+	if sve := os.Getenv("TEST_TLS_SKIP_VERIFY"); sve != "" {
+		sv = true
+	}
+	c, err := NewClient(th, WithPort(tp))
+	if err != nil {
+		return c, err
+	}
+	c.tlsconfig.InsecureSkipVerify = sv
+	if auth {
+		st := os.Getenv("TEST_SMTPAUTH_TYPE")
+		if st != "" {
+			c.SetSMTPAuth(SMTPAuthType(st))
+		}
+		u := os.Getenv("TEST_SMTPAUTH_USER")
+		if u != "" {
+			c.SetUsername(u)
+		}
+		p := os.Getenv("TEST_SMTPAUTH_PASS")
+		if p != "" {
+			c.SetPassword(p)
+		}
+		// We don't want to log authentication data in tests
+		c.SetDebugLog(false)
 	}
 	return c, nil
 }

--- a/smtp/smtp.go
+++ b/smtp/smtp.go
@@ -432,9 +432,13 @@ func (c *Client) Quit() error {
 }
 
 // SetDebugLog enables the debug logging for incoming and outgoing SMTP messages
-func (c *Client) SetDebugLog() {
-	c.debug = true
-	c.logger = log.New(os.Stderr, "[DEBUG] ", log.LstdFlags|log.Lmsgprefix)
+func (c *Client) SetDebugLog(v bool) {
+	c.debug = v
+	if v {
+		c.logger = log.New(os.Stderr, "[DEBUG] ", log.LstdFlags|log.Lmsgprefix)
+		return
+	}
+	c.logger = nil
 }
 
 // debugLog checks if the debug flag is set and if so logs the provided message to StdErr

--- a/smtp/smtp.go
+++ b/smtp/smtp.go
@@ -444,7 +444,7 @@ func (c *Client) SetDebugLog(v bool) {
 // debugLog checks if the debug flag is set and if so logs the provided message to StdErr
 func (c *Client) debugLog(d logDirection, f string, a ...interface{}) {
 	if c.debug {
-		p := "S <-- C:"
+		p := "C <-- S:"
 		if d == logOut {
 			p = "C --> S:"
 		}

--- a/smtp/smtp_test.go
+++ b/smtp/smtp_test.go
@@ -633,6 +633,34 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+// TestClient_SetDebugLog tests the Client method with the Client.SetDebugLog method
+// to enable debug logging
+func TestClient_SetDebugLog(t *testing.T) {
+	server := strings.Join(strings.Split(newClientServer, "\n"), "\r\n")
+
+	var cmdbuf strings.Builder
+	bcmdbuf := bufio.NewWriter(&cmdbuf)
+	out := func() string {
+		if err := bcmdbuf.Flush(); err != nil {
+			t.Errorf("failed to flush: %s", err)
+		}
+		return cmdbuf.String()
+	}
+	var fake faker
+	fake.ReadWriter = bufio.NewReadWriter(bufio.NewReader(strings.NewReader(server)), bcmdbuf)
+	c, err := NewClient(fake, "fake.host")
+	if err != nil {
+		t.Fatalf("NewClient: %v\n(after %v)", err, out())
+	}
+	defer func() {
+		_ = c.Close()
+	}()
+	c.SetDebugLog()
+	if !c.debug {
+		t.Errorf("Expected DebugLog flag to be true but received false")
+	}
+}
+
 var newClientServer = `220 hello world
 250-mx.google.com at your service
 250-SIZE 35651584

--- a/smtp/smtp_test.go
+++ b/smtp/smtp_test.go
@@ -655,7 +655,7 @@ func TestClient_SetDebugLog(t *testing.T) {
 	defer func() {
 		_ = c.Close()
 	}()
-	c.SetDebugLog()
+	c.SetDebugLog(true)
 	if !c.debug {
 		t.Errorf("Expected DebugLog flag to be true but received false")
 	}


### PR DESCRIPTION
Resolves #101.

Since we now have full control over the SMTP client we can also access the message input and output.

This PR introduces a new debug logging feature. Via the `Client.WithDebugLog` the user can enable this feature. It will then make use of the new `smtp/Client.SetDebugLog` method. Once the flag is set to true, the SMTP client will start logging incoming and outgoing messages to os.Stderr.

Log directions will be logged accordingly. 
- `C --> S` means Client to Server communication
- `C <-- S` means Server to Client communication

Example:
![image](https://user-images.githubusercontent.com/542696/212471001-50f8ef95-400b-45c6-b208-8e79c73c9e38.png)
