### PR TITLE
Add GetBoundary method and corresponding test

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -679,6 +679,11 @@ func (m *Msg) GetAttachments() []*File {
 	return m.attachments
 }
 
+// GetBoundary returns the boundary of the Msg
+func (m *Msg) GetBoundary() string {
+	return m.boundary
+}
+
 // SetAttachements sets the attachements of the message.
 func (m *Msg) SetAttachements(files []*File) {
 	m.attachments = files

--- a/msg_test.go
+++ b/msg_test.go
@@ -2855,6 +2855,19 @@ func TestMsg_GetBccString(t *testing.T) {
 	}
 }
 
+// TestMsg_GetBoundary will test the Msg.GetBoundary method
+func TestMsg_GetBoundary(t *testing.T) {
+	b := "random_boundary_string"
+	m := NewMsg()
+	if boundary := m.GetBoundary(); boundary != "" {
+		t.Errorf("GetBoundary failed. Expected empty string, but got: %s", boundary)
+	}
+	m = NewMsg(WithBoundary(b))
+	if boundary := m.GetBoundary(); boundary != b {
+		t.Errorf("GetBoundary failed. Expected boundary: %s, got: %s", b, boundary)
+	}
+}
+
 // TestMsg_AttachEmbedReader_consecutive tests the Msg.AttachReader and Msg.EmbedReader
 // methods with consecutive calls to Msg.WriteTo to make sure the attachments are not
 // lost (see Github issue #110)


### PR DESCRIPTION
The GetBoundary method has been added to the Msg struct in msg.go. Alongside this, a corresponding test method, TestMsg_GetBoundary, was introduced in msg_test.go to ensure the proper working of GetBoundary. This new method returns the boundary string of the Msg, which was previously inaccessible.