### PR TITLE
Add "X-Auto-Response-Suppress" header and update SetBulk method

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -3,7 +3,7 @@
 ## SPDX-License-Identifier: MIT
 
 [run]
-go = "1.20"
+go = "1.22"
 tests = true
 
 [linters]

--- a/header.go
+++ b/header.go
@@ -82,6 +82,9 @@ const (
 	// HeaderUserAgent is the "User-Agent" header field
 	HeaderUserAgent Header = "User-Agent"
 
+	// HeaderXAutoResponseSuppress is the "X-Auto-Response-Suppress" header field
+	HeaderXAutoResponseSuppress Header = "X-Auto-Response-Suppress"
+
 	// HeaderXMailer is the "X-Mailer" header field
 	HeaderXMailer Header = "X-Mailer"
 

--- a/msg.go
+++ b/msg.go
@@ -470,11 +470,13 @@ func (m *Msg) SetMessageIDWithValue(v string) {
 	m.SetGenHeader(HeaderMessageID, fmt.Sprintf("<%s>", v))
 }
 
-// SetBulk sets the "Precedence: bulk" genHeader which is recommended for
-// automated mails like OOO replies
+// SetBulk sets the "Precedence: bulk" and "X-Auto-Response-Suppress: All" genHeaders which are
+// recommended for automated mails like OOO replies
 // See: https://www.rfc-editor.org/rfc/rfc2076#section-3.9
+// See also: https://learn.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxcmail/ced68690-498a-4567-9d14-5c01f974d8b1#Appendix_A_Target_51
 func (m *Msg) SetBulk() {
 	m.SetGenHeader(HeaderPrecedence, "bulk")
+	m.SetGenHeader(HeaderXAutoResponseSuppress, "All")
 }
 
 // SetDate sets the Date genHeader field to the current time in a valid format

--- a/msg_test.go
+++ b/msg_test.go
@@ -701,7 +701,16 @@ func TestMsg_SetBulk(t *testing.T) {
 		return
 	}
 	if m.genHeader[HeaderPrecedence][0] != "bulk" {
-		t.Errorf("SetBulk() failed. Expected %q, got: %q", "bulk", m.genHeader[HeaderPrecedence][0])
+		t.Errorf("SetBulk() failed. Expected Precedence header: %q, got: %q", "bulk",
+			m.genHeader[HeaderPrecedence][0])
+	}
+	if m.genHeader[HeaderXAutoResponseSuppress] == nil {
+		t.Errorf("SetBulk() failed. X-Auto-Response-Suppress header is nil")
+		return
+	}
+	if m.genHeader[HeaderXAutoResponseSuppress][0] != "All" {
+		t.Errorf("SetBulk() failed. Expected X-Auto-Response-Suppress header: %q, got: %q", "All",
+			m.genHeader[HeaderXAutoResponseSuppress][0])
 	}
 }
 

--- a/smtp/smtp_test.go
+++ b/smtp/smtp_test.go
@@ -1088,7 +1088,6 @@ Subject: SendMail test
 
 SendMail is working for me.
 `, "\n", "\r\n", -1)))
-
 	if err != nil {
 		t.Errorf("%v", err)
 	}


### PR DESCRIPTION
A new "X-Auto-Response-Suppress" header has been added. The SetBulk method has been updated to include this new header, as it is recommended for automated emails. This functionality is tested in the msg_test.go file.