### PR TITLE
fix: parsing of ReplyTo with special characters

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -398,7 +398,7 @@ func (m *Msg) BccIgnoreInvalid(b ...string) {
 
 // ReplyTo takes and validates a given mail address and sets it as "Reply-To" addrHeader of the Msg
 func (m *Msg) ReplyTo(r string) error {
-	rt, err := mail.ParseAddress(m.encodeString(r))
+	rt, err := mail.ParseAddress(r)
 	if err != nil {
 		return fmt.Errorf("failed to parse reply-to address: %w", err)
 	}


### PR DESCRIPTION
Encoding makes no sense at this point and leads to parsing errors. Encoding is applied in SetGenHeader