### PR TITLE
Update Go version in GitHub workflow files

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: [1.17, 1.18, 1.19, '1.20', '1.21']
+        go: [1.18, 1.19, '1.20', '1.21', '1.22']
     steps:
     - name: Checkout Code
       uses: actions/checkout@master
@@ -42,14 +42,14 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
     - name: Install sendmail
-      if: matrix.go == '1.21' && matrix.os == 'ubuntu-latest'
+      if: matrix.go == '1.22' && matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get -y install sendmail; which sendmail
     - name: Run Tests
       run: |
         go test -v -race --coverprofile=coverage.coverprofile --covermode=atomic ./...
     - name: Upload coverage to Codecov
-      if: success() && matrix.go == '1.21' && matrix.os == 'ubuntu-latest'
+      if: success() && matrix.go == '1.22' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21.x'
+          go-version: '1.22.x'
           
       - name: Run unit Tests
         run: |


### PR DESCRIPTION
The Go version has been updated to '1.22' in the 'sonarqube.yml', 'golangci-lint.yml', and 'codecov.yml' GitHub action workflow files. This includes an additional modification for the Go versions matrix and condition statements in the 'codecov.yml' workflow.