### PR TITLE
Update SMTP authentication mechanisms and related tests

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -11,14 +11,19 @@ type SMTPAuthType string
 
 // Supported SMTP AUTH types
 const (
+	// SMTPAuthCramMD5 is the "CRAM-MD5" SASL authentication mechanism as described in RFC 4954
+	SMTPAuthCramMD5 SMTPAuthType = "CRAM-MD5"
+
 	// SMTPAuthLogin is the "LOGIN" SASL authentication mechanism
 	SMTPAuthLogin SMTPAuthType = "LOGIN"
 
+	// SMTPAuthNoAuth is equivalent to performing no authentication at all. It is a convenience
+	// option and should not be used. Instead, for mail servers that do no support/require
+	// authentication, the Client should not be used with the WithSMTPAuth option
+	SMTPAuthNoAuth SMTPAuthType = ""
+
 	// SMTPAuthPlain is the "PLAIN" authentication mechanism as described in RFC 4616
 	SMTPAuthPlain SMTPAuthType = "PLAIN"
-
-	// SMTPAuthCramMD5 is the "CRAM-MD5" SASL authentication mechanism as described in RFC 4954
-	SMTPAuthCramMD5 SMTPAuthType = "CRAM-MD5"
 
 	// SMTPAuthXOAUTH2 is the "XOAUTH2" SASL authentication mechanism.
 	// https://developers.google.com/gmail/imap/xoauth2-protocol

--- a/client_test.go
+++ b/client_test.go
@@ -97,6 +97,7 @@ func TestNewClientWithOptions(t *testing.T) {
 		{"WithTLSPortPolicy()", WithTLSPortPolicy(TLSOpportunistic), false},
 		{"WithTLSConfig()", WithTLSConfig(&tls.Config{}), false},
 		{"WithTLSConfig(); config is nil", WithTLSConfig(nil), true},
+		{"WithSMTPAuth(NoAuth)", WithSMTPAuth(SMTPAuthNoAuth), false},
 		{"WithSMTPAuth()", WithSMTPAuth(SMTPAuthLogin), false},
 		{
 			"WithSMTPAuthCustom()",
@@ -576,9 +577,9 @@ func TestSetSMTPAuthCustom(t *testing.T) {
 		want  string
 		sf    bool
 	}{
-		{"SMTPAuth: PLAIN", smtp.PlainAuth("", "", "", ""), "PLAIN", false},
 		{"SMTPAuth: CRAM-MD5", smtp.CRAMMD5Auth("", ""), "CRAM-MD5", false},
 		{"SMTPAuth: LOGIN", smtp.LoginAuth("", "", ""), "LOGIN", false},
+		{"SMTPAuth: PLAIN", smtp.PlainAuth("", "", "", ""), "PLAIN", false},
 	}
 	si := smtp.ServerInfo{TLS: true}
 	for _, tt := range tests {
@@ -1405,7 +1406,7 @@ func TestXOAuth2OK(t *testing.T) {
 	}
 	c, err := NewClient("fake.host",
 		WithDialContextFunc(getFakeDialFunc(fake)),
-		WithTLSPolicy(TLSOpportunistic),
+		WithTLSPortPolicy(TLSOpportunistic),
 		WithSMTPAuth(SMTPAuthXOAUTH2),
 		WithUsername("user"),
 		WithPassword("token"))
@@ -1444,7 +1445,7 @@ func TestXOAuth2Unsupported(t *testing.T) {
 	}
 	c, err := NewClient("fake.host",
 		WithDialContextFunc(getFakeDialFunc(fake)),
-		WithTLSPolicy(TLSOpportunistic),
+		WithTLSPortPolicy(TLSOpportunistic),
 		WithSMTPAuth(SMTPAuthXOAUTH2))
 	if err != nil {
 		t.Fatalf("unable to create new client: %v", err)


### PR DESCRIPTION
Introduced the SMTPAuthNoAuth mechanism in the auth.go file meant for instances where authentication is not required or supported. Adjusted tests in client_test.go to account for this new mechanism. Minor order modifications were also made to the list of supported SMTP AUTH types and respective tests for better consistency.

Closes #176