### PR TITLE
Improved error handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -798,13 +798,17 @@ func (c *Client) sendSingleMsg(message *Msg) error {
 	}
 	from, err := message.GetSender(false)
 	if err != nil {
-		return &SendError{Reason: ErrGetSender, errlist: []error{err}, isTemp: isTempError(err),
-			affectedMsg: message}
+		return &SendError{
+			Reason: ErrGetSender, errlist: []error{err}, isTemp: isTempError(err),
+			affectedMsg: message,
+		}
 	}
 	rcpts, err := message.GetRecipients()
 	if err != nil {
-		return &SendError{Reason: ErrGetRcpts, errlist: []error{err}, isTemp: isTempError(err),
-			affectedMsg: message}
+		return &SendError{
+			Reason: ErrGetRcpts, errlist: []error{err}, isTemp: isTempError(err),
+			affectedMsg: message,
+		}
 	}
 
 	if c.dsn {
@@ -813,8 +817,10 @@ func (c *Client) sendSingleMsg(message *Msg) error {
 		}
 	}
 	if err = c.smtpClient.Mail(from); err != nil {
-		retError := &SendError{Reason: ErrSMTPMailFrom, errlist: []error{err}, isTemp: isTempError(err),
-			affectedMsg: message}
+		retError := &SendError{
+			Reason: ErrSMTPMailFrom, errlist: []error{err}, isTemp: isTempError(err),
+			affectedMsg: message,
+		}
 		if resetSendErr := c.smtpClient.Reset(); resetSendErr != nil {
 			retError.errlist = append(retError.errlist, resetSendErr)
 		}
@@ -843,28 +849,38 @@ func (c *Client) sendSingleMsg(message *Msg) error {
 	}
 	writer, err := c.smtpClient.Data()
 	if err != nil {
-		return &SendError{Reason: ErrSMTPData, errlist: []error{err}, isTemp: isTempError(err),
-			affectedMsg: message}
+		return &SendError{
+			Reason: ErrSMTPData, errlist: []error{err}, isTemp: isTempError(err),
+			affectedMsg: message,
+		}
 	}
 	_, err = message.WriteTo(writer)
 	if err != nil {
-		return &SendError{Reason: ErrWriteContent, errlist: []error{err}, isTemp: isTempError(err),
-			affectedMsg: message}
+		return &SendError{
+			Reason: ErrWriteContent, errlist: []error{err}, isTemp: isTempError(err),
+			affectedMsg: message,
+		}
 	}
 	message.isDelivered = true
 
 	if err = writer.Close(); err != nil {
-		return &SendError{Reason: ErrSMTPDataClose, errlist: []error{err}, isTemp: isTempError(err),
-			affectedMsg: message}
+		return &SendError{
+			Reason: ErrSMTPDataClose, errlist: []error{err}, isTemp: isTempError(err),
+			affectedMsg: message,
+		}
 	}
 
 	if err = c.Reset(); err != nil {
-		return &SendError{Reason: ErrSMTPReset, errlist: []error{err}, isTemp: isTempError(err),
-			affectedMsg: message}
+		return &SendError{
+			Reason: ErrSMTPReset, errlist: []error{err}, isTemp: isTempError(err),
+			affectedMsg: message,
+		}
 	}
 	if err = c.checkConn(); err != nil {
-		return &SendError{Reason: ErrConnCheck, errlist: []error{err}, isTemp: isTempError(err),
-			affectedMsg: message}
+		return &SendError{
+			Reason: ErrConnCheck, errlist: []error{err}, isTemp: isTempError(err),
+			affectedMsg: message,
+		}
 	}
 	return nil
 }

--- a/client.go
+++ b/client.go
@@ -787,3 +787,78 @@ func (c *Client) auth() error {
 	}
 	return nil
 }
