### PR TITLE
Update FreeBSD version in .cirrus.yml

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,9 +9,9 @@ freebsd_task:
     - name: FreeBSD 13.2
       freebsd_instance:
         image_family: freebsd-13-2
-    - name: FreeBSD 12.4
+    - name: FreeBSD 14.0
       freebsd_instance:
-        image_family: freebsd-12-4
+        image_family: freebsd-14-0
 
   env:
     TEST_ALLOW_SEND: 0


### PR DESCRIPTION
The FreeBSD version used for testing in .cirrus.yml has been updated from 12.4 to 14.0. This change ensures that the tests run on the latest stable version of the operating system, providing more reliable and up-to-date test results.