### PR TITLE
feat(smtp): auth login extension draft support

### DIFF
--- a/smtp/auth_login.go
+++ b/smtp/auth_login.go
@@ -16,11 +16,31 @@ type loginAuth struct {
 }
 
 const (
-	// ServerRespUsername represents the "Username:" response by the SMTP server
-	ServerRespUsername = "Username:"
+	// LoginXUsernameChallenge represents the Username Challenge response sent by the SMTP server per the AUTH LOGIN
+	// extension.
+	//
+	// See: https://learn.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-xlogin/.
+	LoginXUsernameChallenge = "Username:"
 
-	// ServerRespPassword represents the "Password:" response by the SMTP server
-	ServerRespPassword = "Password:"
+	// LoginXPasswordChallenge represents the Password Challenge response sent by the SMTP server per the AUTH LOGIN
+	// extension.
+	//
+	//	See: https://learn.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-xlogin/.
+	LoginXPasswordChallenge = "Password:"
+
+	// LoginXDraftUsernameChallenge represents the Username Challenge response sent by the SMTP server per the IETF
+	// draft AUTH LOGIN extension. It should be noted this extension is an expired draft which was never formally
+	// published and was deprecated in favor of the AUTH PLAIN extension.
+	//
+	// See: https://datatracker.ietf.org/doc/html/draft-murchison-sasl-login-00.
+	LoginXDraftUsernameChallenge = "User Name\x00"
+
+	// LoginXDraftPasswordChallenge represents the Password Challenge response sent by the SMTP server per the IETF
+	// draft AUTH LOGIN extension. It should be noted this extension is an expired draft which was never formally
+	// published and was deprecated in favor of the AUTH PLAIN extension.
+	//
+	// See: https://datatracker.ietf.org/doc/html/draft-murchison-sasl-login-00.
+	LoginXDraftPasswordChallenge = "Password\x00"
 )
 
 // LoginAuth returns an Auth that implements the LOGIN authentication
@@ -56,9 +76,9 @@ func (a *loginAuth) Start(server *ServerInfo) (string, []byte, error) {
 func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 	if more {
 		switch string(fromServer) {
-		case ServerRespUsername:
+		case LoginXUsernameChallenge, LoginXDraftUsernameChallenge:
 			return []byte(a.username), nil
-		case ServerRespPassword:
+		case LoginXPasswordChallenge, LoginXDraftPasswordChallenge:
 			return []byte(a.password), nil
 		default:
 			return nil, fmt.Errorf("unexpected server response: %s", string(fromServer))

--- a/smtp/smtp_test.go
+++ b/smtp/smtp_test.go
@@ -57,10 +57,10 @@ var authTests = []authTest{
 	},
 	{
 		LoginAuth("user", "pass", "testserver"),
-		[]string{"Username:", "Password:", "Invalid:"},
+		[]string{"Username:", "Password:", "User Name\x00", "Password\x00", "Invalid:"},
 		"LOGIN",
-		[]string{"", "user", "pass", ""},
-		[]bool{false, false, true},
+		[]string{"", "user", "pass", "user", "pass", ""},
+		[]bool{false, false, false, false, true},
 	},
 	{
 		CRAMMD5Auth("user", "pass"),


### PR DESCRIPTION
This adds support for the auth login extension draft. This effectively is a draft that expired and was deprecated in favor of the `AUTH PLAIN` SASL extension. Microsoft is the only entity that I can find that has published a `AUTH LOGIN` SASL extension specification (which is currently supported), and Google seems to have adopted it too. 

This makes the Microsoft specification easily the most popular however there are some SMTP servers still using the version that was never formally published (including [Stalwart Mail Server](https://stalw.art/) [<sup>GitHub</sup>](https://github.com/stalwartlabs/mail-server) currently - I am trying to convince the developer to use the modern standard and have an opt in fallback to the deprecated/legacy/non-standard variant).

I've added documentation and tests. It is theoretically possible we could add an option to enable this as part of the LoginAuth method (using functional options) which would not break anything.

Let me know what you think. Maybe this isn't something you want to adopt? Effectively the draft it implements was never standardized. But I don't see the harm in implementing it either.