### PR TITLE
Provide more ways for middleware to interact with mail parts

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -141,6 +141,8 @@ const (
 	TypeTextPlain      ContentType = "text/plain"
 	TypeTextHTML       ContentType = "text/html"
 	TypeAppOctetStream ContentType = "application/octet-stream"
+	TypePGPSignature   ContentType = "application/pgp-signature"
+	TypePGPEncrypted   ContentType = "application/pgp-encrypted"
 )
 
 // List of MIMETypes

--- a/file.go
+++ b/file.go
@@ -14,9 +14,12 @@ type FileOption func(*File)
 
 // File is an attachment or embedded file of the Msg
 type File struct {
-	Name   string
-	Header textproto.MIMEHeader
-	Writer func(w io.Writer) (int64, error)
+	ContentType ContentType
+	Desc        string
+	Enc         Encoding
+	Header      textproto.MIMEHeader
+	Name        string
+	Writer      func(w io.Writer) (int64, error)
 }
 
 // WithFileName sets the filename of the File
@@ -26,11 +29,45 @@ func WithFileName(n string) FileOption {
 	}
 }
 
+// WithFileDescription sets an optional file description of the File that will be
+// added as Content-Description part
+func WithFileDescription(d string) FileOption {
+	return func(f *File) {
+		f.Desc = d
+	}
+}
+
+// WithFileEncoding sets the encoding of the File. By default we should always use
+// Base64 encoding but there might be exceptions, where this might come handy.
+// Please note that quoted-printable should never be used for attachments/embeds. If this
+// is provided as argument, the function will automatically override back to Base64
+func WithFileEncoding(e Encoding) FileOption {
+	return func(f *File) {
+		if e == EncodingQP {
+			return
+		}
+		f.Enc = e
+	}
+}
+
+// WithFileContentType sets the content type of the File.
+// By default go-mail will try to guess the file type and its corresponding
+// content type and fall back to application/octet-stream if the file type
+// could not be guessed. In some cases, however, it might be needed to force
+// this to a specific type. For such situations this override method can
+// be used
+func WithFileContentType(t ContentType) FileOption {
+	return func(f *File) {
+		f.ContentType = t
+	}
+}
+
 // setHeader sets header fields to a File
 func (f *File) setHeader(h Header, v string) {
 	f.Header.Set(string(h), v)
 }
 
+// getHeader return header fields of a File
 func (f *File) getHeader(h Header) (string, bool) {
 	v := f.Header.Get(string(h))
 	return v, v != ""

--- a/file_test.go
+++ b/file_test.go
@@ -30,3 +30,84 @@ func TestFile_SetGetHeader(t *testing.T) {
 		t.Errorf("getHeader returned wrong value. Expected: %s, got: %s", "", fi)
 	}
 }