+
+// sendSingleMsg sends out a single message and returns an error if the transmission/delivery fails.
+// It is invoked by the public Send methods
+func (c *Client) sendSingleMsg(message *Msg) error {
+	if message.encoding == NoEncoding {
+		if ok, _ := c.smtpClient.Extension("8BITMIME"); !ok {
+			return &SendError{Reason: ErrNoUnencoded, isTemp: false}
+		}
+	}
+	from, err := message.GetSender(false)
+	if err != nil {
+		return &SendError{Reason: ErrGetSender, errlist: []error{err}, isTemp: isTempError(err),
+			affectedMsg: message}
+	}
+	rcpts, err := message.GetRecipients()
+	if err != nil {
+		return &SendError{Reason: ErrGetRcpts, errlist: []error{err}, isTemp: isTempError(err),
+			affectedMsg: message}
+	}
+
+	if c.dsn {
+		if c.dsnmrtype != "" {
+			c.smtpClient.SetDSNMailReturnOption(string(c.dsnmrtype))
+		}
+	}
+	if err = c.smtpClient.Mail(from); err != nil {
+		retError := &SendError{Reason: ErrSMTPMailFrom, errlist: []error{err}, isTemp: isTempError(err)}
+		if resetSendErr := c.smtpClient.Reset(); resetSendErr != nil {
+			retError.errlist = append(retError.errlist, resetSendErr)
+		}
+		return retError
+	}
+	hasError := false
+	rcptSendErr := &SendError{}
+	rcptSendErr.errlist = make([]error, 0)
+	rcptSendErr.rcpt = make([]string, 0)
+	rcptNotifyOpt := strings.Join(c.dsnrntype, ",")
+	c.smtpClient.SetDSNRcptNotifyOption(rcptNotifyOpt)
+	for _, rcpt := range rcpts {
+		if err = c.smtpClient.Rcpt(rcpt); err != nil {
+			rcptSendErr.Reason = ErrSMTPRcptTo
+			rcptSendErr.errlist = append(rcptSendErr.errlist, err)
+			rcptSendErr.rcpt = append(rcptSendErr.rcpt, rcpt)
+			rcptSendErr.isTemp = isTempError(err)
+			hasError = true
+		}
+	}
+	if hasError {
+		if resetSendErr := c.smtpClient.Reset(); resetSendErr != nil {
+			rcptSendErr.errlist = append(rcptSendErr.errlist, resetSendErr)
+		}
+		return rcptSendErr
+	}
+	writer, err := c.smtpClient.Data()
+	if err != nil {
+		return &SendError{Reason: ErrSMTPData, errlist: []error{err}, isTemp: isTempError(err)}
+	}
+	_, err = message.WriteTo(writer)
+	if err != nil {
+		return &SendError{Reason: ErrWriteContent, errlist: []error{err}, isTemp: isTempError(err)}
+	}
+	message.isDelivered = true
+
+	if err = writer.Close(); err != nil {
+		return &SendError{Reason: ErrSMTPDataClose, errlist: []error{err}, isTemp: isTempError(err)}
+	}
+
+	if err = c.Reset(); err != nil {
+		return &SendError{Reason: ErrSMTPReset, errlist: []error{err}, isTemp: isTempError(err)}
+	}
+	if err = c.checkConn(); err != nil {
+		return &SendError{Reason: ErrConnCheck, errlist: []error{err}, isTemp: isTempError(err)}
+	}
+	return nil
+}

