### PR TITLE
Add Charset support for message parts

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -1141,6 +1141,7 @@ func (m *Msg) hasPGPType() bool {
 func (m *Msg) newPart(ct ContentType, o ...PartOption) *Part {
 	p := &Part{
 		ctype: ct,
+		cset:  m.charset,
 		enc:   m.encoding,
 	}
 

--- a/msgwriter.go
+++ b/msgwriter.go
@@ -245,7 +245,11 @@ func (mw *msgWriter) newPart(h map[string][]string) {
 
 // writePart writes the corresponding part to the Msg body
 func (mw *msgWriter) writePart(p *Part, cs Charset) {
-	ct := fmt.Sprintf("%s; charset=%s", p.ctype, cs)
+	pcs := p.cset
+	if pcs.String() == "" {
+		pcs = cs
+	}
+	ct := fmt.Sprintf("%s; charset=%s", p.ctype, pcs)
 	cte := p.enc.String()
 	if mw.d == 0 {
 		mw.writeHeader(HeaderContentType, ct)

--- a/part.go
+++ b/part.go
@@ -31,6 +31,11 @@ func (p *Part) GetContent() ([]byte, error) {
 	return b.Bytes(), nil
 }
 
+// GetCharset returns the currently set Charset of the Part
+func (p *Part) GetCharset() Charset {
+	return p.cset
+}
+
 // GetContentType returns the currently set ContentType of the Part
 func (p *Part) GetContentType() ContentType {
 	return p.ctype

--- a/part.go
+++ b/part.go
@@ -15,6 +15,7 @@ type PartOption func(*Part)
 // Part is a part of the Msg
 type Part struct {
 	ctype ContentType
+	cset  Charset
 	desc  string
 	enc   Encoding
 	del   bool
@@ -61,6 +62,11 @@ func (p *Part) SetContentType(c ContentType) {
 	p.ctype = c
 }
 
+// SetCharset overrides the Charset of the Part
+func (p *Part) SetCharset(c Charset) {
+	p.cset = c
+}
+
 // SetEncoding creates a new mime.WordEncoder based on the encoding setting of the message
 func (p *Part) SetEncoding(e Encoding) {
 	p.enc = e
@@ -80,6 +86,13 @@ func (p *Part) SetWriteFunc(w func(io.Writer) (int64, error)) {
 // del flag to true. The msgWriter will skip it then
 func (p *Part) Delete() {
 	p.del = true
+}
+
+// WithPartCharset overrides the default Part charset
+func WithPartCharset(c Charset) PartOption {
+	return func(p *Part) {
+		p.cset = c
+	}
 }
 
 // WithPartEncoding overrides the default Part encoding


### PR DESCRIPTION
Charset support has been added in the 'Part' struct. A 'SetCharset' method and a 'WithPartCharset' option have been added to override the default Part charset. The 'writePart' function in msgWriter now accommodates the charset defined at the Part level, defaulting to the previous functionality if not set.

This closes #171 