### PR TITLE
Implement Logger interface

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/wneessen/go-mail/log"
 	"github.com/wneessen/go-mail/smtp"
 )
 
@@ -106,6 +107,7 @@ func TestNewClientWithOptions(t *testing.T) {
 		{"WithDSNRcptNotifyType() wrong option", WithDSNRcptNotifyType("FAIL"), true},
 		{"WithoutNoop()", WithoutNoop(), false},
 		{"WithDebugLog()", WithDebugLog(), false},
+		{"WithLogger()", WithLogger(log.New(os.Stderr, log.LevelDebug)), false},
 
 		{
 			"WithDSNRcptNotifyType() NEVER combination",
@@ -562,6 +564,31 @@ func TestClient_DialWithContext_Debug(t *testing.T) {
 		t.Errorf("DialWithContext didn't fail but no SMTP client found.")
 	}
 	c.SetDebugLog(true)
+	if err := c.Close(); err != nil {
+		t.Errorf("failed to close connection: %s", err)
+	}
+}
+
+// TestClient_DialWithContext_Debug_custom tests the DialWithContext method for the Client
+// object with debug logging enabled and a custom logger on the SMTP client
+func TestClient_DialWithContext_Debug_custom(t *testing.T) {
+	c, err := getTestClient(true)
+	if err != nil {
+		t.Skipf("failed to create test client: %s. Skipping tests", err)
+	}
+	ctx := context.Background()
+	if err := c.DialWithContext(ctx); err != nil {
+		t.Errorf("failed to dial with context: %s", err)
+		return
+	}
+	if c.co == nil {
+		t.Errorf("DialWithContext didn't fail but no connection found.")
+	}
+	if c.sc == nil {
+		t.Errorf("DialWithContext didn't fail but no SMTP client found.")
+	}
+	c.SetDebugLog(true)
+	c.SetLogger(log.New(os.Stderr, log.LevelDebug))
 	if err := c.Close(); err != nil {
 		t.Errorf("failed to close connection: %s", err)
 	}

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2023 The go-mail Authors
+//
+// SPDX-License-Identifier: MIT
+
+// Package log implements a logger interface that can be used within the go-mail package
+package log
+
+// Logger is the log interface for go-mail
+type Logger interface {
+	Errorf(format string, v ...interface{})
+	Warnf(format string, v ...interface{})
+	Infof(format string, v ...interface{})
+	Debugf(format string, v ...interface{})
+}

--- a/log/stdlog.go
+++ b/log/stdlog.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023 The go-mail Authors
+//
+// SPDX-License-Identifier: MIT
+
+package log
+
+import (
+	"fmt"
+	"io"
+	"log"
+)
+
+// Level is a type wrapper for an int
+type Level int
+
+// Stdlog is the default logger that satisfies the Logger interface
+type Stdlog struct {
+	l     Level
+	err   *log.Logger
+	warn  *log.Logger
+	info  *log.Logger
+	debug *log.Logger
+}
+
+const (
+	// LevelError is the Level for only ERROR log messages
+	LevelError Level = iota
+	// LevelWarn is the Level for WARN and higher log messages
+	LevelWarn
+	// LevelInfo is the Level for INFO and higher log messages
+	LevelInfo
+	// LevelDebug is the Level for DEBUG and higher log messages
+	LevelDebug
+)
+
+// New returns a new Stdlog type that satisfies the Logger interface
+func New(o io.Writer, l Level) *Stdlog {
+	lf := log.Lmsgprefix | log.LstdFlags
+	return &Stdlog{
+		l:     l,
+		err:   log.New(o, "ERROR: ", lf),
+		warn:  log.New(o, " WARN: ", lf),
+		info:  log.New(o, " INFO: ", lf),
+		debug: log.New(o, "DEBUG: ", lf),
+	}
+}
+
+// Debugf performs a Printf() on the debug logger
+func (l *Stdlog) Debugf(f string, v ...interface{}) {
+	if l.l >= LevelDebug {
+		_ = l.debug.Output(2, fmt.Sprintf(f, v...))
+	}
+}
+
+// Infof performs a Printf() on the info logger
+func (l *Stdlog) Infof(f string, v ...interface{}) {
+	if l.l >= LevelInfo {
+		_ = l.info.Output(2, fmt.Sprintf(f, v...))
+	}
+}
+
+// Warnf performs a Printf() on the warn logger
+func (l *Stdlog) Warnf(f string, v ...interface{}) {
+	if l.l >= LevelWarn {
+		_ = l.warn.Output(2, fmt.Sprintf(f, v...))
+	}
+}
+
+// Errorf performs a Printf() on the error logger
+func (l *Stdlog) Errorf(f string, v ...interface{}) {
+	if l.l >= LevelError {
+		_ = l.err.Output(2, fmt.Sprintf(f, v...))
+	}
+}

--- a/log/stdlog_test.go
+++ b/log/stdlog_test.go
@@ -1,0 +1,89 @@
+package log
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	var b bytes.Buffer
+	l := New(&b, LevelDebug)
+	if l.l != LevelDebug {
+		t.Error("Expected level to be LevelDebug, got ", l.l)
+	}
+	if l.err == nil || l.warn == nil || l.info == nil || l.debug == nil {
+		t.Error("Loggers not initialized")
+	}
+}
+
+func TestDebugf(t *testing.T) {
+	var b bytes.Buffer
+	l := New(&b, LevelDebug)
+
+	l.Debugf("test %s", "foo")
+	expected := "DEBUG: test foo\n"
+	if !strings.HasSuffix(b.String(), expected) {
+		t.Errorf("Expected %q, got %q", expected, b.String())
+	}
+
+	b.Reset()
+	l.l = LevelInfo
+	l.Debugf("test %s", "foo")
+	if b.String() != "" {
+		t.Error("Debug message was not expected to be logged")
+	}
+}
+
+func TestInfof(t *testing.T) {
+	var b bytes.Buffer
+	l := New(&b, LevelInfo)
+
+	l.Infof("test %s", "foo")
+	expected := " INFO: test foo\n"
+	if !strings.HasSuffix(b.String(), expected) {
+		t.Errorf("Expected %q, got %q", expected, b.String())
+	}
+
+	b.Reset()
+	l.l = LevelWarn
+	l.Infof("test %s", "foo")
+	if b.String() != "" {
+		t.Error("Info message was not expected to be logged")
+	}
+}
+
+func TestWarnf(t *testing.T) {
+	var b bytes.Buffer
+	l := New(&b, LevelWarn)
+
+	l.Warnf("test %s", "foo")
+	expected := " WARN: test foo\n"
+	if !strings.HasSuffix(b.String(), expected) {
+		t.Errorf("Expected %q, got %q", expected, b.String())
+	}
+
+	b.Reset()
+	l.l = LevelError
+	l.Warnf("test %s", "foo")
+	if b.String() != "" {
+		t.Error("Warn message was not expected to be logged")
+	}
+}
+
+func TestErrorf(t *testing.T) {
+	var b bytes.Buffer
+	l := New(&b, LevelError)
+
+	l.Errorf("test %s", "foo")
+	expected := "ERROR: test foo\n"
+	if !strings.HasSuffix(b.String(), expected) {
+		t.Errorf("Expected %q, got %q", expected, b.String())
+	}
+	b.Reset()
+	l.l = LevelError - 1
+	l.Warnf("test %s", "foo")
+	if b.String() != "" {
+		t.Error("Error message was not expected to be logged")
+	}
+}

--- a/log/stdlog_test.go
+++ b/log/stdlog_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: Copyright (c) 2023 The go-mail Authors
+//
+// SPDX-License-Identifier: MIT
+
 package log
 
 import (


### PR DESCRIPTION
As stated in https://github.com/wneessen/go-mail/pull/102#issuecomment-1411956040 it would be beneficial if, instead of forcing the Go stdlib logger on the user to provide a simple interface and use that for logging purposes.

This PR implements this simple log.Logger interface as well as a standard logger that satisfies this interface. If no custom logger is provided, the Stdlog will be used (which makes use of the Go stdlib again).

Accordingly, a `Client.WithLogger` and `Client.SetLogger` have been implemented. Same applies for the smtp counterparts.

Closes #112 