### PR TITLE
Add delivery status indication for messages

### DIFF
--- a/client_119.go
+++ b/client_119.go
@@ -91,6 +91,7 @@ func (c *Client) Send(ml ...*Msg) error {
 			errs = append(errs, se)
 			continue
 		}
+		m.isDelivered = true
 
 		if err := w.Close(); err != nil {
 			se := &SendError{Reason: ErrSMTPDataClose, errlist: []error{err}, isTemp: isTempError(err)}

--- a/client_120.go
+++ b/client_120.go
@@ -88,6 +88,7 @@ func (c *Client) Send(ml ...*Msg) (rerr error) {
 			rerr = errors.Join(rerr, m.sendError)
 			continue
 		}
+		m.isDelivered = true
 
 		if err := w.Close(); err != nil {
 			m.sendError = &SendError{Reason: ErrSMTPDataClose, errlist: []error{err}, isTemp: isTempError(err)}

--- a/client_test.go
+++ b/client_test.go
@@ -763,6 +763,9 @@ func TestClient_DialSendClose(t *testing.T) {
 	if err := c.Close(); err != nil {
 		t.Errorf("Close() failed: %s", err)
 	}
+	if !m.IsDelivered() {
+		t.Errorf("message should be delivered but is indicated no to")
+	}
 }
 
 // TestClient_DialAndSendWithContext tests the DialAndSendWithContext() method of Client
@@ -1134,7 +1137,9 @@ func TestClient_DialAndSendWithContext_withSendError(t *testing.T) {
 	}
 	if se.IsTemp() {
 		t.Errorf("expected permanent error but IsTemp() returned true")
-		return
+	}
+	if m.IsDelivered() {
+		t.Errorf("message is indicated to be delivered but shouldn't")
 	}
 }
 

--- a/msg.go
+++ b/msg.go
@@ -94,6 +94,9 @@ type Msg struct {
 	// genHeader is a slice of strings that the different generic mail Header fields
 	genHeader map[Header][]string
 
+	// isDelivered signals if a message has been delivered or not
+	isDelivered bool
+
 	// middlewares is the list of middlewares to apply to the Msg before sending in FIFO order
 	middlewares []Middleware
 
@@ -505,6 +508,11 @@ func (m *Msg) SetOrganization(o string) {
 func (m *Msg) SetUserAgent(a string) {
 	m.SetGenHeader(HeaderUserAgent, a)
 	m.SetGenHeader(HeaderXMailer, a)
+}
+
+// IsDelivered will return true if the Msg has been successfully delivered
+func (m *Msg) IsDelivered() bool {
+	return m.isDelivered
 }
 
 // RequestMDNTo adds the Disposition-Notification-To header to request a MDN from the receiving end


### PR DESCRIPTION
This update introduces a new property, `isDelivered`, in the message struct to track if a message has been successfully sent or not. Additionally, this also includes a new helper function `IsDelivered` to easily retrieve the status. This feature enhances the tracking capabilities of outgoing messages across different client files.

This PR will address #166