+
+// TestFile_WithFileDescription tests the WithFileDescription option
+func TestFile_WithFileDescription(t *testing.T) {
+	tests := []struct {
+		name string
+		desc string
+	}{
+		{"File description: test", "test"},
+		{"File description: empty", ""},
+	}
+	for _, tt := range tests {
+		m := NewMsg()
+		t.Run(tt.name, func(t *testing.T) {
+			m.AttachFile("file.go", WithFileDescription(tt.desc))
+			al := m.GetAttachments()
+			if len(al) <= 0 {
+				t.Errorf("AttachFile() failed. Attachment list is empty")
+			}
+			a := al[0]
+			if a.Desc != tt.desc {
+				t.Errorf("WithFileDescription() failed. Expected: %s, got: %s", tt.desc, a.Desc)
+			}
+		})
+	}
+}
+
+// TestFile_WithFileEncoding tests the WithFileEncoding option
+func TestFile_WithFileEncoding(t *testing.T) {
+	tests := []struct {
+		name string
+		enc  Encoding
+		want Encoding
+	}{
+		{"File encoding: 8bit raw", NoEncoding, NoEncoding},
+		{"File encoding: Base64", EncodingB64, EncodingB64},
+		{"File encoding: quoted-printable (not allowed)", EncodingQP, ""},
+	}
+	for _, tt := range tests {
+		m := NewMsg()
+		t.Run(tt.name, func(t *testing.T) {
+			m.AttachFile("file.go", WithFileEncoding(tt.enc))
+			al := m.GetAttachments()
+			if len(al) <= 0 {
+				t.Errorf("AttachFile() failed. Attachment list is empty")
+			}
+			a := al[0]
+			if a.Enc != tt.want {
+				t.Errorf("WithFileEncoding() failed. Expected: %s, got: %s", tt.enc, a.Enc)
+			}
+		})
+	}
+}
+
+// TestFile_WithFileContentType tests the WithFileContentType option
+func TestFile_WithFileContentType(t *testing.T) {
+	tests := []struct {
+		name string
+		ct   ContentType
+		want string
+	}{
+		{"File content-type: text/plain", TypeTextPlain, "text/plain"},
+		{"File content-type: html/html", TypeTextHTML, "text/html"},
+		{"File content-type: application/octet-stream", TypeAppOctetStream, "application/octet-stream"},
+		{"File content-type: application/pgp-encrypted", TypePGPEncrypted, "application/pgp-encrypted"},
+		{"File content-type: application/pgp-signature", TypePGPSignature, "application/pgp-signature"},
+	}
+	for _, tt := range tests {
+		m := NewMsg()
+		t.Run(tt.name, func(t *testing.T) {
+			m.AttachFile("file.go", WithFileContentType(tt.ct))
+			al := m.GetAttachments()
+			if len(al) <= 0 {
+				t.Errorf("AttachFile() failed. Attachment list is empty")
+			}
+			a := al[0]
+			if a.ContentType != ContentType(tt.want) {
+				t.Errorf("WithFileContentType() failed. Expected: %s, got: %s", tt.want, a.ContentType)
+			}
+		})
+	}
+}

--- a/header.go
+++ b/header.go
@@ -15,6 +15,9 @@ type Importance int
 
 // List of common generic header field names
 const (
+	// HeaderContentDescription is the "Content-Description" header
+	HeaderContentDescription Header = "Content-Description"
+
 	// HeaderContentDisposition is the "Content-Disposition" header
 	HeaderContentDisposition Header = "Content-Disposition"
 

--- a/msg.go
+++ b/msg.go
@@ -806,10 +806,10 @@ func (m *Msg) EmbedFile(n string, o ...FileOption) {
 
 // EmbedReader adds an embedded File from an io.Reader to the Msg
 //
-// CAVEAT: For AttachReader to work it has to read all data of the io.Reader
+// CAVEAT: For EmbedReader to work it has to read all data of the io.Reader
 // into memory first, so it can seek through it. Using larger amounts of
 // data on the io.Reader should be avoided. For such, it is recommeded to
-// either use AttachFile or AttachReadSeeker instead
+// either use EmbedFile or EmbedReadSeeker instead
 func (m *Msg) EmbedReader(n string, r io.Reader, o ...FileOption) {
 	f := fileFromReader(n, r)
 	m.embeds = m.appendFile(m.embeds, f, o...)

--- a/msg_test.go
+++ b/msg_test.go
@@ -179,6 +179,36 @@ func TestNewMsgWithBoundary(t *testing.T) {
 	}
 }
 
+// TestNewMsg_WithPGPType tests WithPGPType option
+func TestNewMsg_WithPGPType(t *testing.T) {
+	tests := []struct {
+		name string
+		pt   PGPType
+		hpt  bool
+	}{
+		{"Not a PGP encoded message", NoPGP, false},
+		{"PGP encrypted message", PGPEncrypt, true},
+		{"PGP signed message", PGPSignature, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewMsg(WithPGPType(tt.pt))
+			if m.pgptype != tt.pt {
+				t.Errorf("WithPGPType() failed. Expected: %d, got: %d", tt.pt, m.pgptype)
+			}
+			m.pgptype = 99
+			m.SetPGPType(tt.pt)
+			if m.pgptype != tt.pt {
+				t.Errorf("SetPGPType() failed. Expected: %d, got: %d", tt.pt, m.pgptype)
+			}
+			if m.hasPGPType() != tt.hpt {
+				t.Errorf("hasPGPType() failed. Expected %t, got: %t", tt.hpt, m.hasPGPType())
+			}
+		})
+	}
+}
+
 type uppercaseMiddleware struct{}
 
 func (mw uppercaseMiddleware) Handle(m *Msg) *Msg {

--- a/msgwriter.go
+++ b/msgwriter.go
@@ -108,7 +108,6 @@ func (mw *msgWriter) writeMsg(m *Msg) {
 			mw.startMP(`signed; protocol="application/pgp-signature";`, m.boundary)
 		}
 		mw.writeString(DoubleNewLine)
-		mw.startMP("mixed", m.boundary)
 	}
 
 	for _, p := range m.parts {
@@ -117,9 +116,6 @@ func (mw *msgWriter) writeMsg(m *Msg) {
 		}
 	}
 
-	if m.hasPGPType() {
-		mw.stopMP()
-	}
 	if m.hasAlt() {
 		mw.stopMP()
 	}

--- a/msgwriter_test.go
+++ b/msgwriter_test.go
@@ -104,3 +104,32 @@ func TestMsgWriter_writeMsg(t *testing.T) {
 		t.Errorf(em)
 	}
 }
