### PR TITLE
Fix nil pointer dereference in msgwriter due to missing error handling

### DIFF
--- a/msgwriter.go
+++ b/msgwriter.go
@@ -231,7 +231,10 @@ func (mw *msgWriter) addFiles(fl []*File, a bool) {
 		if mw.d > 0 {
 			mw.newPart(f.Header)
 		}
-		mw.writeBody(f.Writer, e)
+
+		if mw.err == nil {
+			mw.writeBody(f.Writer, e)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #138 