### PR TITLE
Add read permissions to GitHub workflow files

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -6,6 +6,9 @@ name: REUSE Compliance Check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: CC0-1.0
 
 name: SonarQube
+
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
This commit adds read permissions for 'contents' in the GitHub workflow files sonarqube.yml and reuse.yml. This allows these specific workflows to access the relevant contents they need for execution.