--- a/client_119.go
+++ b/client_119.go
@@ -9,8 +9,8 @@ package mail
 
 // Send sends out the mail message
 func (c *Client) Send(messages ...*Msg) error {
-	if cerr := c.checkConn(); cerr != nil {
-		return &SendError{Reason: ErrConnCheck, errlist: []error{cerr}, isTemp: isTempError(cerr)}
+	if err := c.checkConn(); err != nil {
+		return &SendError{Reason: ErrConnCheck, errlist: []error{err}, isTemp: isTempError(err)}
 	}
 	var errs []*SendError
 	for _, message := range messages {

--- a/client_119.go
+++ b/client_119.go
@@ -7,8 +7,6 @@
 
 package mail
 
-import "strings"
-
 // Send sends out the mail message
 func (c *Client) Send(messages ...*Msg) error {
 	if cerr := c.checkConn(); cerr != nil {
@@ -16,101 +14,9 @@ func (c *Client) Send(messages ...*Msg) error {
 	}
 	var errs []*SendError
 	for _, message := range messages {
-		message.sendError = nil
-		if message.encoding == NoEncoding {
-			if ok, _ := c.smtpClient.Extension("8BITMIME"); !ok {
-				sendErr := &SendError{Reason: ErrNoUnencoded, isTemp: false}
-				message.sendError = sendErr
-				errs = append(errs, sendErr)
-				continue
-			}
-		}
-		from, err := message.GetSender(false)
-		if err != nil {
-			sendErr := &SendError{Reason: ErrGetSender, errlist: []error{err}, isTemp: isTempError(err)}
-			message.sendError = sendErr
+		if sendErr := c.sendSingleMsg(message); sendErr != nil {
+			messages[id].sendError = sendErr
 			errs = append(errs, sendErr)
-			continue
-		}
-		rcpts, err := message.GetRecipients()
-		if err != nil {
-			sendErr := &SendError{Reason: ErrGetRcpts, errlist: []error{err}, isTemp: isTempError(err)}
-			message.sendError = sendErr
-			errs = append(errs, sendErr)
-			continue
-		}
-
-		if c.dsn {
-			if c.dsnmrtype != "" {
-				c.smtpClient.SetDSNMailReturnOption(string(c.dsnmrtype))
-			}
-		}
-		if err = c.smtpClient.Mail(from); err != nil {
-			sendErr := &SendError{Reason: ErrSMTPMailFrom, errlist: []error{err}, isTemp: isTempError(err)}
-			if resetSendErr := c.smtpClient.Reset(); resetSendErr != nil {
-				sendErr.errlist = append(sendErr.errlist, resetSendErr)
-			}
-			message.sendError = sendErr
-			errs = append(errs, sendErr)
-			continue
-		}
-		failed := false
-		rcptSendErr := &SendError{}
-		rcptSendErr.errlist = make([]error, 0)
-		rcptSendErr.rcpt = make([]string, 0)
-		rcptNotifyOpt := strings.Join(c.dsnrntype, ",")
-		c.smtpClient.SetDSNRcptNotifyOption(rcptNotifyOpt)
-		for _, rcpt := range rcpts {
-			if err = c.smtpClient.Rcpt(rcpt); err != nil {
-				rcptSendErr.Reason = ErrSMTPRcptTo
-				rcptSendErr.errlist = append(rcptSendErr.errlist, err)
-				rcptSendErr.rcpt = append(rcptSendErr.rcpt, rcpt)
-				rcptSendErr.isTemp = isTempError(err)
-				failed = true
-			}
-		}
-		if failed {
-			if resetSendErr := c.smtpClient.Reset(); resetSendErr != nil {
-				rcptSendErr.errlist = append(rcptSendErr.errlist, err)
-			}
-			message.sendError = rcptSendErr
-			errs = append(errs, rcptSendErr)
-			continue
-		}
-		writer, err := c.smtpClient.Data()
-		if err != nil {
-			sendErr := &SendError{Reason: ErrSMTPData, errlist: []error{err}, isTemp: isTempError(err)}
-			message.sendError = sendErr
-			errs = append(errs, sendErr)
-			continue
-		}
-		_, err = message.WriteTo(writer)
-		if err != nil {
-			sendErr := &SendError{Reason: ErrWriteContent, errlist: []error{err}, isTemp: isTempError(err)}
-			message.sendError = sendErr
-			errs = append(errs, sendErr)
-			continue
-		}
-		message.isDelivered = true
-
-		if err = writer.Close(); err != nil {
-			sendErr := &SendError{Reason: ErrSMTPDataClose, errlist: []error{err}, isTemp: isTempError(err)}
-			message.sendError = sendErr
-			errs = append(errs, sendErr)
-			continue
-		}
-
-		if err = c.Reset(); err != nil {
-			sendErr := &SendError{Reason: ErrSMTPReset, errlist: []error{err}, isTemp: isTempError(err)}
-			message.sendError = sendErr
-			errs = append(errs, sendErr)
-			continue
-		}
-		if err = c.checkConn(); err != nil {
-			sendErr := &SendError{Reason: ErrConnCheck, errlist: []error{err}, isTemp: isTempError(err)}
-			message.sendError = sendErr
-			errs = append(errs, sendErr)
-			continue
 		}
 	}
 

--- a/client_120.go
+++ b/client_120.go
@@ -18,25 +18,33 @@ func (c *Client) Send(messages ...*Msg) (returnErr error) {
 		returnErr = &SendError{Reason: ErrConnCheck, errlist: []error{err}, isTemp: isTempError(err)}
 		return
 	}
-	for _, message := range messages {
+
+	var errs []error
+	defer func() {
+		returnErr = errors.Join(errs...)
+	}()
+
+	for msgid, message := range messages {
 		message.sendError = nil
 		if message.encoding == NoEncoding {
 			if ok, _ := c.smtpClient.Extension("8BITMIME"); !ok {
 				message.sendError = &SendError{Reason: ErrNoUnencoded, isTemp: false}
-				returnErr = errors.Join(returnErr, message.sendError)
+				errs = append(errs, message.sendError)
 				continue
 			}
 		}
 		from, err := message.GetSender(false)
 		if err != nil {
-			message.sendError = &SendError{Reason: ErrGetSender, errlist: []error{err}, isTemp: isTempError(err)}
-			returnErr = errors.Join(returnErr, message.sendError)
+			message.sendError = &SendError{Reason: ErrGetSender, errlist: []error{err}, isTemp: isTempError(err),
+				affectedMsg: messages[msgid]}
+			errs = append(errs, message.sendError)
 			continue
 		}
 		rcpts, err := message.GetRecipients()
 		if err != nil {
-			message.sendError = &SendError{Reason: ErrGetRcpts, errlist: []error{err}, isTemp: isTempError(err)}
-			returnErr = errors.Join(returnErr, message.sendError)
+			message.sendError = &SendError{Reason: ErrGetRcpts, errlist: []error{err}, isTemp: isTempError(err),
+				affectedMsg: messages[msgid]}
+			errs = append(errs, message.sendError)
 			continue
 		}
 
@@ -47,9 +55,9 @@ func (c *Client) Send(messages ...*Msg) (returnErr error) {
 		}
 		if err = c.smtpClient.Mail(from); err != nil {
 			message.sendError = &SendError{Reason: ErrSMTPMailFrom, errlist: []error{err}, isTemp: isTempError(err)}
-			returnErr = errors.Join(returnErr, message.sendError)
+			errs = append(errs, message.sendError)
 			if resetSendErr := c.smtpClient.Reset(); resetSendErr != nil {
-				returnErr = errors.Join(returnErr, resetSendErr)
+				errs = append(errs, resetSendErr)
 			}
 			continue
 		}
@@ -70,40 +78,40 @@ func (c *Client) Send(messages ...*Msg) (returnErr error) {
 		}
 		if failed {
 			if resetSendErr := c.smtpClient.Reset(); resetSendErr != nil {
-				returnErr = errors.Join(returnErr, resetSendErr)
+				errs = append(errs, resetSendErr)
 			}
 			message.sendError = rcptSendErr
-			returnErr = errors.Join(returnErr, message.sendError)
+			errs = append(errs, message.sendError)
 			continue
 		}
 		writer, err := c.smtpClient.Data()
 		if err != nil {
 			message.sendError = &SendError{Reason: ErrSMTPData, errlist: []error{err}, isTemp: isTempError(err)}
-			returnErr = errors.Join(returnErr, message.sendError)
+			errs = append(errs, message.sendError)
 			continue
 		}
 		_, err = message.WriteTo(writer)
 		if err != nil {
 			message.sendError = &SendError{Reason: ErrWriteContent, errlist: []error{err}, isTemp: isTempError(err)}
-			returnErr = errors.Join(returnErr, message.sendError)
+			errs = append(errs, message.sendError)
 			continue
 		}
 		message.isDelivered = true
 
 		if err = writer.Close(); err != nil {
 			message.sendError = &SendError{Reason: ErrSMTPDataClose, errlist: []error{err}, isTemp: isTempError(err)}
-			returnErr = errors.Join(returnErr, message.sendError)
+			errs = append(errs, message.sendError)
 			continue
 		}
 
 		if err = c.Reset(); err != nil {
 			message.sendError = &SendError{Reason: ErrSMTPReset, errlist: []error{err}, isTemp: isTempError(err)}
-			returnErr = errors.Join(returnErr, message.sendError)
+			errs = append(errs, message.sendError)
 			continue
 		}
 		if err = c.checkConn(); err != nil {
 			message.sendError = &SendError{Reason: ErrConnCheck, errlist: []error{err}, isTemp: isTempError(err)}
-			returnErr = errors.Join(returnErr, message.sendError)
+			errs = append(errs, message.sendError)
 		}
 	}
 

--- a/client_120.go
+++ b/client_120.go
@@ -9,7 +9,6 @@ package mail
 
 import (
 	"errors"
-	"strings"
 )
 
 // Send sends out the mail message
@@ -32,79 +31,4 @@ func (c *Client) Send(messages ...*Msg) (returnErr error) {
 	}
 
 	return
-}
-
-// sendSingleMsg sends out a single message and returns an error if the transmission/delivery fails.
-// It is invoked by the public Send methods
-func (c *Client) sendSingleMsg(message *Msg) error {
-	if message.encoding == NoEncoding {
-		if ok, _ := c.smtpClient.Extension("8BITMIME"); !ok {
-			return &SendError{Reason: ErrNoUnencoded, isTemp: false}
-		}
-	}
-	from, err := message.GetSender(false)
-	if err != nil {
-		return &SendError{Reason: ErrGetSender, errlist: []error{err}, isTemp: isTempError(err),
-			affectedMsg: message}
-	}
-	rcpts, err := message.GetRecipients()
-	if err != nil {
-		return &SendError{Reason: ErrGetRcpts, errlist: []error{err}, isTemp: isTempError(err),
-			affectedMsg: message}
-	}
-
-	if c.dsn {
-		if c.dsnmrtype != "" {
-			c.smtpClient.SetDSNMailReturnOption(string(c.dsnmrtype))
-		}
-	}
-	if err = c.smtpClient.Mail(from); err != nil {
-		retError := &SendError{Reason: ErrSMTPMailFrom, errlist: []error{err}, isTemp: isTempError(err)}
-		if resetSendErr := c.smtpClient.Reset(); resetSendErr != nil {
-			retError.errlist = append(retError.errlist, resetSendErr)
-		}
-		return retError
-	}
-	hasError := false
-	rcptSendErr := &SendError{}
-	rcptSendErr.errlist = make([]error, 0)
-	rcptSendErr.rcpt = make([]string, 0)
-	rcptNotifyOpt := strings.Join(c.dsnrntype, ",")
-	c.smtpClient.SetDSNRcptNotifyOption(rcptNotifyOpt)
-	for _, rcpt := range rcpts {
-		if err = c.smtpClient.Rcpt(rcpt); err != nil {
-			rcptSendErr.Reason = ErrSMTPRcptTo
-			rcptSendErr.errlist = append(rcptSendErr.errlist, err)
-			rcptSendErr.rcpt = append(rcptSendErr.rcpt, rcpt)
-			rcptSendErr.isTemp = isTempError(err)
-			hasError = true
-		}
-	}
-	if hasError {
-		if resetSendErr := c.smtpClient.Reset(); resetSendErr != nil {
-			rcptSendErr.errlist = append(rcptSendErr.errlist, resetSendErr)
-		}
-		return rcptSendErr
-	}
-	writer, err := c.smtpClient.Data()
-	if err != nil {
-		return &SendError{Reason: ErrSMTPData, errlist: []error{err}, isTemp: isTempError(err)}
-	}
-	_, err = message.WriteTo(writer)
-	if err != nil {
-		return &SendError{Reason: ErrWriteContent, errlist: []error{err}, isTemp: isTempError(err)}
-	}
-	message.isDelivered = true
-
-	if err = writer.Close(); err != nil {
-		return &SendError{Reason: ErrSMTPDataClose, errlist: []error{err}, isTemp: isTempError(err)}
-	}
-
-	if err = c.Reset(); err != nil {
-		return &SendError{Reason: ErrSMTPReset, errlist: []error{err}, isTemp: isTempError(err)}
-	}
-	if err = c.checkConn(); err != nil {
-		return &SendError{Reason: ErrConnCheck, errlist: []error{err}, isTemp: isTempError(err)}
-	}
-	return nil
 }

--- a/client_120.go
+++ b/client_120.go
@@ -65,7 +65,7 @@ func (c *Client) sendSingleMsg(message *Msg) error {
 		}
 		return retError
 	}
-	failed := false
+	hasError := false
 	rcptSendErr := &SendError{}
 	rcptSendErr.errlist = make([]error, 0)
 	rcptSendErr.rcpt = make([]string, 0)
@@ -77,10 +77,10 @@ func (c *Client) sendSingleMsg(message *Msg) error {
 			rcptSendErr.errlist = append(rcptSendErr.errlist, err)
 			rcptSendErr.rcpt = append(rcptSendErr.rcpt, rcpt)
 			rcptSendErr.isTemp = isTempError(err)
-			failed = true
+			hasError = true
 		}
 	}
-	if failed {
+	if hasError {
 		if resetSendErr := c.smtpClient.Reset(); resetSendErr != nil {
 			rcptSendErr.errlist = append(rcptSendErr.errlist, resetSendErr)
 		}

--- a/client_120.go
+++ b/client_120.go
@@ -24,9 +24,9 @@ func (c *Client) Send(messages ...*Msg) (returnErr error) {
 		returnErr = errors.Join(errs...)
 	}()
 
-	for _, message := range messages {
+	for id, message := range messages {
 		if sendErr := c.sendSingleMsg(message); sendErr != nil {
-			message.sendError = sendErr
+			messages[id].sendError = sendErr
 			errs = append(errs, sendErr)
 		}
 	}

--- a/msg.go
+++ b/msg.go
@@ -476,6 +476,17 @@ func (m *Msg) SetMessageID() {
 	m.SetMessageIDWithValue(messageID)
 }
 
+// GetMessageID returns the message ID of the Msg as string value. If no message ID
+// is set, an empty string will be returned
+func (m *Msg) GetMessageID() string {
+	if msgidheader, ok := m.genHeader[HeaderMessageID]; ok {
+		if len(msgidheader) > 0 {
+			return msgidheader[0]
+		}
+	}
+	return ""
+}
+
 // SetMessageIDWithValue sets the message id for the mail
 func (m *Msg) SetMessageIDWithValue(messageID string) {
 	m.SetGenHeader(HeaderMessageID, fmt.Sprintf("<%s>", messageID))

--- a/msg_test.go
+++ b/msg_test.go
@@ -805,6 +805,21 @@ func TestMsg_SetMessageIDRandomness(t *testing.T) {
 	}
 }
 
+func TestMsg_GetMessageID(t *testing.T) {
+	expected := "this.is.a.message.id"
+	msg := NewMsg()
+	msg.SetMessageIDWithValue(expected)
+	val := msg.GetMessageID()
+	if !strings.EqualFold(val, fmt.Sprintf("<%s>", expected)) {
+		t.Errorf("GetMessageID() failed. Expected: %s, got: %s", fmt.Sprintf("<%s>", expected), val)
+	}
+	msg.genHeader[HeaderMessageID] = nil
+	val = msg.GetMessageID()
+	if val != "" {
+		t.Errorf("GetMessageID() failed. Expected empty string, got: %s", val)
+	}
+}
+
 // TestMsg_FromFormat tests the FromFormat and EnvelopeFrom methods for the Msg object
 func TestMsg_FromFormat(t *testing.T) {
 	tests := []struct {

--- a/senderror.go
+++ b/senderror.go
@@ -56,10 +56,11 @@ const (
 
 // SendError is an error wrapper for delivery errors of the Msg
 type SendError struct {
-	Reason  SendErrReason
-	isTemp  bool
-	errlist []error
-	rcpt    []string
+	affectedMsg *Msg
+	errlist     []error
+	isTemp      bool
+	rcpt        []string
+	Reason      SendErrReason
 }
 
 // SendErrReason represents a comparable reason on why the delivery failed

--- a/senderror.go
+++ b/senderror.go
@@ -93,6 +93,11 @@ func (e *SendError) Error() string {
 			}
 		}
 	}
+	if e.affectedMsg != nil && e.affectedMsg.GetMessageID() != "" {
+		errMessage.WriteString(", affected message ID: ")
+		errMessage.WriteString(e.affectedMsg.GetMessageID())
+	}
+
 	return errMessage.String()
 }
 

--- a/senderror_test.go
+++ b/senderror_test.go
@@ -83,6 +83,13 @@ func TestSendError_IsTemp(t *testing.T) {
 	}
 }
 
+func TestSendError_IsTempNil(t *testing.T) {
+	var se *SendError
+	if se.IsTemp() {
+		t.Error("expected false on nil-senderror")
+	}
+}
+
 // returnSendError is a helper method to retunr a SendError with a specific reason
 func returnSendError(r SendErrReason, t bool) error {
 	return &SendError{Reason: r, isTemp: t}


### PR DESCRIPTION
The error handling was refactored in accordance to #168. Errors are not nested into each other anymore. The send logic for a single message has been moved to the non-version-specific Client.go while the version-specific only handle multi-message handling and error combination. Error messages now also refer to a message ID of the message that failed (if present), for easier debugging.

This PR closes #168 