### PR TITLE
Add OpenSSF Scorecard badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ SPDX-License-Identifier: CC0-1.0
 [![#go-mail on Discord](https://img.shields.io/badge/Discord-%23go%E2%80%93mail-blue.svg)](https://discord.gg/ysQXkaccXk) 
 [![REUSE status](https://api.reuse.software/badge/github.com/wneessen/go-mail)](https://api.reuse.software/info/github.com/wneessen/go-mail)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8701/badge)](https://www.bestpractices.dev/projects/8701)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/wneessen/go-mail/badge)](https://securityscorecards.dev/viewer/?uri=github.com/wneessen/go-mail)
 <a href="https://ko-fi.com/D1D24V9IX"><img src="https://uploads-ssl.webflow.com/5c14e387dab576fe667689cf/5cbed8a4ae2b88347c06c923_BuyMeACoffee_blue.png" height="20" alt="buy ma a coffee"></a>
 
 <p align="center"><img src="./assets/gopher2.svg" width="250" alt="go-mail logo"/></p>


### PR DESCRIPTION
This commit introduces the OpenSSF Scorecard badge to the README file. The badge will provide immediate access to the security scorecards of the go-mail project for users.