### PR TITLE
Introducing Msg part deletion

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -989,7 +989,13 @@ func (m *Msg) encodeString(s string) string {
 
 // hasAlt returns true if the Msg has more than one part
 func (m *Msg) hasAlt() bool {
-	return len(m.parts) > 1
+	c := 0
+	for _, p := range m.parts {
+		if !p.del {
+			c++
+		}
+	}
+	return c > 1
 }
 
 // hasMixed returns true if the Msg has mixed parts

--- a/msgwriter.go
+++ b/msgwriter.go
@@ -102,7 +102,9 @@ func (mw *msgWriter) writeMsg(m *Msg) {
 	}
 
 	for _, p := range m.parts {
-		mw.writePart(p, m.charset)
+		if !p.del {
+			mw.writePart(p, m.charset)
+		}
 	}
 	if m.hasAlt() {
 		mw.stopMP()

--- a/part.go
+++ b/part.go
@@ -16,6 +16,7 @@ type PartOption func(*Part)
 type Part struct {
 	ctype ContentType
 	enc   Encoding
+	del   bool
 	w     func(io.Writer) (int64, error)
 }
 
@@ -62,6 +63,12 @@ func (p *Part) SetEncoding(e Encoding) {
 // SetWriteFunc overrides the WriteFunc of the Part
 func (p *Part) SetWriteFunc(w func(io.Writer) (int64, error)) {
 	p.w = w
+}
+
+// Delete removes the current part from the parts list of the Msg by setting the
+// del flag to true. The msgWriter will skip it then
+func (p *Part) Delete() {
+	p.del = true
 }
 
 // WithPartEncoding overrides the default Part encoding

--- a/part_test.go
+++ b/part_test.go
@@ -241,6 +241,22 @@ func TestPart_SetContent(t *testing.T) {
 	}
 }
 
+// TestPart_Delete tests Part.Delete
+func TestPart_Delete(t *testing.T) {
+	c := "This is a test with ümläutß"
+	m := NewMsg()
+	m.SetBodyString(TypeTextPlain, c)
+	pl, err := getPartList(m)
+	if err != nil {
+		t.Errorf("failed: %s", err)
+		return
+	}
+	pl[0].Delete()
+	if !pl[0].del {
+		t.Errorf("Delete failed. Expected: %t, got: %t", true, pl[0].del)
+	}
+}
+
 // getPartList is a helper function
 func getPartList(m *Msg) ([]*Part, error) {
 	pl := m.GetParts()


### PR DESCRIPTION
This PR introduces a new struct field for the message parts: `del`. If the del flag is set to `true`, the msgWriter will ignore this part during the writing process. Additionally, the `part` has now a `Delete` method that lets the user mark the part as deleted

This allows middleware to take further control of the Msg and is part of #107.