### PR TITLE
#147 add remove attachments and embeds methods

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -638,14 +638,30 @@ func (m *Msg) SetAttachements(ff []*File) {
 	m.attachments = ff
 }
 
+// UnsetAllAttachments unset the attachments of the message.
+func (m *Msg) UnsetAllAttachments() {
+	m.attachments = nil
+}
+
 // GetEmbeds returns the embeds of the Msg
 func (m *Msg) GetEmbeds() []*File {
 	return m.embeds
 }
 
-// SetEmbeds sets the attachements of the message.
+// SetEmbeds sets the embeds of the message.
 func (m *Msg) SetEmbeds(ff []*File) {
 	m.embeds = ff
+}
+
+// UnsetAllEmbeds unset the embeds of the message.
+func (m *Msg) UnsetAllEmbeds() {
+	m.embeds = nil
+}
+
+// UnsetAllParts unset the embeds and attachments of the message.
+func (m *Msg) UnsetAllParts() {
+	m.UnsetAllAttachments()
+	m.UnsetAllEmbeds()
 }
 
 // SetBodyString sets the body of the message.

--- a/msg_test.go
+++ b/msg_test.go
@@ -1400,6 +1400,40 @@ func TestMsg_SetAttachments(t *testing.T) {
 	}
 }
 
+// TestMsg_UnsetAllAttachments tests the Msg.UnsetAllAttachments method
+func TestMsg_UnsetAllAttachments(t *testing.T) {
+	tests := []struct {
+		name        string
+		attachments []string
+	}{
+		{"File: one file", []string{"README.md"}},
+		{"File: two files", []string{"README.md", "doc.go"}},
+		{"File: nil", nil},
+	}
+	m := NewMsg()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var files []*File
+			for _, f := range tt.attachments {
+				files = append(files, &File{Name: f})
+			}
+			m.SetAttachements(files)
+
+			if len(m.attachments) != len(files) {
+				t.Errorf("SetAttachements() failed. Number of attachments expected: %d, got: %d", len(files),
+					len(m.attachments))
+				return
+			}
+			m.UnsetAllAttachments()
+			if m.attachments != nil {
+				t.Errorf("UnsetAllAttachments() failed. The attachments file's pointer is not nil")
+				return
+			}
+			m.Reset()
+		})
+	}
+}
+
 // TestMsg_GetEmbeds tests the Msg.GetEmbeds method
 func TestMsg_GetEmbeds(t *testing.T) {
 	tests := []struct {
@@ -1487,6 +1521,88 @@ func TestMsg_SetEmbeds(t *testing.T) {
 						m.embeds[i].Name)
 					return
 				}
+			}
+			m.Reset()
+		})
+	}
+}
+
+// TestMsg_UnsetAllEmbeds tests the Msg.TestMsg_UnsetAllEmbeds method
+func TestMsg_UnsetAllEmbeds(t *testing.T) {
+	tests := []struct {
+		name   string
+		embeds []string
+	}{
+		{"File: one file", []string{"README.md"}},
+		{"File: two files", []string{"README.md", "doc.go"}},
+		{"File: nil", nil},
+	}
+	m := NewMsg()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var files []*File
+			for _, f := range tt.embeds {
+				files = append(files, &File{Name: f})
+			}
+			m.SetEmbeds(files)
+			if len(m.embeds) != len(files) {
+				t.Errorf("SetEmbeds() failed. Number of embedded files expected: %d, got: %d", len(files),
+					len(m.embeds))
+				return
+			}
+			m.UnsetAllEmbeds()
+			if m.embeds != nil {
+				t.Errorf("UnsetAllEmbeds() failed. The embeds file's point is not nil")
+				return
+			}
+			m.Reset()
+		})
+	}
+}
+
+// TestMsg_UnsetAllParts tests the Msg.TestMsg_UnsetAllParts method
+func TestMsg_UnsetAllParts(t *testing.T) {
+	tests := []struct {
+		name        string
+		attachments []string
+		embeds      []string
+	}{
+		{"File: both is exist", []string{"README.md"}, []string{"doc.go"}},
+		{"File: both is nil", nil, nil},
+		{"File: attachment exist, embed nil", []string{"README.md"}, nil},
+		{"File: attachment nil, embed exist", nil, []string{"README.md"}},
+	}
+	m := NewMsg()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var attachments []*File
+			for _, f := range tt.attachments {
+				attachments = append(attachments, &File{Name: f})
+			}
+			m.SetAttachements(attachments)
+			if len(m.attachments) != len(attachments) {
+				t.Errorf("SetAttachements() failed. Number of attachments files expected: %d, got: %d",
+					len(attachments), len(m.attachments))
+				return
+			}
+			var embeds []*File
+			for _, f := range tt.embeds {
+				embeds = append(embeds, &File{Name: f})
+			}
+			m.SetEmbeds(embeds)
+			if len(m.embeds) != len(embeds) {
+				t.Errorf("SetEmbeds() failed. Number of embedded files expected: %d, got: %d", len(embeds),
+					len(m.embeds))
+				return
+			}
+			m.UnsetAllParts()
+			if m.attachments != nil {
+				t.Errorf("UnsetAllParts() failed. The attachments file's point is not nil")
+				return
+			}
+			if m.embeds != nil {
+				t.Errorf("UnsetAllParts() failed. The embeds file's point is not nil")
+				return
 			}
 			m.Reset()
 		})


### PR DESCRIPTION
See issue #147.
I added three methods in the Msg file.

- Msg.UnsetAllAttachments()
- Msg.UnsetAllEmbeds()
- Msg.UnsetAllParts()

If there is any error, please tell me, and I will fix it.