### PR TITLE
Update format string in Debugf method calls in tests

### DIFF
--- a/smtp/smtp_test.go
+++ b/smtp/smtp_test.go
@@ -777,9 +777,9 @@ func TestClient_SetLogger(t *testing.T) {
 	if c.logger == nil {
 		t.Errorf("Expected Logger to be set but received nil")
 	}
-	c.logger.Debugf(log.Log{Direction: log.DirServerToClient, Format: "", Messages: []interface{}{"test"}})
+	c.logger.Debugf(log.Log{Direction: log.DirServerToClient, Format: "%s", Messages: []interface{}{"test"}})
 	c.SetLogger(nil)
-	c.logger.Debugf(log.Log{Direction: log.DirServerToClient, Format: "", Messages: []interface{}{"test"}})
+	c.logger.Debugf(log.Log{Direction: log.DirServerToClient, Format: "%s", Messages: []interface{}{"test"}})
 }
 
 var newClientServer = `220 hello world


### PR DESCRIPTION
The format string for the Debugf method calls within the smtp_test.go file have been updated. Previously, the format string was empty, but it has now been changed to "%s" to align with the standard formatting expectations, improving the correctness of the tests.