+
+// TestMsgWriter_writeMsg_PGP tests the writeMsg method of the msgWriter with PGP types set
+func TestMsgWriter_writeMsg_PGP(t *testing.T) {
+	m := NewMsg(WithPGPType(PGPEncrypt))
+	_ = m.From(`"Toni Tester" <test@example.com>`)
+	_ = m.To(`"Toni Receiver" <receiver@example.com>`)
+	m.Subject("This is a subject")
+	m.SetBodyString(TypeTextPlain, "This is the body")
+	buf := bytes.Buffer{}
+	mw := &msgWriter{w: &buf, c: CharsetUTF8, en: mime.QEncoding}
+	mw.writeMsg(m)
+	ms := buf.String()
+	if !strings.Contains(ms, `encrypted; protocol="application/pgp-encrypted"`) {
+		t.Errorf("writeMsg failed. Expected PGP encoding header but didn't find it in message output")
+	}
+
+	m = NewMsg(WithPGPType(PGPSignature))
+	_ = m.From(`"Toni Tester" <test@example.com>`)
+	_ = m.To(`"Toni Receiver" <receiver@example.com>`)
+	m.Subject("This is a subject")
+	m.SetBodyString(TypeTextPlain, "This is the body")
+	buf = bytes.Buffer{}
+	mw = &msgWriter{w: &buf, c: CharsetUTF8, en: mime.QEncoding}
+	mw.writeMsg(m)
+	ms = buf.String()
+	if !strings.Contains(ms, `signed; protocol="application/pgp-signature"`) {
+		t.Errorf("writeMsg failed. Expected PGP encoding header but didn't find it in message output")
+	}
+}

