### PR TITLE
Refactor variable names for readability

### DIFF
--- a/b64linebreaker.go
+++ b/b64linebreaker.go
@@ -20,39 +20,39 @@ type Base64LineBreaker struct {
 	out  io.Writer
 }
 
-var nl = []byte(SingleNewLine)
+var newlineBytes = []byte(SingleNewLine)
 
 // Write writes the data stream and inserts a SingleNewLine when the maximum
 // line length is reached
-func (l *Base64LineBreaker) Write(b []byte) (n int, err error) {
+func (l *Base64LineBreaker) Write(data []byte) (numBytes int, err error) {
 	if l.out == nil {
 		err = fmt.Errorf(ErrNoOutWriter)
 		return
 	}
-	if l.used+len(b) < MaxBodyLength {
-		copy(l.line[l.used:], b)
-		l.used += len(b)
-		return len(b), nil
+	if l.used+len(data) < MaxBodyLength {
+		copy(l.line[l.used:], data)
+		l.used += len(data)
+		return len(data), nil
 	}
 
-	n, err = l.out.Write(l.line[0:l.used])
+	numBytes, err = l.out.Write(l.line[0:l.used])
 	if err != nil {
 		return
 	}
 	excess := MaxBodyLength - l.used
 	l.used = 0
 
-	n, err = l.out.Write(b[0:excess])
+	numBytes, err = l.out.Write(data[0:excess])
 	if err != nil {
 		return
 	}
 
-	n, err = l.out.Write(nl)
+	numBytes, err = l.out.Write(newlineBytes)
 	if err != nil {
 		return
 	}
 
-	return l.Write(b[excess:])
+	return l.Write(data[excess:])
 }
 
 // Close closes the Base64LineBreaker and writes any access data that is still
@@ -63,7 +63,7 @@ func (l *Base64LineBreaker) Close() (err error) {
 		if err != nil {
 			return
 		}
-		_, err = l.out.Write(nl)
+		_, err = l.out.Write(newlineBytes)
 	}
 
 	return

--- a/client.go
+++ b/client.go
@@ -87,11 +87,11 @@ type DialContextFunc func(ctx context.Context, network, address string) (net.Con
 
 // Client is the SMTP client struct
 type Client struct {
-	// co is the net.Conn that the smtp.Client is based on
-	co net.Conn
+	// connection is the net.Conn that the smtp.Client is based on
+	connection net.Conn
 
 	// Timeout for the SMTP server connection
-	cto time.Duration
+	connTimeout time.Duration
 
 	// dsn indicates that we want to use DSN for the Client
 	dsn bool
@@ -102,8 +102,8 @@ type Client struct {
 	// dsnrntype defines the DSNRcptNotifyOption in case DSN is enabled
 	dsnrntype []string
 
-	// enc indicates if a Client connection is encrypted or not
-	enc bool
+	// isEncrypted indicates if a Client connection is encrypted or not
+	isEncrypted bool
 
 	// noNoop indicates the Noop is to be skipped
 	noNoop bool
@@ -121,17 +121,17 @@ type Client struct {
 	port         int
 	fallbackPort int
 
-	// sa is a pointer to smtp.Auth
-	sa smtp.Auth
+	// smtpAuth is a pointer to smtp.Auth
+	smtpAuth smtp.Auth
 
-	// satype represents the authentication type for SMTP AUTH
-	satype SMTPAuthType
+	// smtpAuthType represents the authentication type for SMTP AUTH
+	smtpAuthType SMTPAuthType
 
-	// sc is the smtp.Client that is set up when using the Dial*() methods
-	sc *smtp.Client
+	// smtpClient is the smtp.Client that is set up when using the Dial*() methods
+	smtpClient *smtp.Client
 
 	// Use SSL for the connection
-	ssl bool
+	useSSL bool
 
 	// tlspolicy sets the client to use the provided TLSPolicy for the STARTTLS protocol
 	tlspolicy TLSPolicy
@@ -142,11 +142,11 @@ type Client struct {
 	// user is the SMTP AUTH username
 	user string
 
-	// dl enables the debug logging on the SMTP client
-	dl bool
+	// useDebugLog enables the debug logging on the SMTP client
+	useDebugLog bool
 
-	// l is a logger that implements the log.Logger interface
-	l log.Logger
+	// logger is a logger that implements the log.Logger interface
+	logger log.Logger
 
 	// dialContextFunc is a custom DialContext function to dial target SMTP server
 	dialContextFunc DialContextFunc
@@ -198,13 +198,13 @@ var (
 )
 
 // NewClient returns a new Session client object
-func NewClient(h string, o ...Option) (*Client, error) {
+func NewClient(host string, opts ...Option) (*Client, error) {
 	c := &Client{
-		cto:       DefaultTimeout,
-		host:      h,
-		port:      DefaultPort,
-		tlsconfig: &tls.Config{ServerName: h, MinVersion: DefaultTLSMinVersion},
-		tlspolicy: DefaultTLSPolicy,
+		connTimeout: DefaultTimeout,
+		host:        host,
+		port:        DefaultPort,
+		tlsconfig:   &tls.Config{ServerName: host, MinVersion: DefaultTLSMinVersion},
+		tlspolicy:   DefaultTLSPolicy,
 	}
 
 	// Set default HELO/EHLO hostname
@@ -213,11 +213,11 @@ func NewClient(h string, o ...Option) (*Client, error) {
 	}
 
 	// Override defaults with optionally provided Option functions
-	for _, co := range o {
-		if co == nil {
+	for _, opt := range opts {
+		if opt == nil {
 			continue
 		}
-		if err := co(c); err != nil {
+		if err := opt(c); err != nil {
 			return c, fmt.Errorf("failed to apply option: %w", err)
 		}
 	}
@@ -231,23 +231,23 @@ func NewClient(h string, o ...Option) (*Client, error) {
 }
 
 // WithPort overrides the default connection port
-func WithPort(p int) Option {
+func WithPort(port int) Option {
 	return func(c *Client) error {
-		if p < 1 || p > 65535 {
+		if port < 1 || port > 65535 {
 			return ErrInvalidPort
 		}
-		c.port = p
+		c.port = port
 		return nil
 	}
 }
 
 // WithTimeout overrides the default connection timeout
-func WithTimeout(t time.Duration) Option {
+func WithTimeout(timeout time.Duration) Option {
 	return func(c *Client) error {
-		if t <= 0 {
+		if timeout <= 0 {
 			return ErrInvalidTimeout
 		}
-		c.cto = t
+		c.connTimeout = timeout
 		return nil
 	}
 }
@@ -257,7 +257,7 @@ func WithTimeout(t time.Duration) Option {
 // Deprecated: use WithSSLPort instead.
 func WithSSL() Option {
 	return func(c *Client) error {
-		c.ssl = true
+		c.useSSL = true
 		return nil
 	}
 }
@@ -267,9 +267,9 @@ func WithSSL() Option {
 //
 // When the SSL connection fails and fallback is set to true,
 // the client will attempt to connect on port 25 using plaintext.
-func WithSSLPort(fb bool) Option {
+func WithSSLPort(fallback bool) Option {
 	return func(c *Client) error {
-		c.SetSSLPort(true, fb)
+		c.SetSSLPort(true, fallback)
 		return nil
 	}
 }
@@ -278,26 +278,26 @@ func WithSSLPort(fb bool) Option {
 // to StdErr
 func WithDebugLog() Option {
 	return func(c *Client) error {
-		c.dl = true
+		c.useDebugLog = true
 		return nil
 	}
 }
 
 // WithLogger overrides the default log.Logger that is used for debug logging
-func WithLogger(l log.Logger) Option {
+func WithLogger(logger log.Logger) Option {
 	return func(c *Client) error {
-		c.l = l
+		c.logger = logger
 		return nil
 	}
 }
 
 // WithHELO tells the client to use the provided string as HELO/EHLO greeting host
-func WithHELO(h string) Option {
+func WithHELO(helo string) Option {
 	return func(c *Client) error {
-		if h == "" {
+		if helo == "" {
 			return ErrInvalidHELO
 		}
-		c.helo = h
+		c.helo = helo
 		return nil
 	}
 }
@@ -305,9 +305,9 @@ func WithHELO(h string) Option {
 // WithTLSPolicy tells the client to use the provided TLSPolicy
 //
 // Deprecated: use WithTLSPortPolicy instead.
-func WithTLSPolicy(p TLSPolicy) Option {
+func WithTLSPolicy(policy TLSPolicy) Option {
 	return func(c *Client) error {
-		c.tlspolicy = p
+		c.tlspolicy = policy
 		return nil
 	}
 }
@@ -319,52 +319,52 @@ func WithTLSPolicy(p TLSPolicy) Option {
 // If the connection fails with TLSOpportunistic,
 // a plaintext connection is attempted on port 25 as a fallback.
 // NoTLS will allways use port 25.
-func WithTLSPortPolicy(p TLSPolicy) Option {
+func WithTLSPortPolicy(policy TLSPolicy) Option {
 	return func(c *Client) error {
-		c.SetTLSPortPolicy(p)
+		c.SetTLSPortPolicy(policy)
 		return nil
 	}
 }
 
 // WithTLSConfig tells the client to use the provided *tls.Config
-func WithTLSConfig(co *tls.Config) Option {
+func WithTLSConfig(tlsconfig *tls.Config) Option {
 	return func(c *Client) error {
-		if co == nil {
+		if tlsconfig == nil {
 			return ErrInvalidTLSConfig
 		}
-		c.tlsconfig = co
+		c.tlsconfig = tlsconfig
 		return nil
 	}
 }
 
 // WithSMTPAuth tells the client to use the provided SMTPAuthType for authentication
-func WithSMTPAuth(t SMTPAuthType) Option {
+func WithSMTPAuth(authtype SMTPAuthType) Option {
 	return func(c *Client) error {
-		c.satype = t
+		c.smtpAuthType = authtype
 		return nil
 	}
 }
 
 // WithSMTPAuthCustom tells the client to use the provided smtp.Auth for SMTP authentication
-func WithSMTPAuthCustom(a smtp.Auth) Option {
+func WithSMTPAuthCustom(smtpAuth smtp.Auth) Option {
 	return func(c *Client) error {
-		c.sa = a
+		c.smtpAuth = smtpAuth
 		return nil
 	}
 }
 
 // WithUsername tells the client to use the provided string as username for authentication
-func WithUsername(u string) Option {
+func WithUsername(username string) Option {
 	return func(c *Client) error {
-		c.user = u
+		c.user = username
 		return nil
 	}
 }
 
 // WithPassword tells the client to use the provided string as password/secret for authentication
-func WithPassword(p string) Option {
+func WithPassword(password string) Option {
 	return func(c *Client) error {
-		c.pass = p
+		c.pass = password
 		return nil
 	}
 }
@@ -386,9 +386,9 @@ func WithDSN() Option {
 // as described in the RFC 1891 and set the MAIL FROM Return option type to the
 // given DSNMailReturnOption
 // See: https://www.rfc-editor.org/rfc/rfc1891
-func WithDSNMailReturnType(mro DSNMailReturnOption) Option {
+func WithDSNMailReturnType(option DSNMailReturnOption) Option {
 	return func(c *Client) error {
-		switch mro {
+		switch option {
 		case DSNMailReturnHeadersOnly:
 		case DSNMailReturnFull:
 		default:
@@ -396,7 +396,7 @@ func WithDSNMailReturnType(mro DSNMailReturnOption) Option {
 		}
 
 		c.dsn = true
-		c.dsnmrtype = mro
+		c.dsnmrtype = option
 		return nil
 	}
 }
@@ -404,13 +404,13 @@ func WithDSNMailReturnType(mro DSNMailReturnOption) Option {
 // WithDSNRcptNotifyType enables the Client to request DSNs as described in the RFC 1891
 // and sets the RCPT TO notify options to the given list of DSNRcptNotifyOption
 // See: https://www.rfc-editor.org/rfc/rfc1891
-func WithDSNRcptNotifyType(rno ...DSNRcptNotifyOption) Option {
+func WithDSNRcptNotifyType(opts ...DSNRcptNotifyOption) Option {
 	return func(c *Client) error {
-		var rnol []string
+		var rcptOpts []string
 		var ns, nns bool
-		if len(rno) > 0 {
-			for _, crno := range rno {
-				switch crno {
+		if len(opts) > 0 {
+			for _, opt := range opts {
+				switch opt {
 				case DSNRcptNotifyNever:
 					ns = true
 				case DSNRcptNotifySuccess:
@@ -422,7 +422,7 @@ func WithDSNRcptNotifyType(rno ...DSNRcptNotifyOption) Option {
 				default:
 					return ErrInvalidDSNRcptNotifyOption
 				}
-				rnol = append(rnol, string(crno))
+				rcptOpts = append(rcptOpts, string(opt))
 			}
 		}
 		if ns && nns {
@@ -430,7 +430,7 @@ func WithDSNRcptNotifyType(rno ...DSNRcptNotifyOption) Option {
 		}
 
 		c.dsn = true
-		c.dsnrntype = rnol
+		c.dsnrntype = rcptOpts
 		return nil
 	}
 }
@@ -445,9 +445,9 @@ func WithoutNoop() Option {
 }
 
 // WithDialContextFunc overrides the default DialContext for connecting SMTP server
-func WithDialContextFunc(f DialContextFunc) Option {
+func WithDialContextFunc(dialCtxFunc DialContextFunc) Option {
 	return func(c *Client) error {
-		c.dialContextFunc = f
+		c.dialContextFunc = dialCtxFunc
 		return nil
 	}
 }
@@ -463,8 +463,8 @@ func (c *Client) ServerAddr() string {
 }
 
 // SetTLSPolicy overrides the current TLSPolicy with the given TLSPolicy value
-func (c *Client) SetTLSPolicy(p TLSPolicy) {
-	c.tlspolicy = p
+func (c *Client) SetTLSPolicy(policy TLSPolicy) {
+	c.tlspolicy = policy
 }
 
 // SetTLSPortPolicy overrides the current TLSPolicy with the given TLSPolicy
@@ -474,22 +474,22 @@ func (c *Client) SetTLSPolicy(p TLSPolicy) {
 // If the connection fails with TLSOpportunistic, a plaintext connection is
 // attempted on port 25 as a fallback.
 // NoTLS will allways use port 25.
-func (c *Client) SetTLSPortPolicy(p TLSPolicy) {
+func (c *Client) SetTLSPortPolicy(policy TLSPolicy) {
 	c.port = DefaultPortTLS
 
-	if p == TLSOpportunistic {
+	if policy == TLSOpportunistic {
 		c.fallbackPort = DefaultPort
 	}
-	if p == NoTLS {
+	if policy == NoTLS {
 		c.port = DefaultPort
 	}
 
-	c.tlspolicy = p
+	c.tlspolicy = policy
 }
 
 // SetSSL tells the Client wether to use SSL or not
-func (c *Client) SetSSL(s bool) {
-	c.ssl = s
+func (c *Client) SetSSL(ssl bool) {
+	c.useSSL = ssl
 }
 
 // SetSSLPort tells the Client wether or not to use SSL and fallback.
@@ -499,124 +499,124 @@ func (c *Client) SetSSL(s bool) {
 // Port 25 is used when SSL is unset (false).
 // When the SSL connection fails and fb is set to true,
 // the client will attempt to connect on port 25 using plaintext.
-func (c *Client) SetSSLPort(ssl bool, fb bool) {
+func (c *Client) SetSSLPort(ssl bool, fallback bool) {
 	c.port = DefaultPort
 	if ssl {
 		c.port = DefaultPortSSL
 	}
 
 	c.fallbackPort = 0
-	if fb {
+	if fallback {
 		c.fallbackPort = DefaultPort
 	}
 
-	c.ssl = ssl
+	c.useSSL = ssl
 }
 
 // SetDebugLog tells the Client whether debug logging is enabled or not
-func (c *Client) SetDebugLog(v bool) {
-	c.dl = v
-	if c.sc != nil {
-		c.sc.SetDebugLog(v)
+func (c *Client) SetDebugLog(val bool) {
+	c.useDebugLog = val
+	if c.smtpClient != nil {
+		c.smtpClient.SetDebugLog(val)
 	}
 }
 
 // SetLogger tells the Client which log.Logger to use
-func (c *Client) SetLogger(l log.Logger) {
-	c.l = l
-	if c.sc != nil {
-		c.sc.SetLogger(l)
+func (c *Client) SetLogger(logger log.Logger) {
+	c.logger = logger
+	if c.smtpClient != nil {
+		c.smtpClient.SetLogger(logger)
 	}
 }
 
 // SetTLSConfig overrides the current *tls.Config with the given *tls.Config value
-func (c *Client) SetTLSConfig(co *tls.Config) error {
-	if co == nil {
+func (c *Client) SetTLSConfig(tlsconfig *tls.Config) error {
+	if tlsconfig == nil {
 		return ErrInvalidTLSConfig
 	}
-	c.tlsconfig = co
+	c.tlsconfig = tlsconfig
 	return nil
 }
 
 // SetUsername overrides the current username string with the given value
-func (c *Client) SetUsername(u string) {
-	c.user = u
+func (c *Client) SetUsername(username string) {
+	c.user = username
 }
 
 // SetPassword overrides the current password string with the given value
-func (c *Client) SetPassword(p string) {
-	c.pass = p
+func (c *Client) SetPassword(password string) {
+	c.pass = password
 }
 
 // SetSMTPAuth overrides the current SMTP AUTH type setting with the given value
-func (c *Client) SetSMTPAuth(a SMTPAuthType) {
-	c.satype = a
+func (c *Client) SetSMTPAuth(authtype SMTPAuthType) {
+	c.smtpAuthType = authtype
 }
 
 // SetSMTPAuthCustom overrides the current SMTP AUTH setting with the given custom smtp.Auth
-func (c *Client) SetSMTPAuthCustom(sa smtp.Auth) {
-	c.sa = sa
+func (c *Client) SetSMTPAuthCustom(smtpAuth smtp.Auth) {
+	c.smtpAuth = smtpAuth
 }
 
 // setDefaultHelo retrieves the current hostname and sets it as HELO/EHLO hostname
 func (c *Client) setDefaultHelo() error {
-	hn, err := os.Hostname()
+	hostname, err := os.Hostname()
 	if err != nil {
-		return fmt.Errorf("failed cto read local hostname: %w", err)
+		return fmt.Errorf("failed to read local hostname: %w", err)
 	}
-	c.helo = hn
+	c.helo = hostname
 	return nil
 }
 
-// DialWithContext establishes a connection cto the SMTP server with a given context.Context
-func (c *Client) DialWithContext(pc context.Context) error {
-	ctx, cfn := context.WithDeadline(pc, time.Now().Add(c.cto))
-	defer cfn()
+// DialWithContext establishes a connection to the SMTP server with a given context.Context
+func (c *Client) DialWithContext(dialCtx context.Context) error {
+	ctx, cancel := context.WithDeadline(dialCtx, time.Now().Add(c.connTimeout))
+	defer cancel()
 
 	if c.dialContextFunc == nil {
-		nd := net.Dialer{}
-		c.dialContextFunc = nd.DialContext
+		netDialer := net.Dialer{}
+		c.dialContextFunc = netDialer.DialContext
 
-		if c.ssl {
-			td := tls.Dialer{NetDialer: &nd, Config: c.tlsconfig}
-			c.enc = true
-			c.dialContextFunc = td.DialContext
+		if c.useSSL {
+			tlsDialer := tls.Dialer{NetDialer: &netDialer, Config: c.tlsconfig}
+			c.isEncrypted = true
+			c.dialContextFunc = tlsDialer.DialContext
 		}
 	}
 	var err error
-	c.co, err = c.dialContextFunc(ctx, "tcp", c.ServerAddr())
+	c.connection, err = c.dialContextFunc(ctx, "tcp", c.ServerAddr())
 	if err != nil && c.fallbackPort != 0 {
 		// TODO: should we somehow log or append the previous error?
-		c.co, err = c.dialContextFunc(ctx, "tcp", c.serverFallbackAddr())
+		c.connection, err = c.dialContextFunc(ctx, "tcp", c.serverFallbackAddr())
 	}
 	if err != nil {
 		return err
 	}
 
-	sc, err := smtp.NewClient(c.co, c.host)
+	client, err := smtp.NewClient(c.connection, c.host)
 	if err != nil {
 		return err
 	}
-	if sc == nil {
+	if client == nil {
 		return fmt.Errorf("SMTP client is nil")
 	}
-	c.sc = sc
+	c.smtpClient = client
 
-	if c.l != nil {
-		c.sc.SetLogger(c.l)
+	if c.logger != nil {
+		c.smtpClient.SetLogger(c.logger)
 	}
-	if c.dl {
-		c.sc.SetDebugLog(true)
+	if c.useDebugLog {
+		c.smtpClient.SetDebugLog(true)
 	}
-	if err := c.sc.Hello(c.helo); err != nil {
+	if err = c.smtpClient.Hello(c.helo); err != nil {
 		return err
 	}
 
-	if err := c.tls(); err != nil {
+	if err = c.tls(); err != nil {
 		return err
 	}
 
-	if err := c.auth(); err != nil {
+	if err = c.auth(); err != nil {
 		return err
 	}
 
@@ -628,7 +628,7 @@ func (c *Client) Close() error {
 	if err := c.checkConn(); err != nil {
 		return err
 	}
-	if err := c.sc.Quit(); err != nil {
+	if err := c.smtpClient.Quit(); err != nil {
 		return fmt.Errorf("failed to close SMTP client: %w", err)
 	}
 
@@ -640,7 +640,7 @@ func (c *Client) Reset() error {
 	if err := c.checkConn(); err != nil {
 		return err
 	}
-	if err := c.sc.Reset(); err != nil {
+	if err := c.smtpClient.Reset(); err != nil {
 		return fmt.Errorf("failed to send RSET to SMTP client: %w", err)
 	}
 
@@ -672,17 +672,17 @@ func (c *Client) DialAndSendWithContext(ctx context.Context, ml ...*Msg) error {
 // checkConn makes sure that a required server connection is available and extends the
 // connection deadline
 func (c *Client) checkConn() error {
-	if c.co == nil {
+	if c.connection == nil {
 		return ErrNoActiveConnection
 	}
 
 	if !c.noNoop {
-		if err := c.sc.Noop(); err != nil {
+		if err := c.smtpClient.Noop(); err != nil {
 			return ErrNoActiveConnection
 		}
 	}
 
-	if err := c.co.SetDeadline(time.Now().Add(c.cto)); err != nil {
+	if err := c.connection.SetDeadline(time.Now().Add(c.connTimeout)); err != nil {
 		return ErrDeadlineExtendFailed
 	}
 	return nil
@@ -696,12 +696,12 @@ func (c *Client) serverFallbackAddr() string {
 
 // tls tries to make sure that the STARTTLS requirements are satisfied
 func (c *Client) tls() error {
-	if c.co == nil {
+	if c.connection == nil {
 		return ErrNoActiveConnection
 	}
-	if !c.ssl && c.tlspolicy != NoTLS {
+	if !c.useSSL && c.tlspolicy != NoTLS {
 		est := false
-		st, _ := c.sc.Extension("STARTTLS")
+		st, _ := c.smtpClient.Extension("STARTTLS")
 		if c.tlspolicy == TLSMandatory {
 			est = true
 			if !st {
@@ -715,11 +715,11 @@ func (c *Client) tls() error {
 			}
 		}
 		if est {
-			if err := c.sc.StartTLS(c.tlsconfig); err != nil {
+			if err := c.smtpClient.StartTLS(c.tlsconfig); err != nil {
 				return err
 			}
 		}
-		_, c.enc = c.sc.TLSConnectionState()
+		_, c.isEncrypted = c.smtpClient.TLSConnectionState()
 	}
 	return nil
 }
@@ -729,40 +729,40 @@ func (c *Client) auth() error {
 	if err := c.checkConn(); err != nil {
 		return fmt.Errorf("failed to authenticate: %w", err)
 	}
-	if c.sa == nil && c.satype != "" {
-		sa, sat := c.sc.Extension("AUTH")
+	if c.smtpAuth == nil && c.smtpAuthType != "" {
+		sa, sat := c.smtpClient.Extension("AUTH")
 		if !sa {
 			return fmt.Errorf("server does not support SMTP AUTH")
 		}
 
-		switch c.satype {
+		switch c.smtpAuthType {
 		case SMTPAuthPlain:
 			if !strings.Contains(sat, string(SMTPAuthPlain)) {
 				return ErrPlainAuthNotSupported
 			}
-			c.sa = smtp.PlainAuth("", c.user, c.pass, c.host)
+			c.smtpAuth = smtp.PlainAuth("", c.user, c.pass, c.host)
 		case SMTPAuthLogin:
 			if !strings.Contains(sat, string(SMTPAuthLogin)) {
 				return ErrLoginAuthNotSupported
 			}
-			c.sa = smtp.LoginAuth(c.user, c.pass, c.host)
+			c.smtpAuth = smtp.LoginAuth(c.user, c.pass, c.host)
 		case SMTPAuthCramMD5:
 			if !strings.Contains(sat, string(SMTPAuthCramMD5)) {
 				return ErrCramMD5AuthNotSupported
 			}
-			c.sa = smtp.CRAMMD5Auth(c.user, c.pass)
+			c.smtpAuth = smtp.CRAMMD5Auth(c.user, c.pass)
 		case SMTPAuthXOAUTH2:
 			if !strings.Contains(sat, string(SMTPAuthXOAUTH2)) {
 				return ErrXOauth2AuthNotSupported
 			}
-			c.sa = smtp.XOAuth2Auth(c.user, c.pass)
+			c.smtpAuth = smtp.XOAuth2Auth(c.user, c.pass)
 		default:
-			return fmt.Errorf("unsupported SMTP AUTH type %q", c.satype)
+			return fmt.Errorf("unsupported SMTP AUTH type %q", c.smtpAuthType)
 		}
 	}
 
-	if c.sa != nil {
-		if err := c.sc.Auth(c.sa); err != nil {
+	if c.smtpAuth != nil {
+		if err := c.smtpClient.Auth(c.smtpAuth); err != nil {
 			return fmt.Errorf("SMTP AUTH failed: %w", err)
 		}
 	}

--- a/client_119.go
+++ b/client_119.go
@@ -10,33 +10,33 @@ package mail
 import "strings"
 
 // Send sends out the mail message
-func (c *Client) Send(ml ...*Msg) error {
+func (c *Client) Send(messages ...*Msg) error {
 	if cerr := c.checkConn(); cerr != nil {
 		return &SendError{Reason: ErrConnCheck, errlist: []error{cerr}, isTemp: isTempError(cerr)}
 	}
 	var errs []*SendError
-	for _, m := range ml {
-		m.sendError = nil
-		if m.encoding == NoEncoding {
+	for _, message := range messages {
+		message.sendError = nil
+		if message.encoding == NoEncoding {
 			if ok, _ := c.smtpClient.Extension("8BITMIME"); !ok {
-				se := &SendError{Reason: ErrNoUnencoded, isTemp: false}
-				m.sendError = se
-				errs = append(errs, se)
+				sendErr := &SendError{Reason: ErrNoUnencoded, isTemp: false}
+				message.sendError = sendErr
+				errs = append(errs, sendErr)
 				continue
 			}
 		}
-		f, err := m.GetSender(false)
+		from, err := message.GetSender(false)
 		if err != nil {
-			se := &SendError{Reason: ErrGetSender, errlist: []error{err}, isTemp: isTempError(err)}
-			m.sendError = se
-			errs = append(errs, se)
+			sendErr := &SendError{Reason: ErrGetSender, errlist: []error{err}, isTemp: isTempError(err)}
+			message.sendError = sendErr
+			errs = append(errs, sendErr)
 			continue
 		}
-		rl, err := m.GetRecipients()
+		rcpts, err := message.GetRecipients()
 		if err != nil {
-			se := &SendError{Reason: ErrGetRcpts, errlist: []error{err}, isTemp: isTempError(err)}
-			m.sendError = se
-			errs = append(errs, se)
+			sendErr := &SendError{Reason: ErrGetRcpts, errlist: []error{err}, isTemp: isTempError(err)}
+			message.sendError = sendErr
+			errs = append(errs, sendErr)
 			continue
 		}
 
@@ -45,88 +45,88 @@ func (c *Client) Send(ml ...*Msg) error {
 				c.smtpClient.SetDSNMailReturnOption(string(c.dsnmrtype))
 			}
 		}
-		if err := c.smtpClient.Mail(f); err != nil {
-			se := &SendError{Reason: ErrSMTPMailFrom, errlist: []error{err}, isTemp: isTempError(err)}
-			if reserr := c.smtpClient.Reset(); reserr != nil {
-				se.errlist = append(se.errlist, reserr)
+		if err = c.smtpClient.Mail(from); err != nil {
+			sendErr := &SendError{Reason: ErrSMTPMailFrom, errlist: []error{err}, isTemp: isTempError(err)}
+			if resetSendErr := c.smtpClient.Reset(); resetSendErr != nil {
+				sendErr.errlist = append(sendErr.errlist, resetSendErr)
 			}
-			m.sendError = se
-			errs = append(errs, se)
+			message.sendError = sendErr
+			errs = append(errs, sendErr)
 			continue
 		}
 		failed := false
-		rse := &SendError{}
-		rse.errlist = make([]error, 0)
-		rse.rcpt = make([]string, 0)
-		rno := strings.Join(c.dsnrntype, ",")
-		c.smtpClient.SetDSNRcptNotifyOption(rno)
-		for _, r := range rl {
-			if err := c.smtpClient.Rcpt(r); err != nil {
-				rse.Reason = ErrSMTPRcptTo
-				rse.errlist = append(rse.errlist, err)
-				rse.rcpt = append(rse.rcpt, r)
-				rse.isTemp = isTempError(err)
+		rcptSendErr := &SendError{}
+		rcptSendErr.errlist = make([]error, 0)
+		rcptSendErr.rcpt = make([]string, 0)
+		rcptNotifyOpt := strings.Join(c.dsnrntype, ",")
+		c.smtpClient.SetDSNRcptNotifyOption(rcptNotifyOpt)
+		for _, rcpt := range rcpts {
+			if err = c.smtpClient.Rcpt(rcpt); err != nil {
+				rcptSendErr.Reason = ErrSMTPRcptTo
+				rcptSendErr.errlist = append(rcptSendErr.errlist, err)
+				rcptSendErr.rcpt = append(rcptSendErr.rcpt, rcpt)
+				rcptSendErr.isTemp = isTempError(err)
 				failed = true
 			}
 		}
 		if failed {
-			if reserr := c.smtpClient.Reset(); reserr != nil {
-				rse.errlist = append(rse.errlist, err)
+			if resetSendErr := c.smtpClient.Reset(); resetSendErr != nil {
+				rcptSendErr.errlist = append(rcptSendErr.errlist, err)
 			}
-			m.sendError = rse
-			errs = append(errs, rse)
+			message.sendError = rcptSendErr
+			errs = append(errs, rcptSendErr)
 			continue
 		}
-		w, err := c.smtpClient.Data()
+		writer, err := c.smtpClient.Data()
 		if err != nil {
-			se := &SendError{Reason: ErrSMTPData, errlist: []error{err}, isTemp: isTempError(err)}
-			m.sendError = se
-			errs = append(errs, se)
+			sendErr := &SendError{Reason: ErrSMTPData, errlist: []error{err}, isTemp: isTempError(err)}
+			message.sendError = sendErr
+			errs = append(errs, sendErr)
 			continue
 		}
-		_, err = m.WriteTo(w)
+		_, err = message.WriteTo(writer)
 		if err != nil {
-			se := &SendError{Reason: ErrWriteContent, errlist: []error{err}, isTemp: isTempError(err)}
-			m.sendError = se
-			errs = append(errs, se)
+			sendErr := &SendError{Reason: ErrWriteContent, errlist: []error{err}, isTemp: isTempError(err)}
+			message.sendError = sendErr
+			errs = append(errs, sendErr)
 			continue
 		}
-		m.isDelivered = true
+		message.isDelivered = true
 
-		if err := w.Close(); err != nil {
-			se := &SendError{Reason: ErrSMTPDataClose, errlist: []error{err}, isTemp: isTempError(err)}
-			m.sendError = se
-			errs = append(errs, se)
+		if err = writer.Close(); err != nil {
+			sendErr := &SendError{Reason: ErrSMTPDataClose, errlist: []error{err}, isTemp: isTempError(err)}
+			message.sendError = sendErr
+			errs = append(errs, sendErr)
 			continue
 		}
 
-		if err := c.Reset(); err != nil {
-			se := &SendError{Reason: ErrSMTPReset, errlist: []error{err}, isTemp: isTempError(err)}
-			m.sendError = se
-			errs = append(errs, se)
+		if err = c.Reset(); err != nil {
+			sendErr := &SendError{Reason: ErrSMTPReset, errlist: []error{err}, isTemp: isTempError(err)}
+			message.sendError = sendErr
+			errs = append(errs, sendErr)
 			continue
 		}
-		if err := c.checkConn(); err != nil {
-			se := &SendError{Reason: ErrConnCheck, errlist: []error{err}, isTemp: isTempError(err)}
-			m.sendError = se
-			errs = append(errs, se)
+		if err = c.checkConn(); err != nil {
+			sendErr := &SendError{Reason: ErrConnCheck, errlist: []error{err}, isTemp: isTempError(err)}
+			message.sendError = sendErr
+			errs = append(errs, sendErr)
 			continue
 		}
 	}
 
 	if len(errs) > 0 {
 		if len(errs) > 1 {
-			re := &SendError{Reason: ErrAmbiguous}
+			returnErr := &SendError{Reason: ErrAmbiguous}
 			for i := range errs {
-				re.errlist = append(re.errlist, errs[i].errlist...)
-				re.rcpt = append(re.rcpt, errs[i].rcpt...)
+				returnErr.errlist = append(returnErr.errlist, errs[i].errlist...)
+				returnErr.rcpt = append(returnErr.rcpt, errs[i].rcpt...)
 			}
 
 			// We assume that the isTemp flag from the last error we received should be the
 			// indicator for the returned isTemp flag as well
-			re.isTemp = errs[len(errs)-1].isTemp
+			returnErr.isTemp = errs[len(errs)-1].isTemp
 
-			return re
+			return returnErr
 		}
 		return errs[0]
 	}

--- a/file.go
+++ b/file.go
@@ -23,17 +23,17 @@ type File struct {
 }
 
 // WithFileName sets the filename of the File
-func WithFileName(n string) FileOption {
+func WithFileName(name string) FileOption {
 	return func(f *File) {
-		f.Name = n
+		f.Name = name
 	}
 }
 
 // WithFileDescription sets an optional file description of the File that will be
 // added as Content-Description part
-func WithFileDescription(d string) FileOption {
+func WithFileDescription(description string) FileOption {
 	return func(f *File) {
-		f.Desc = d
+		f.Desc = description
 	}
 }
 
@@ -41,12 +41,12 @@ func WithFileDescription(d string) FileOption {
 // Base64 encoding but there might be exceptions, where this might come handy.
 // Please note that quoted-printable should never be used for attachments/embeds. If this
 // is provided as argument, the function will automatically override back to Base64
-func WithFileEncoding(e Encoding) FileOption {
+func WithFileEncoding(encoding Encoding) FileOption {
 	return func(f *File) {
-		if e == EncodingQP {
+		if encoding == EncodingQP {
 			return
 		}
-		f.Enc = e
+		f.Enc = encoding
 	}
 }
 
@@ -56,19 +56,19 @@ func WithFileEncoding(e Encoding) FileOption {
 // could not be guessed. In some cases, however, it might be needed to force
 // this to a specific type. For such situations this override method can
 // be used
-func WithFileContentType(t ContentType) FileOption {
+func WithFileContentType(contentType ContentType) FileOption {
 	return func(f *File) {
-		f.ContentType = t
+		f.ContentType = contentType
 	}
 }
 
 // setHeader sets header fields to a File
-func (f *File) setHeader(h Header, v string) {
-	f.Header.Set(string(h), v)
+func (f *File) setHeader(header Header, value string) {
+	f.Header.Set(string(header), value)
 }
 
 // getHeader return header fields of a File
-func (f *File) getHeader(h Header) (string, bool) {
-	v := f.Header.Get(string(h))
+func (f *File) getHeader(header Header) (string, bool) {
+	v := f.Header.Get(string(header))
 	return v, v != ""
 }

--- a/log/jsonlog.go
+++ b/log/jsonlog.go
@@ -15,68 +15,68 @@ import (
 
 // JSONlog is the default structured JSON logger that satisfies the Logger interface
 type JSONlog struct {
-	l   Level
-	log *slog.Logger
+	level Level
+	log   *slog.Logger
 }
 
 // NewJSON returns a new JSONlog type that satisfies the Logger interface
-func NewJSON(o io.Writer, l Level) *JSONlog {
-	lo := slog.HandlerOptions{}
-	switch l {
+func NewJSON(output io.Writer, level Level) *JSONlog {
+	logOpts := slog.HandlerOptions{}
+	switch level {
 	case LevelDebug:
-		lo.Level = slog.LevelDebug
+		logOpts.Level = slog.LevelDebug
 	case LevelInfo:
-		lo.Level = slog.LevelInfo
+		logOpts.Level = slog.LevelInfo
 	case LevelWarn:
-		lo.Level = slog.LevelWarn
+		logOpts.Level = slog.LevelWarn
 	case LevelError:
-		lo.Level = slog.LevelError
+		logOpts.Level = slog.LevelError
 	default:
-		lo.Level = slog.LevelDebug
+		logOpts.Level = slog.LevelDebug
 	}
-	lh := slog.NewJSONHandler(o, &lo)
+	logHandler := slog.NewJSONHandler(output, &logOpts)
 	return &JSONlog{
-		l:   l,
-		log: slog.New(lh),
+		level: level,
+		log:   slog.New(logHandler),
 	}
 }
 
 // Debugf logs a debug message via the structured JSON logger
-func (l *JSONlog) Debugf(lo Log) {
-	if l.l >= LevelDebug {
+func (l *JSONlog) Debugf(log Log) {
+	if l.level >= LevelDebug {
 		l.log.WithGroup(DirString).With(
-			slog.String(DirFromString, lo.directionFrom()),
-			slog.String(DirToString, lo.directionTo()),
-		).Debug(fmt.Sprintf(lo.Format, lo.Messages...))
+			slog.String(DirFromString, log.directionFrom()),
+			slog.String(DirToString, log.directionTo()),
+		).Debug(fmt.Sprintf(log.Format, log.Messages...))
 	}
 }
 
 // Infof logs a info message via the structured JSON logger
-func (l *JSONlog) Infof(lo Log) {
-	if l.l >= LevelInfo {
+func (l *JSONlog) Infof(log Log) {
+	if l.level >= LevelInfo {
 		l.log.WithGroup(DirString).With(
-			slog.String(DirFromString, lo.directionFrom()),
-			slog.String(DirToString, lo.directionTo()),
-		).Info(fmt.Sprintf(lo.Format, lo.Messages...))
+			slog.String(DirFromString, log.directionFrom()),
+			slog.String(DirToString, log.directionTo()),
+		).Info(fmt.Sprintf(log.Format, log.Messages...))
 	}
 }
 
 // Warnf logs a warn message via the structured JSON logger
-func (l *JSONlog) Warnf(lo Log) {
-	if l.l >= LevelWarn {
+func (l *JSONlog) Warnf(log Log) {
+	if l.level >= LevelWarn {
 		l.log.WithGroup(DirString).With(
-			slog.String(DirFromString, lo.directionFrom()),
-			slog.String(DirToString, lo.directionTo()),
-		).Warn(fmt.Sprintf(lo.Format, lo.Messages...))
+			slog.String(DirFromString, log.directionFrom()),
+			slog.String(DirToString, log.directionTo()),
+		).Warn(fmt.Sprintf(log.Format, log.Messages...))
 	}
 }
 
 // Errorf logs a warn message via the structured JSON logger
-func (l *JSONlog) Errorf(lo Log) {
-	if l.l >= LevelError {
+func (l *JSONlog) Errorf(log Log) {
+	if l.level >= LevelError {
 		l.log.WithGroup(DirString).With(
-			slog.String(DirFromString, lo.directionFrom()),
-			slog.String(DirToString, lo.directionTo()),
-		).Error(fmt.Sprintf(lo.Format, lo.Messages...))
+			slog.String(DirFromString, log.directionFrom()),
+			slog.String(DirToString, log.directionTo()),
+		).Error(fmt.Sprintf(log.Format, log.Messages...))
 	}
 }

--- a/log/jsonlog_test.go
+++ b/log/jsonlog_test.go
@@ -30,8 +30,8 @@ type jsonDir struct {
 func TestNewJSON(t *testing.T) {
 	var b bytes.Buffer
 	l := NewJSON(&b, LevelDebug)
-	if l.l != LevelDebug {
-		t.Error("Expected level to be LevelDebug, got ", l.l)
+	if l.level != LevelDebug {
+		t.Error("Expected level to be LevelDebug, got ", l.level)
 	}
 	if l.log == nil {
 		t.Error("logger not initialized")
@@ -81,7 +81,7 @@ func TestJSONDebugf(t *testing.T) {
 	}
 
 	b.Reset()
-	l.l = LevelInfo
+	l.level = LevelInfo
 	l.Debugf(Log{Direction: DirServerToClient, Format: "test %s", Messages: []interface{}{"foo"}})
 	if b.String() != "" {
 		t.Error("Debug message was not expected to be logged")
@@ -131,7 +131,7 @@ func TestJSONDebugf_WithDefault(t *testing.T) {
 	}
 
 	b.Reset()
-	l.l = LevelInfo
+	l.level = LevelInfo
 	l.Debugf(Log{Direction: DirServerToClient, Format: "test %s", Messages: []interface{}{"foo"}})
 	if b.String() != "" {
 		t.Error("Debug message was not expected to be logged")
@@ -181,7 +181,7 @@ func TestJSONInfof(t *testing.T) {
 	}
 
 	b.Reset()
-	l.l = LevelWarn
+	l.level = LevelWarn
 	l.Infof(Log{Direction: DirServerToClient, Format: "test %s", Messages: []interface{}{"foo"}})
 	if b.String() != "" {
 		t.Error("Info message was not expected to be logged")
@@ -231,7 +231,7 @@ func TestJSONWarnf(t *testing.T) {
 	}
 
 	b.Reset()
-	l.l = LevelError
+	l.level = LevelError
 	l.Warnf(Log{Direction: DirServerToClient, Format: "test %s", Messages: []interface{}{"foo"}})
 	if b.String() != "" {
 		t.Error("Warn message was not expected to be logged")
@@ -281,7 +281,7 @@ func TestJSONErrorf(t *testing.T) {
 	}
 
 	b.Reset()
-	l.l = -99
+	l.level = -99
 	l.Errorf(Log{Direction: DirServerToClient, Format: "test %s", Messages: []interface{}{"foo"}})
 	if b.String() != "" {
 		t.Error("Error message was not expected to be logged")

--- a/log/stdlog.go
+++ b/log/stdlog.go
@@ -12,7 +12,7 @@ import (
 
 // Stdlog is the default logger that satisfies the Logger interface
 type Stdlog struct {
-	l     Level
+	level Level
 	err   *log.Logger
 	warn  *log.Logger
 	info  *log.Logger
@@ -24,45 +24,45 @@ type Stdlog struct {
 const CallDepth = 2
 
 // New returns a new Stdlog type that satisfies the Logger interface
-func New(o io.Writer, l Level) *Stdlog {
+func New(output io.Writer, level Level) *Stdlog {
 	lf := log.Lmsgprefix | log.LstdFlags
 	return &Stdlog{
-		l:     l,
-		err:   log.New(o, "ERROR: ", lf),
-		warn:  log.New(o, " WARN: ", lf),
-		info:  log.New(o, " INFO: ", lf),
-		debug: log.New(o, "DEBUG: ", lf),
+		level: level,
+		err:   log.New(output, "ERROR: ", lf),
+		warn:  log.New(output, " WARN: ", lf),
+		info:  log.New(output, " INFO: ", lf),
+		debug: log.New(output, "DEBUG: ", lf),
 	}
 }
 
 // Debugf performs a Printf() on the debug logger
-func (l *Stdlog) Debugf(lo Log) {
-	if l.l >= LevelDebug {
-		f := fmt.Sprintf("%s %s", lo.directionPrefix(), lo.Format)
-		_ = l.debug.Output(CallDepth, fmt.Sprintf(f, lo.Messages...))
+func (l *Stdlog) Debugf(log Log) {
+	if l.level >= LevelDebug {
+		format := fmt.Sprintf("%s %s", log.directionPrefix(), log.Format)
+		_ = l.debug.Output(CallDepth, fmt.Sprintf(format, log.Messages...))
 	}
 }
 
 // Infof performs a Printf() on the info logger
-func (l *Stdlog) Infof(lo Log) {
-	if l.l >= LevelInfo {
-		f := fmt.Sprintf("%s %s", lo.directionPrefix(), lo.Format)
-		_ = l.info.Output(CallDepth, fmt.Sprintf(f, lo.Messages...))
+func (l *Stdlog) Infof(log Log) {
+	if l.level >= LevelInfo {
+		format := fmt.Sprintf("%s %s", log.directionPrefix(), log.Format)
+		_ = l.info.Output(CallDepth, fmt.Sprintf(format, log.Messages...))
 	}
 }
 
 // Warnf performs a Printf() on the warn logger
-func (l *Stdlog) Warnf(lo Log) {
-	if l.l >= LevelWarn {
-		f := fmt.Sprintf("%s %s", lo.directionPrefix(), lo.Format)
-		_ = l.warn.Output(CallDepth, fmt.Sprintf(f, lo.Messages...))
+func (l *Stdlog) Warnf(log Log) {
+	if l.level >= LevelWarn {
+		format := fmt.Sprintf("%s %s", log.directionPrefix(), log.Format)
+		_ = l.warn.Output(CallDepth, fmt.Sprintf(format, log.Messages...))
 	}
 }
 
 // Errorf performs a Printf() on the error logger
-func (l *Stdlog) Errorf(lo Log) {
-	if l.l >= LevelError {
-		f := fmt.Sprintf("%s %s", lo.directionPrefix(), lo.Format)
-		_ = l.err.Output(CallDepth, fmt.Sprintf(f, lo.Messages...))
+func (l *Stdlog) Errorf(log Log) {
+	if l.level >= LevelError {
+		format := fmt.Sprintf("%s %s", log.directionPrefix(), log.Format)
+		_ = l.err.Output(CallDepth, fmt.Sprintf(format, log.Messages...))
 	}
 }

--- a/log/stdlog_test.go
+++ b/log/stdlog_test.go
@@ -13,8 +13,8 @@ import (
 func TestNew(t *testing.T) {
 	var b bytes.Buffer
 	l := New(&b, LevelDebug)
-	if l.l != LevelDebug {
-		t.Error("Expected level to be LevelDebug, got ", l.l)
+	if l.level != LevelDebug {
+		t.Error("Expected level to be LevelDebug, got ", l.level)
 	}
 	if l.err == nil || l.warn == nil || l.info == nil || l.debug == nil {
 		t.Error("Loggers not initialized")
@@ -37,7 +37,7 @@ func TestDebugf(t *testing.T) {
 	}
 
 	b.Reset()
-	l.l = LevelInfo
+	l.level = LevelInfo
 	l.Debugf(Log{Direction: DirServerToClient, Format: "test %s", Messages: []interface{}{"foo"}})
 	if b.String() != "" {
 		t.Error("Debug message was not expected to be logged")
@@ -60,7 +60,7 @@ func TestInfof(t *testing.T) {
 	}
 
 	b.Reset()
-	l.l = LevelWarn
+	l.level = LevelWarn
 	l.Infof(Log{Direction: DirServerToClient, Format: "test %s", Messages: []interface{}{"foo"}})
 	if b.String() != "" {
 		t.Error("Info message was not expected to be logged")
@@ -83,7 +83,7 @@ func TestWarnf(t *testing.T) {
 	}
 
 	b.Reset()
-	l.l = LevelError
+	l.level = LevelError
 	l.Warnf(Log{Direction: DirServerToClient, Format: "test %s", Messages: []interface{}{"foo"}})
 	if b.String() != "" {
 		t.Error("Warn message was not expected to be logged")
@@ -106,7 +106,7 @@ func TestErrorf(t *testing.T) {
 	}
 
 	b.Reset()
-	l.l = LevelError - 1
+	l.level = LevelError - 1
 	l.Errorf(Log{Direction: DirServerToClient, Format: "test %s", Messages: []interface{}{"foo"}})
 	if b.String() != "" {
 		t.Error("Error message was not expected to be logged")

--- a/msg.go
+++ b/msg.go
@@ -1087,7 +1087,7 @@ func (m *Msg) NewReader() *Reader {
 	if err != nil {
 		reader.err = fmt.Errorf("failed to write Msg to Reader buffer: %w", err)
 	}
-	reader.buf = buffer.Bytes()
+	reader.buffer = buffer.Bytes()
 	return reader
 }
 
@@ -1097,7 +1097,7 @@ func (m *Msg) UpdateReader(reader *Reader) {
 	buffer := bytes.Buffer{}
 	_, err := m.Write(&buffer)
 	reader.Reset()
-	reader.buf = buffer.Bytes()
+	reader.buffer = buffer.Bytes()
 	reader.err = err
 }
 

--- a/msg.go
+++ b/msg.go
@@ -723,7 +723,7 @@ func (m *Msg) SetBodyWriter(
 	opts ...PartOption,
 ) {
 	p := m.newPart(contentType, opts...)
-	p.w = writeFunc
+	p.writeFunc = writeFunc
 	m.parts = []*Part{p}
 }
 
@@ -770,7 +770,7 @@ func (m *Msg) AddAlternativeWriter(
 	opts ...PartOption,
 ) {
 	part := m.newPart(contentType, opts...)
-	part.w = writeFunc
+	part.writeFunc = writeFunc
 	m.parts = append(m.parts, part)
 }
 
@@ -1142,7 +1142,7 @@ func (m *Msg) encodeString(str string) string {
 func (m *Msg) hasAlt() bool {
 	count := 0
 	for _, part := range m.parts {
-		if !part.del {
+		if !part.isDeleted {
 			count++
 		}
 	}
@@ -1167,9 +1167,9 @@ func (m *Msg) hasPGPType() bool {
 // newPart returns a new Part for the Msg
 func (m *Msg) newPart(contentType ContentType, opts ...PartOption) *Part {
 	p := &Part{
-		ctype: contentType,
-		cset:  m.charset,
-		enc:   m.encoding,
+		contentType: contentType,
+		charset:     m.charset,
+		encoding:    m.encoding,
 	}
 
 	// Override defaults with optionally provided MsgOption functions

--- a/msg.go
+++ b/msg.go
@@ -933,9 +933,9 @@ func (m *Msg) applyMiddlewares(ms *Msg) *Msg {
 
 // WriteTo writes the formated Msg into a give io.Writer and satisfies the io.WriteTo interface
 func (m *Msg) WriteTo(w io.Writer) (int64, error) {
-	mw := &msgWriter{w: w, c: m.charset, en: m.encoder}
+	mw := &msgWriter{writer: w, charset: m.charset, encoder: m.encoder}
 	mw.writeMsg(m.applyMiddlewares(m))
-	return mw.n, mw.err
+	return mw.bytesWritten, mw.err
 }
 
 // WriteToSkipMiddleware writes the formated Msg into a give io.Writer and satisfies
@@ -950,10 +950,10 @@ func (m *Msg) WriteToSkipMiddleware(w io.Writer, mt MiddlewareType) (int64, erro
 		mwl = append(mwl, m.middlewares[i])
 	}
 	m.middlewares = mwl
-	mw := &msgWriter{w: w, c: m.charset, en: m.encoder}
+	mw := &msgWriter{writer: w, charset: m.charset, encoder: m.encoder}
 	mw.writeMsg(m.applyMiddlewares(m))
 	m.middlewares = omwl
-	return mw.n, mw.err
+	return mw.bytesWritten, mw.err
 }
 
 // Write is an alias method to WriteTo due to compatibility reasons

--- a/msg_test.go
+++ b/msg_test.go
@@ -3211,3 +3211,11 @@ func TestMsg_checkUserAgent(t *testing.T) {
 		})
 	}
 }
+
+// TestNewMsgWithMIMEVersion tests WithMIMEVersion and Msg.SetMIMEVersion
+func TestNewMsgWithNoDefaultUserAgent(t *testing.T) {
+	m := NewMsg(WithNoDefaultUserAgent())
+	if m.noDefaultUserAgent != true {
+		t.Errorf("WithNoDefaultUserAgent() failed. Expected: %t, got: %t", true, false)
+	}
+}

--- a/msg_test.go
+++ b/msg_test.go
@@ -1251,7 +1251,7 @@ func TestMsg_SetBodyString(t *testing.T) {
 			}
 			part := m.parts[0]
 			res := bytes.Buffer{}
-			if _, err := part.w(&res); err != nil && !tt.sf {
+			if _, err := part.writeFunc(&res); err != nil && !tt.sf {
 				t.Errorf("WriteFunc of part failed: %s", err)
 			}
 			if res.String() != tt.want {
@@ -1286,7 +1286,7 @@ func TestMsg_AddAlternativeString(t *testing.T) {
 			}
 			apart := m.parts[1]
 			res := bytes.Buffer{}
-			if _, err := apart.w(&res); err != nil && !tt.sf {
+			if _, err := apart.writeFunc(&res); err != nil && !tt.sf {
 				t.Errorf("WriteFunc of part failed: %s", err)
 			}
 			if res.String() != tt.want {

--- a/msg_test.go
+++ b/msg_test.go
@@ -3174,7 +3174,7 @@ func TestMsg_checkUserAgent(t *testing.T) {
 		{
 			name:               "check default user agent",
 			noDefaultUserAgent: false,
-			wantUserAgent:      "go-mail v0.4.1 // https://github.com/wneessen/go-mail",
+			wantUserAgent:      fmt.Sprintf("go-mail v%s // https://github.com/wneessen/go-mail", VERSION),
 			sf:                 false,
 		},
 		{

--- a/msgwriter.go
+++ b/msgwriter.go
@@ -114,7 +114,7 @@ func (mw *msgWriter) writeMsg(msg *Msg) {
 	}
 
 	for _, part := range msg.parts {
-		if !part.del {
+		if !part.isDeleted {
 			mw.writePart(part, msg.charset)
 		}
 	}
@@ -249,12 +249,12 @@ func (mw *msgWriter) newPart(header map[string][]string) {
 
 // writePart writes the corresponding part to the Msg body
 func (mw *msgWriter) writePart(part *Part, charset Charset) {
-	partCharset := part.cset
+	partCharset := part.charset
 	if partCharset.String() == "" {
 		partCharset = charset
 	}
-	contentType := fmt.Sprintf("%s; charset=%s", part.ctype, partCharset)
-	contentTransferEnc := part.enc.String()
+	contentType := fmt.Sprintf("%s; charset=%s", part.contentType, partCharset)
+	contentTransferEnc := part.encoding.String()
 	if mw.depth == 0 {
 		mw.writeHeader(HeaderContentType, contentType)
 		mw.writeHeader(HeaderContentTransferEnc, contentTransferEnc)
@@ -262,14 +262,14 @@ func (mw *msgWriter) writePart(part *Part, charset Charset) {
 	}
 	if mw.depth > 0 {
 		mimeHeader := textproto.MIMEHeader{}
-		if part.desc != "" {
-			mimeHeader.Add(string(HeaderContentDescription), part.desc)
+		if part.description != "" {
+			mimeHeader.Add(string(HeaderContentDescription), part.description)
 		}
 		mimeHeader.Add(string(HeaderContentType), contentType)
 		mimeHeader.Add(string(HeaderContentTransferEnc), contentTransferEnc)
 		mw.newPart(mimeHeader)
 	}
-	mw.writeBody(part.w, part.enc)
+	mw.writeBody(part.writeFunc, part.encoding)
 }
 
 // writeString writes a string into the msgWriter's io.Writer interface

--- a/msgwriter.go
+++ b/msgwriter.go
@@ -35,237 +35,241 @@ const DoubleNewLine = "\r\n\r\n"
 
 // msgWriter handles the I/O to the io.WriteCloser of the SMTP client
 type msgWriter struct {
-	c   Charset
-	d   int8
-	en  mime.WordEncoder
-	err error
-	mpw [3]*multipart.Writer
-	n   int64
-	pw  io.Writer
-	w   io.Writer
+	bytesWritten    int64
+	charset         Charset
+	depth           int8
+	encoder         mime.WordEncoder
+	err             error
+	multiPartWriter [3]*multipart.Writer
+	partWriter      io.Writer
+	writer          io.Writer
 }
 
 // Write implements the io.Writer interface for msgWriter
-func (mw *msgWriter) Write(p []byte) (int, error) {
+func (mw *msgWriter) Write(payload []byte) (int, error) {
 	if mw.err != nil {
 		return 0, fmt.Errorf("failed to write due to previous error: %w", mw.err)
 	}
 
 	var n int
-	n, mw.err = mw.w.Write(p)
-	mw.n += int64(n)
+	n, mw.err = mw.writer.Write(payload)
+	mw.bytesWritten += int64(n)
 	return n, mw.err
 }
 
 // writeMsg formats the message and sends it to its io.Writer
-func (mw *msgWriter) writeMsg(m *Msg) {
-	m.addDefaultHeader()
-	m.checkUserAgent()
-	mw.writeGenHeader(m)
-	mw.writePreformattedGenHeader(m)
+func (mw *msgWriter) writeMsg(msg *Msg) {
+	msg.addDefaultHeader()
+	msg.checkUserAgent()
+	mw.writeGenHeader(msg)
+	mw.writePreformattedGenHeader(msg)
 
 	// Set the FROM header (or envelope FROM if FROM is empty)
-	hf := true
-	f, ok := m.addrHeader[HeaderFrom]
-	if !ok || (len(f) == 0 || f == nil) {
-		f, ok = m.addrHeader[HeaderEnvelopeFrom]
-		if !ok || (len(f) == 0 || f == nil) {
-			hf = false
+	hasFrom := true
+	from, ok := msg.addrHeader[HeaderFrom]
+	if !ok || (len(from) == 0 || from == nil) {
+		from, ok = msg.addrHeader[HeaderEnvelopeFrom]
+		if !ok || (len(from) == 0 || from == nil) {
+			hasFrom = false
 		}
 	}
-	if hf && (len(f) > 0 && f[0] != nil) {
-		mw.writeHeader(Header(HeaderFrom), f[0].String())
+	if hasFrom && (len(from) > 0 && from[0] != nil) {
+		mw.writeHeader(Header(HeaderFrom), from[0].String())
 	}
 
 	// Set the rest of the address headers
-	for _, t := range []AddrHeader{HeaderTo, HeaderCc} {
-		if al, ok := m.addrHeader[t]; ok {
-			var v []string
-			for _, a := range al {
-				v = append(v, a.String())
+	for _, to := range []AddrHeader{HeaderTo, HeaderCc} {
+		if addresses, ok := msg.addrHeader[to]; ok {
+			var val []string
+			for _, addr := range addresses {
+				val = append(val, addr.String())
 			}
-			mw.writeHeader(Header(t), v...)
+			mw.writeHeader(Header(to), val...)
 		}
 	}
 
-	if m.hasMixed() {
-		mw.startMP("mixed", m.boundary)
+	if msg.hasMixed() {
+		mw.startMP("mixed", msg.boundary)
 		mw.writeString(DoubleNewLine)
 	}
-	if m.hasRelated() {
-		mw.startMP("related", m.boundary)
+	if msg.hasRelated() {
+		mw.startMP("related", msg.boundary)
 		mw.writeString(DoubleNewLine)
 	}
-	if m.hasAlt() {
-		mw.startMP(MIMEAlternative, m.boundary)
+	if msg.hasAlt() {
+		mw.startMP(MIMEAlternative, msg.boundary)
 		mw.writeString(DoubleNewLine)
 	}
-	if m.hasPGPType() {
-		switch m.pgptype {
+	if msg.hasPGPType() {
+		switch msg.pgptype {
 		case PGPEncrypt:
-			mw.startMP(`encrypted; protocol="application/pgp-encrypted"`, m.boundary)
+			mw.startMP(`encrypted; protocol="application/pgp-encrypted"`,
+				msg.boundary)
 		case PGPSignature:
-			mw.startMP(`signed; protocol="application/pgp-signature";`, m.boundary)
+			mw.startMP(`signed; protocol="application/pgp-signature";`,
+				msg.boundary)
+		default:
 		}
 		mw.writeString(DoubleNewLine)
 	}
 
-	for _, p := range m.parts {
-		if !p.del {
-			mw.writePart(p, m.charset)
+	for _, part := range msg.parts {
+		if !part.del {
+			mw.writePart(part, msg.charset)
 		}
 	}
 
-	if m.hasAlt() {
+	if msg.hasAlt() {
 		mw.stopMP()
 	}
 
 	// Add embeds
-	mw.addFiles(m.embeds, false)
-	if m.hasRelated() {
+	mw.addFiles(msg.embeds, false)
+	if msg.hasRelated() {
 		mw.stopMP()
 	}
 
 	// Add attachments
-	mw.addFiles(m.attachments, true)
-	if m.hasMixed() {
+	mw.addFiles(msg.attachments, true)
+	if msg.hasMixed() {
 		mw.stopMP()
 	}
 }
 
 // writeGenHeader writes out all generic headers to the msgWriter
-func (mw *msgWriter) writeGenHeader(m *Msg) {
-	gk := make([]string, 0, len(m.genHeader))
-	for k := range m.genHeader {
-		gk = append(gk, string(k))
+func (mw *msgWriter) writeGenHeader(msg *Msg) {
+	keys := make([]string, 0, len(msg.genHeader))
+	for key := range msg.genHeader {
+		keys = append(keys, string(key))
 	}
-	sort.Strings(gk)
-	for _, k := range gk {
-		mw.writeHeader(Header(k), m.genHeader[Header(k)]...)
+	sort.Strings(keys)
+	for _, key := range keys {
+		mw.writeHeader(Header(key), msg.genHeader[Header(key)]...)
 	}
 }
 
 // writePreformatedHeader writes out all preformated generic headers to the msgWriter
-func (mw *msgWriter) writePreformattedGenHeader(m *Msg) {
-	for k, v := range m.preformHeader {
-		mw.writeString(fmt.Sprintf("%s: %s%s", k, v, SingleNewLine))
+func (mw *msgWriter) writePreformattedGenHeader(msg *Msg) {
+	for key, val := range msg.preformHeader {
+		mw.writeString(fmt.Sprintf("%s: %s%s", key, val, SingleNewLine))
 	}
 }
 
 // startMP writes a multipart beginning
-func (mw *msgWriter) startMP(mt MIMEType, b string) {
-	mp := multipart.NewWriter(mw)
-	if b != "" {
-		mw.err = mp.SetBoundary(b)
+func (mw *msgWriter) startMP(mimeType MIMEType, boundary string) {
+	multiPartWriter := multipart.NewWriter(mw)
+	if boundary != "" {
+		mw.err = multiPartWriter.SetBoundary(boundary)
 	}
 
-	ct := fmt.Sprintf("multipart/%s;\r\n boundary=%s", mt, mp.Boundary())
-	mw.mpw[mw.d] = mp
+	contentType := fmt.Sprintf("multipart/%s;\r\n boundary=%s", mimeType,
+		multiPartWriter.Boundary())
+	mw.multiPartWriter[mw.depth] = multiPartWriter
 
-	if mw.d == 0 {
-		mw.writeString(fmt.Sprintf("%s: %s", HeaderContentType, ct))
+	if mw.depth == 0 {
+		mw.writeString(fmt.Sprintf("%s: %s", HeaderContentType, contentType))
 	}
-	if mw.d > 0 {
-		mw.newPart(map[string][]string{"Content-Type": {ct}})
+	if mw.depth > 0 {
+		mw.newPart(map[string][]string{"Content-Type": {contentType}})
 	}
-	mw.d++
+	mw.depth++
 }
 
 // stopMP closes the multipart
 func (mw *msgWriter) stopMP() {
-	if mw.d > 0 {
-		mw.err = mw.mpw[mw.d-1].Close()
-		mw.d--
+	if mw.depth > 0 {
+		mw.err = mw.multiPartWriter[mw.depth-1].Close()
+		mw.depth--
 	}
 }
 
 // addFiles adds the attachments/embeds file content to the mail body
-func (mw *msgWriter) addFiles(fl []*File, a bool) {
-	for _, f := range fl {
-		e := EncodingB64
-		if _, ok := f.getHeader(HeaderContentType); !ok {
-			mt := mime.TypeByExtension(filepath.Ext(f.Name))
-			if mt == "" {
-				mt = "application/octet-stream"
+func (mw *msgWriter) addFiles(files []*File, isAttachment bool) {
+	for _, file := range files {
+		encoding := EncodingB64
+		if _, ok := file.getHeader(HeaderContentType); !ok {
+			mimeType := mime.TypeByExtension(filepath.Ext(file.Name))
+			if mimeType == "" {
+				mimeType = "application/octet-stream"
 			}
-			if f.ContentType != "" {
-				mt = string(f.ContentType)
+			if file.ContentType != "" {
+				mimeType = string(file.ContentType)
 			}
-			f.setHeader(HeaderContentType, fmt.Sprintf(`%s; name="%s"`, mt,
-				mw.en.Encode(mw.c.String(), f.Name)))
+			file.setHeader(HeaderContentType, fmt.Sprintf(`%s; name="%s"`, mimeType,
+				mw.encoder.Encode(mw.charset.String(), file.Name)))
 		}
 
-		if _, ok := f.getHeader(HeaderContentTransferEnc); !ok {
-			if f.Enc != "" {
-				e = f.Enc
+		if _, ok := file.getHeader(HeaderContentTransferEnc); !ok {
+			if file.Enc != "" {
+				encoding = file.Enc
 			}
-			f.setHeader(HeaderContentTransferEnc, string(e))
+			file.setHeader(HeaderContentTransferEnc, string(encoding))
 		}
 
-		if f.Desc != "" {
-			if _, ok := f.getHeader(HeaderContentDescription); !ok {
-				f.setHeader(HeaderContentDescription, f.Desc)
+		if file.Desc != "" {
+			if _, ok := file.getHeader(HeaderContentDescription); !ok {
+				file.setHeader(HeaderContentDescription, file.Desc)
 			}
 		}
 
-		if _, ok := f.getHeader(HeaderContentDisposition); !ok {
-			d := "inline"
-			if a {
-				d = "attachment"
+		if _, ok := file.getHeader(HeaderContentDisposition); !ok {
+			disposition := "inline"
+			if isAttachment {
+				disposition = "attachment"
 			}
-			f.setHeader(HeaderContentDisposition, fmt.Sprintf(`%s; filename="%s"`, d,
-				mw.en.Encode(mw.c.String(), f.Name)))
+			file.setHeader(HeaderContentDisposition, fmt.Sprintf(`%s; filename="%s"`,
+				disposition, mw.encoder.Encode(mw.charset.String(), file.Name)))
 		}
 
-		if !a {
-			if _, ok := f.getHeader(HeaderContentID); !ok {
-				f.setHeader(HeaderContentID, fmt.Sprintf("<%s>", f.Name))
+		if !isAttachment {
+			if _, ok := file.getHeader(HeaderContentID); !ok {
+				file.setHeader(HeaderContentID, fmt.Sprintf("<%s>", file.Name))
 			}
 		}
-		if mw.d == 0 {
-			for h, v := range f.Header {
-				mw.writeHeader(Header(h), v...)
+		if mw.depth == 0 {
+			for header, val := range file.Header {
+				mw.writeHeader(Header(header), val...)
 			}
 			mw.writeString(SingleNewLine)
 		}
-		if mw.d > 0 {
-			mw.newPart(f.Header)
+		if mw.depth > 0 {
+			mw.newPart(file.Header)
 		}
 
 		if mw.err == nil {
-			mw.writeBody(f.Writer, e)
+			mw.writeBody(file.Writer, encoding)
 		}
 	}
 }
 
 // newPart creates a new MIME multipart io.Writer and sets the partwriter to it
-func (mw *msgWriter) newPart(h map[string][]string) {
-	mw.pw, mw.err = mw.mpw[mw.d-1].CreatePart(h)
+func (mw *msgWriter) newPart(header map[string][]string) {
+	mw.partWriter, mw.err = mw.multiPartWriter[mw.depth-1].CreatePart(header)
 }
 
 // writePart writes the corresponding part to the Msg body
-func (mw *msgWriter) writePart(p *Part, cs Charset) {
-	pcs := p.cset
-	if pcs.String() == "" {
-		pcs = cs
+func (mw *msgWriter) writePart(part *Part, charset Charset) {
+	partCharset := part.cset
+	if partCharset.String() == "" {
+		partCharset = charset
 	}
-	ct := fmt.Sprintf("%s; charset=%s", p.ctype, pcs)
-	cte := p.enc.String()
-	if mw.d == 0 {
-		mw.writeHeader(HeaderContentType, ct)
-		mw.writeHeader(HeaderContentTransferEnc, cte)
+	contentType := fmt.Sprintf("%s; charset=%s", part.ctype, partCharset)
+	contentTransferEnc := part.enc.String()
+	if mw.depth == 0 {
+		mw.writeHeader(HeaderContentType, contentType)
+		mw.writeHeader(HeaderContentTransferEnc, contentTransferEnc)
 		mw.writeString(SingleNewLine)
 	}
-	if mw.d > 0 {
-		mh := textproto.MIMEHeader{}
-		if p.desc != "" {
-			mh.Add(string(HeaderContentDescription), p.desc)
+	if mw.depth > 0 {
+		mimeHeader := textproto.MIMEHeader{}
+		if part.desc != "" {
+			mimeHeader.Add(string(HeaderContentDescription), part.desc)
 		}
-		mh.Add(string(HeaderContentType), ct)
-		mh.Add(string(HeaderContentTransferEnc), cte)
-		mw.newPart(mh)
+		mimeHeader.Add(string(HeaderContentType), contentType)
+		mimeHeader.Add(string(HeaderContentTransferEnc), contentTransferEnc)
+		mw.newPart(mimeHeader)
 	}
-	mw.writeBody(p.w, p.enc)
+	mw.writeBody(part.w, part.enc)
 }
 
 // writeString writes a string into the msgWriter's io.Writer interface
@@ -274,24 +278,24 @@ func (mw *msgWriter) writeString(s string) {
 		return
 	}
 	var n int
-	n, mw.err = io.WriteString(mw.w, s)
-	mw.n += int64(n)
+	n, mw.err = io.WriteString(mw.writer, s)
+	mw.bytesWritten += int64(n)
 }
 
 // writeHeader writes a header into the msgWriter's io.Writer
-func (mw *msgWriter) writeHeader(k Header, vl ...string) {
+func (mw *msgWriter) writeHeader(key Header, values ...string) {
 	wbuf := bytes.Buffer{}
 	cl := MaxHeaderLength - 2
-	wbuf.WriteString(string(k))
-	cl -= len(k)
-	if len(vl) == 0 {
+	wbuf.WriteString(string(key))
+	cl -= len(key)
+	if len(values) == 0 {
 		wbuf.WriteString(":\r\n")
 		return
 	}
 	wbuf.WriteString(": ")
 	cl -= 2
 
-	fs := strings.Join(vl, ", ")
+	fs := strings.Join(values, ", ")
 	sfs := strings.Split(fs, " ")
 	for i, v := range sfs {
 		if cl-len(v) <= 1 {
@@ -318,11 +322,11 @@ func (mw *msgWriter) writeBody(f func(io.Writer) (int64, error), e Encoding) {
 	var ew io.WriteCloser
 	var n int64
 	var err error
-	if mw.d == 0 {
-		w = mw.w
+	if mw.depth == 0 {
+		w = mw.writer
 	}
-	if mw.d > 0 {
-		w = mw.pw
+	if mw.depth > 0 {
+		w = mw.partWriter
 	}
 	wbuf := bytes.Buffer{}
 	lb := Base64LineBreaker{}
@@ -342,8 +346,8 @@ func (mw *msgWriter) writeBody(f func(io.Writer) (int64, error), e Encoding) {
 		if err != nil && mw.err == nil {
 			mw.err = fmt.Errorf("bodyWriter io.Copy: %w", err)
 		}
-		if mw.d == 0 {
-			mw.n += n
+		if mw.depth == 0 {
+			mw.bytesWritten += n
 		}
 		return
 	default:
@@ -369,7 +373,7 @@ func (mw *msgWriter) writeBody(f func(io.Writer) (int64, error), e Encoding) {
 
 	// Since the part writer uses the WriteTo() method, we don't need to add the
 	// bytes twice
-	if mw.d == 0 {
-		mw.n += n
+	if mw.depth == 0 {
+		mw.bytesWritten += n
 	}
 }

--- a/msgwriter_test.go
+++ b/msgwriter_test.go
@@ -28,7 +28,7 @@ func (bw *brokenWriter) Write([]byte) (int, error) {
 // TestMsgWriter_Write tests the WriteTo() method of the msgWriter
 func TestMsgWriter_Write(t *testing.T) {
 	bw := &brokenWriter{}
-	mw := &msgWriter{w: bw, c: CharsetUTF8, en: mime.QEncoding}
+	mw := &msgWriter{writer: bw, charset: CharsetUTF8, encoder: mime.QEncoding}
 	_, err := mw.Write([]byte("test"))
 	if err == nil {
 		t.Errorf("msgWriter WriteTo() with brokenWriter should fail, but didn't")
@@ -55,7 +55,7 @@ func TestMsgWriter_writeMsg(t *testing.T) {
 	m.SetBodyString(TypeTextPlain, "This is the body")
 	m.AddAlternativeString(TypeTextHTML, "This is the alternative body")
 	buf := bytes.Buffer{}
-	mw := &msgWriter{w: &buf, c: CharsetUTF8, en: mime.QEncoding}
+	mw := &msgWriter{writer: &buf, charset: CharsetUTF8, encoder: mime.QEncoding}
 	mw.writeMsg(m)
 	ms := buf.String()
 
@@ -134,7 +134,7 @@ func TestMsgWriter_writeMsg_PGP(t *testing.T) {
 	m.Subject("This is a subject")
 	m.SetBodyString(TypeTextPlain, "This is the body")
 	buf := bytes.Buffer{}
-	mw := &msgWriter{w: &buf, c: CharsetUTF8, en: mime.QEncoding}
+	mw := &msgWriter{writer: &buf, charset: CharsetUTF8, encoder: mime.QEncoding}
 	mw.writeMsg(m)
 	ms := buf.String()
 	if !strings.Contains(ms, `encrypted; protocol="application/pgp-encrypted"`) {
@@ -147,7 +147,7 @@ func TestMsgWriter_writeMsg_PGP(t *testing.T) {
 	m.Subject("This is a subject")
 	m.SetBodyString(TypeTextPlain, "This is the body")
 	buf = bytes.Buffer{}
-	mw = &msgWriter{w: &buf, c: CharsetUTF8, en: mime.QEncoding}
+	mw = &msgWriter{writer: &buf, charset: CharsetUTF8, encoder: mime.QEncoding}
 	mw.writeMsg(m)
 	ms = buf.String()
 	if !strings.Contains(ms, `signed; protocol="application/pgp-signature"`) {

--- a/part.go
+++ b/part.go
@@ -14,18 +14,18 @@ type PartOption func(*Part)
 
 // Part is a part of the Msg
 type Part struct {
-	ctype ContentType
-	cset  Charset
-	desc  string
-	enc   Encoding
-	del   bool
-	w     func(io.Writer) (int64, error)
+	contentType ContentType
+	charset     Charset
+	description string
+	encoding    Encoding
+	isDeleted   bool
+	writeFunc   func(io.Writer) (int64, error)
 }
 
 // GetContent executes the WriteFunc of the Part and returns the content as byte slice
 func (p *Part) GetContent() ([]byte, error) {
 	var b bytes.Buffer
-	if _, err := p.w(&b); err != nil {
+	if _, err := p.writeFunc(&b); err != nil {
 		return nil, err
 	}
 	return b.Bytes(), nil
@@ -33,83 +33,83 @@ func (p *Part) GetContent() ([]byte, error) {
 
 // GetCharset returns the currently set Charset of the Part
 func (p *Part) GetCharset() Charset {
-	return p.cset
+	return p.charset
 }
 
 // GetContentType returns the currently set ContentType of the Part
 func (p *Part) GetContentType() ContentType {
-	return p.ctype
+	return p.contentType
 }
 
 // GetEncoding returns the currently set Encoding of the Part
 func (p *Part) GetEncoding() Encoding {
-	return p.enc
+	return p.encoding
 }
 
 // GetWriteFunc returns the currently set WriterFunc of the Part
 func (p *Part) GetWriteFunc() func(io.Writer) (int64, error) {
-	return p.w
+	return p.writeFunc
 }
 
 // GetDescription returns the currently set Content-Description of the Part
 func (p *Part) GetDescription() string {
-	return p.desc
+	return p.description
 }
 
 // SetContent overrides the content of the Part with the given string
-func (p *Part) SetContent(c string) {
-	buf := bytes.NewBufferString(c)
-	p.w = writeFuncFromBuffer(buf)
+func (p *Part) SetContent(content string) {
+	buffer := bytes.NewBufferString(content)
+	p.writeFunc = writeFuncFromBuffer(buffer)
 }
 
 // SetContentType overrides the ContentType of the Part
-func (p *Part) SetContentType(c ContentType) {
-	p.ctype = c
+func (p *Part) SetContentType(contentType ContentType) {
+	p.contentType = contentType
 }
 
 // SetCharset overrides the Charset of the Part
-func (p *Part) SetCharset(c Charset) {
-	p.cset = c
+func (p *Part) SetCharset(charset Charset) {
+	p.charset = charset
 }
 
 // SetEncoding creates a new mime.WordEncoder based on the encoding setting of the message
-func (p *Part) SetEncoding(e Encoding) {
-	p.enc = e
+func (p *Part) SetEncoding(encoding Encoding) {
+	p.encoding = encoding
 }
 
 // SetDescription overrides the Content-Description of the Part
-func (p *Part) SetDescription(d string) {
-	p.desc = d
+func (p *Part) SetDescription(description string) {
+	p.description = description
 }
 
 // SetWriteFunc overrides the WriteFunc of the Part
-func (p *Part) SetWriteFunc(w func(io.Writer) (int64, error)) {
-	p.w = w
+func (p *Part) SetWriteFunc(writeFunc func(io.Writer) (int64, error)) {
+	p.writeFunc = writeFunc
 }
 
 // Delete removes the current part from the parts list of the Msg by setting the
-// del flag to true. The msgWriter will skip it then
+// isDeleted flag to true. The msgWriter will skip it then
 func (p *Part) Delete() {
-	p.del = true
+	p.isDeleted = true
 }
 
 // WithPartCharset overrides the default Part charset
-func WithPartCharset(c Charset) PartOption {
+func WithPartCharset(charset Charset) PartOption {
 	return func(p *Part) {
-		p.cset = c
+		p.charset = charset
 	}
 }
 
 // WithPartEncoding overrides the default Part encoding
-func WithPartEncoding(e Encoding) PartOption {
+func WithPartEncoding(encoding Encoding) PartOption {
 	return func(p *Part) {
-		p.enc = e
+		p.encoding = encoding
 	}
 }
 
 // WithPartContentDescription overrides the default Part Content-Description
-func WithPartContentDescription(d string) PartOption {
+func WithPartContentDescription(description string) PartOption {
 	return func(p *Part) {
-		p.desc = d
+		p.description = description
 	}
 }

--- a/part_test.go
+++ b/part_test.go
@@ -31,15 +31,15 @@ func TestPartEncoding(t *testing.T) {
 				t.Errorf("newPart() WithPartEncoding() failed: no part returned")
 				return
 			}
-			if part.enc.String() != tt.want {
+			if part.encoding.String() != tt.want {
 				t.Errorf("newPart() WithPartEncoding() failed: expected encoding: %s, got: %s", tt.want,
-					part.enc.String())
+					part.encoding.String())
 			}
-			part.enc = ""
+			part.encoding = ""
 			part.SetEncoding(tt.enc)
-			if part.enc.String() != tt.want {
+			if part.encoding.String() != tt.want {
 				t.Errorf("newPart() SetEncoding() failed: expected encoding: %s, got: %s", tt.want,
-					part.enc.String())
+					part.encoding.String())
 			}
 		})
 	}
@@ -64,9 +64,9 @@ func TestWithPartCharset(t *testing.T) {
 				t.Errorf("newPart() WithPartCharset() failed: no part returned")
 				return
 			}
-			if part.cset.String() != tt.want {
+			if part.charset.String() != tt.want {
 				t.Errorf("newPart() WithPartCharset() failed: expected charset: %s, got: %s",
-					tt.want, part.cset.String())
+					tt.want, part.charset.String())
 			}
 		})
 	}
@@ -89,14 +89,14 @@ func TestPart_WithPartContentDescription(t *testing.T) {
 				t.Errorf("newPart() WithPartContentDescription() failed: no part returned")
 				return
 			}
-			if part.desc != tt.desc {
+			if part.description != tt.desc {
 				t.Errorf("newPart() WithPartContentDescription() failed: expected: %s, got: %s", tt.desc,
-					part.desc)
+					part.description)
 			}
-			part.desc = ""
+			part.description = ""
 			part.SetDescription(tt.desc)
-			if part.desc != tt.desc {
-				t.Errorf("newPart() SetDescription() failed: expected: %s, got: %s", tt.desc, part.desc)
+			if part.description != tt.desc {
+				t.Errorf("newPart() SetDescription() failed: expected: %s, got: %s", tt.desc, part.description)
 			}
 		})
 	}
@@ -236,7 +236,7 @@ func TestPart_GetContentBroken(t *testing.T) {
 		t.Errorf("failed: %s", err)
 		return
 	}
-	pl[0].w = func(io.Writer) (int64, error) {
+	pl[0].writeFunc = func(io.Writer) (int64, error) {
 		return 0, fmt.Errorf("broken")
 	}
 	_, err = pl[0].GetContent()
@@ -314,8 +314,8 @@ func TestPart_SetDescription(t *testing.T) {
 		t.Errorf("Part.GetDescription failed. Expected empty description but got: %s", pd)
 	}
 	pl[0].SetDescription(d)
-	if pl[0].desc != d {
-		t.Errorf("Part.SetDescription failed. Expected desc to be: %s, got: %s", d, pd)
+	if pl[0].description != d {
+		t.Errorf("Part.SetDescription failed. Expected description to be: %s, got: %s", d, pd)
 	}
 	pd = pl[0].GetDescription()
 	if pd != d {
@@ -334,8 +334,8 @@ func TestPart_Delete(t *testing.T) {
 		return
 	}
 	pl[0].Delete()
-	if !pl[0].del {
-		t.Errorf("Delete failed. Expected: %t, got: %t", true, pl[0].del)
+	if !pl[0].isDeleted {
+		t.Errorf("Delete failed. Expected: %t, got: %t", true, pl[0].isDeleted)
 	}
 }
 

--- a/random.go
+++ b/random.go
@@ -22,54 +22,53 @@ const (
 	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
 )
 
-// randomStringSecure returns a random, n long string of characters. The character set is based
-// on the s (special chars) and h (human readable) boolean arguments. This method uses the
+// randomStringSecure returns a random, string of length characters. This method uses the
 // crypto/random package and therfore is cryptographically secure
-func randomStringSecure(n int) (string, error) {
-	rs := strings.Builder{}
-	rs.Grow(n)
-	crl := len(cr)
+func randomStringSecure(length int) (string, error) {
+	randString := strings.Builder{}
+	randString.Grow(length)
+	charRangeLength := len(cr)
 
-	rp := make([]byte, 8)
-	_, err := rand.Read(rp)
+	randPool := make([]byte, 8)
+	_, err := rand.Read(randPool)
 	if err != nil {
-		return rs.String(), err
+		return randString.String(), err
 	}
-	for i, c, r := n-1, binary.BigEndian.Uint64(rp), letterIdxMax; i >= 0; {
-		if r == 0 {
-			_, err := rand.Read(rp)
+	for idx, char, rest := length-1, binary.BigEndian.Uint64(randPool), letterIdxMax; idx >= 0; {
+		if rest == 0 {
+			_, err = rand.Read(randPool)
 			if err != nil {
-				return rs.String(), err
+				return randString.String(), err
 			}
-			c, r = binary.BigEndian.Uint64(rp), letterIdxMax
+			char, rest = binary.BigEndian.Uint64(randPool), letterIdxMax
 		}
-		if idx := int(c & letterIdxMask); idx < crl {
-			rs.WriteByte(cr[idx])
-			i--
+		if idx := int(char & letterIdxMask); idx < charRangeLength {
+			randString.WriteByte(cr[idx])
+			idx--
 		}
-		c >>= letterIdxBits
-		r--
+		char >>= letterIdxBits
+		rest--
 	}
 
-	return rs.String(), nil
+	return randString.String(), nil
 }
 
-// randNum returns a random number with a maximum value of n
-func randNum(n int) (int, error) {
-	if n <= 0 {
-		return 0, fmt.Errorf("provided number is <= 0: %d", n)
+// randNum returns a random number with a maximum value of length
+func randNum(length int) (int, error) {
+	if length <= 0 {
+		return 0, fmt.Errorf("provided number is <= 0: %d", length)
 	}
-	mbi := big.NewInt(int64(n))
-	if !mbi.IsUint64() {
-		return 0, fmt.Errorf("big.NewInt() generation returned negative value: %d", mbi)
+	length64 := big.NewInt(int64(length))
+	if !length64.IsUint64() {
+		return 0, fmt.Errorf("big.NewInt() generation returned negative value: %d", length64)
 	}
-	rn64, err := rand.Int(rand.Reader, mbi)
+	randNum64, err := rand.Int(rand.Reader, length64)
 	if err != nil {
 		return 0, err
 	}
-	rn := int(rn64.Int64())
-	if rn < 0 {
-		return 0, fmt.Errorf("generated random number does not fit as int64: %d", rn64)
+	randomNum := int(randNum64.Int64())
+	if randomNum < 0 {
+		return 0, fmt.Errorf("generated random number does not fit as int64: %d", randNum64)
 	}
-	return rn, nil
+	return randomNum, nil
 }

--- a/random.go
+++ b/random.go
@@ -42,8 +42,8 @@ func randomStringSecure(length int) (string, error) {
 			}
 			char, rest = binary.BigEndian.Uint64(randPool), letterIdxMax
 		}
-		if idx := int(char & letterIdxMask); idx < charRangeLength {
-			randString.WriteByte(cr[idx])
+		if i := int(char & letterIdxMask); i < charRangeLength {
+			randString.WriteByte(cr[i])
 			idx--
 		}
 		char >>= letterIdxBits

--- a/reader.go
+++ b/reader.go
@@ -10,9 +10,9 @@ import (
 
 // Reader is a type that implements the io.Reader interface for a Msg
 type Reader struct {
-	buf []byte // contents are the bytes buf[off : len(buf)]
-	off int    // read at &buf[off], write at &buf[len(buf)]
-	err error  // initialization error
+	buffer []byte // contents are the bytes buffer[offset : len(buffer)]
+	offset int    // read at &buffer[offset], write at &buffer[len(buffer)]
+	err    error  // initialization error
 }
 
 // Error returns an error if the Reader err field is not nil
@@ -21,28 +21,28 @@ func (r *Reader) Error() error {
 }
 
 // Read reads the length of p of the Msg buffer to satisfy the io.Reader interface
-func (r *Reader) Read(p []byte) (n int, err error) {
+func (r *Reader) Read(payload []byte) (n int, err error) {
 	if r.err != nil {
 		return 0, r.err
 	}
-	if r.empty() || r.buf == nil {
+	if r.empty() || r.buffer == nil {
 		r.Reset()
-		if len(p) == 0 {
+		if len(payload) == 0 {
 			return 0, nil
 		}
 		return 0, io.EOF
 	}
-	n = copy(p, r.buf[r.off:])
-	r.off += n
+	n = copy(payload, r.buffer[r.offset:])
+	r.offset += n
 	return n, err
 }
 
 // Reset resets the Reader buffer to be empty, but it retains the underlying storage
 // for use by future writes.
 func (r *Reader) Reset() {
-	r.buf = r.buf[:0]
-	r.off = 0
+	r.buffer = r.buffer[:0]
+	r.offset = 0
 }
 
 // empty reports whether the unread portion of the Reader buffer is empty.
-func (r *Reader) empty() bool { return len(r.buf) <= r.off }
+func (r *Reader) empty() bool { return len(r.buffer) <= r.offset }

--- a/reader_test.go
+++ b/reader_test.go
@@ -65,7 +65,7 @@ func TestReader_Read_error(t *testing.T) {
 
 // TestReader_Read_empty tests the Reader.Read method with an empty buffer
 func TestReader_Read_empty(t *testing.T) {
-	r := Reader{buf: []byte{}}
+	r := Reader{buffer: []byte{}}
 	p := make([]byte, 1)
 	p[0] = 'a'
 	_, err := r.Read(p)
@@ -76,7 +76,7 @@ func TestReader_Read_empty(t *testing.T) {
 
 // TestReader_Read_nil tests the Reader.Read method with a nil buffer
 func TestReader_Read_nil(t *testing.T) {
-	r := Reader{buf: nil, off: -10}
+	r := Reader{buffer: nil, offset: -10}
 	p := make([]byte, 0)
 	_, err := r.Read(p)
 	if err != nil && !errors.Is(err, io.EOF) {

--- a/senderror.go
+++ b/senderror.go
@@ -71,34 +71,34 @@ func (e *SendError) Error() string {
 		return "unknown reason"
 	}
 
-	var em strings.Builder
-	em.WriteString(e.Reason.String())
+	var errMessage strings.Builder
+	errMessage.WriteString(e.Reason.String())
 	if len(e.errlist) > 0 {
-		em.WriteRune(':')
+		errMessage.WriteRune(':')
 		for i := range e.errlist {
-			em.WriteRune(' ')
-			em.WriteString(e.errlist[i].Error())
+			errMessage.WriteRune(' ')
+			errMessage.WriteString(e.errlist[i].Error())
 			if i != len(e.errlist)-1 {
-				em.WriteString(", ")
+				errMessage.WriteString(", ")
 			}
 		}
 	}
 	if len(e.rcpt) > 0 {
-		em.WriteString(", affected recipient(s): ")
+		errMessage.WriteString(", affected recipient(s): ")
 		for i := range e.rcpt {
-			em.WriteString(e.rcpt[i])
+			errMessage.WriteString(e.rcpt[i])
 			if i != len(e.rcpt)-1 {
-				em.WriteString(", ")
+				errMessage.WriteString(", ")
 			}
 		}
 	}
-	return em.String()
+	return errMessage.String()
 }
 
 // Is implements the errors.Is functionality and compares the SendErrReason
-func (e *SendError) Is(et error) bool {
+func (e *SendError) Is(errType error) bool {
 	var t *SendError
-	if errors.As(et, &t) && t != nil {
+	if errors.As(errType, &t) && t != nil {
 		return e.Reason == t.Reason && e.isTemp == t.isTemp
 	}
 	return false
@@ -143,6 +143,6 @@ func (r SendErrReason) String() string {
 
 // isTempError checks the given SMTP error and returns true if the given error is of temporary nature
 // and should be retried
-func isTempError(e error) bool {
-	return e.Error()[0] == '4'
+func isTempError(err error) bool {
+	return err.Error()[0] == '4'
 }

--- a/tls.go
+++ b/tls.go
@@ -8,17 +8,17 @@ package mail
 type TLSPolicy int
 
 const (
-	// TLSMandatory requires that the connection cto the server is
+	// TLSMandatory requires that the connection to the server is
 	// encrypting using STARTTLS. If the server does not support STARTTLS
 	// the connection will be terminated with an error
 	TLSMandatory TLSPolicy = iota
 
-	// TLSOpportunistic tries cto establish an encrypted connection via the
+	// TLSOpportunistic tries to establish an encrypted connection via the
 	// STARTTLS protocol. If the server does not support this, it will fall
-	// back cto non-encrypted plaintext transmission
+	// back to non-encrypted plaintext transmission
 	TLSOpportunistic
 
-	// NoTLS forces the transaction cto be not encrypted
+	// NoTLS forces the transaction to be not encrypted
 	NoTLS
 )
 


### PR DESCRIPTION
This PR updates the whole code base with better, more readable variables names to address #179. The code in the `smtp/` directory has been left untouched so that syncing with the upstream stdlib is not made more complicated than it has to be.

Closes #179.