### PR TITLE
Add SPDX license headers to GitHub workflow files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+#
+# SPDX-License-Identifier: CC0-1.0
+
 version: 2
 updates:
   - package-ecosystem: github-actions

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+#
+# SPDX-License-Identifier: CC0-1.0
+
 # Dependency Review Action
 #
 # This Action will scan dependency manifest files that change as part of a Pull Request,

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+#
+# SPDX-License-Identifier: CC0-1.0
+
 # This workflow uses actions that are not certified by GitHub. They are provided
 # by a third-party and are governed by separate terms of service, privacy
 # policy, and support documentation.


### PR DESCRIPTION
This commit adds SPDX license headers to GitHub workflow files: scorecards.yml, dependency-review.yml, and dependabot.yml. This ensures that the license and copyright information is easily available for everyone to see.