### PR TITLE
Fix typo / inconsistency in Msg method

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -684,9 +684,16 @@ func (m *Msg) GetBoundary() string {
 	return m.boundary
 }
 
-// SetAttachements sets the attachements of the message.
-func (m *Msg) SetAttachements(files []*File) {
+// SetAttachments sets the attachments of the message.
+func (m *Msg) SetAttachments(files []*File) {
 	m.attachments = files
+}
+
+// SetAttachements sets the attachments of the message.
+//
+// Deprecated: use SetAttachments instead.
+func (m *Msg) SetAttachements(files []*File) {
+	m.SetAttachments(files)
 }
 
 // UnsetAllAttachments unset the attachments of the message.

--- a/msg_test.go
+++ b/msg_test.go
@@ -1413,7 +1413,7 @@ func TestMsg_SetAttachments(t *testing.T) {
 			for _, f := range tt.files {
 				files = append(files, &File{Name: f})
 			}
-			m.SetAttachements(files)
+			m.SetAttachments(files)
 			if len(m.attachments) != len(files) {
 				t.Errorf("SetAttachements() failed. Number of attachments expected: %d, got: %d", len(files),
 					len(m.attachments))
@@ -1448,7 +1448,7 @@ func TestMsg_UnsetAllAttachments(t *testing.T) {
 			for _, f := range tt.attachments {
 				files = append(files, &File{Name: f})
 			}
-			m.SetAttachements(files)
+			m.SetAttachments(files)
 
 			if len(m.attachments) != len(files) {
 				t.Errorf("SetAttachements() failed. Number of attachments expected: %d, got: %d", len(files),
@@ -1610,7 +1610,7 @@ func TestMsg_UnsetAllParts(t *testing.T) {
 			for _, f := range tt.attachments {
 				attachments = append(attachments, &File{Name: f})
 			}
-			m.SetAttachements(attachments)
+			m.SetAttachments(attachments)
 			if len(m.attachments) != len(attachments) {
 				t.Errorf("SetAttachements() failed. Number of attachments files expected: %d, got: %d",
 					len(attachments), len(m.attachments))


### PR DESCRIPTION
The method `SetAttachements` is probably a typo: In all other methods it's correctly written "Attachments", so this method should be aligned.