--- a/part.go
+++ b/part.go
@@ -15,6 +15,7 @@ type PartOption func(*Part)
 // Part is a part of the Msg
 type Part struct {
 	ctype ContentType
+	desc  string
 	enc   Encoding
 	del   bool
 	w     func(io.Writer) (int64, error)
@@ -44,6 +45,11 @@ func (p *Part) GetWriteFunc() func(io.Writer) (int64, error) {
 	return p.w
 }
 
+// GetDescription returns the currently set Content-Description of the Part
+func (p *Part) GetDescription() string {
+	return p.desc
+}
+
 // SetContent overrides the content of the Part with the given string
 func (p *Part) SetContent(c string) {
 	buf := bytes.NewBufferString(c)
@@ -58,6 +64,11 @@ func (p *Part) SetContentType(c ContentType) {
 // SetEncoding creates a new mime.WordEncoder based on the encoding setting of the message
 func (p *Part) SetEncoding(e Encoding) {
 	p.enc = e
+}
+
+// SetDescription overrides the Content-Description of the Part
+func (p *Part) SetDescription(d string) {
+	p.desc = d
 }
 
 // SetWriteFunc overrides the WriteFunc of the Part
@@ -75,5 +86,12 @@ func (p *Part) Delete() {
 func WithPartEncoding(e Encoding) PartOption {
 	return func(p *Part) {
 		p.enc = e
+	}
+}
+
+// WithPartContentDescription overrides the default Part Content-Description
+func WithPartContentDescription(d string) PartOption {
+	return func(p *Part) {
+		p.desc = d
 	}
 }

--- a/part_test.go
+++ b/part_test.go
@@ -45,6 +45,36 @@ func TestPartEncoding(t *testing.T) {
 	}
 }
 
+// TestPart_WithPartContentDescription tests the WithPartContentDescription method
+func TestPart_WithPartContentDescription(t *testing.T) {
+	tests := []struct {
+		name string
+		desc string
+	}{
+		{"Part description: test", "test"},
+		{"Part description: empty", ""},
+	}
+	for _, tt := range tests {
+		m := NewMsg()
+		t.Run(tt.name, func(t *testing.T) {
+			part := m.newPart(TypeTextPlain, WithPartContentDescription(tt.desc), nil)
+			if part == nil {
+				t.Errorf("newPart() WithPartContentDescription() failed: no part returned")
+				return
+			}
+			if part.desc != tt.desc {
+				t.Errorf("newPart() WithPartContentDescription() failed: expected: %s, got: %s", tt.desc,
+					part.desc)
+			}
+			part.desc = ""
+			part.SetDescription(tt.desc)
+			if part.desc != tt.desc {
+				t.Errorf("newPart() SetDescription() failed: expected: %s, got: %s", tt.desc, part.desc)
+			}
+		})
+	}
+}
+
 // TestPartContentType tests Part.SetContentType
 func TestPart_SetContentType(t *testing.T) {
 	tests := []struct {
@@ -238,6 +268,31 @@ func TestPart_SetContent(t *testing.T) {
 	}
 	if string(nc) != strings.ToUpper(c) {
 		t.Errorf("SetContent failed. Expected: %s, got: %s", strings.ToUpper(c), string(nc))
+	}
+}
+
+// TestPart_SetDescription tests Part.SetDescription
+func TestPart_SetDescription(t *testing.T) {
+	c := "This is a test"
+	d := "test-description"
+	m := NewMsg()
+	m.SetBodyString(TypeTextPlain, c)
+	pl, err := getPartList(m)
+	if err != nil {
+		t.Errorf("failed: %s", err)
+		return
+	}
+	pd := pl[0].GetDescription()
+	if pd != "" {
+		t.Errorf("Part.GetDescription failed. Expected empty description but got: %s", pd)
+	}
+	pl[0].SetDescription(d)
+	if pl[0].desc != d {
+		t.Errorf("Part.SetDescription failed. Expected desc to be: %s, got: %s", d, pd)
+	}
+	pd = pl[0].GetDescription()
+	if pd != d {
+		t.Errorf("Part.GetDescription failed. Expected: %s, got: %s", d, pd)
 	}
 }
 


### PR DESCRIPTION
This PR adds functionalities for middlware (in particular the new OpenPGP middleware) to provide more access to the `Msg`. 

In detail:
* The `File` type now has additional fields: `ContentType`, `Desc` and `Enc` with corresponding `FileOption´ methods to stear those
* A new `PGPType` has been added which can be set as part of the `Msg` struct using the `WithPGPType` option method and a `SetPGPType` setter method
  * 3 PGPTypes have been added: `NoPGP`, `PGPEncrypt` and `PGPSignature`
  * If a PGPType is set, the msgWriter will produce different MIME headers for the content types
* Msg parts received a `description` field which will be reflected in the `Content-Description` header of the part. Corresponding Option-, getter- and setter methods have been added: `WithPartContentDescription`, `GetDescription`, `SetDescription`