### PR TITLE
Improved client error testing

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.20', '1.21', '1.22', '1.23']
+        go: ['1.19', '1.20', '1.23']
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1

--- a/client_119.go
+++ b/client_119.go
@@ -7,16 +7,22 @@
 
 package mail
 
+import "errors"
+
 // Send sends out the mail message
 func (c *Client) Send(messages ...*Msg) error {
 	if err := c.checkConn(); err != nil {
 		return &SendError{Reason: ErrConnCheck, errlist: []error{err}, isTemp: isTempError(err)}
 	}
 	var errs []*SendError
-	for _, message := range messages {
+	for id, message := range messages {
 		if sendErr := c.sendSingleMsg(message); sendErr != nil {
 			messages[id].sendError = sendErr
-			errs = append(errs, sendErr)
+
+			var msgSendErr *SendError
+			if errors.As(sendErr, &msgSendErr) {
+				errs = append(errs, msgSendErr)
+			}
 		}
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -1270,7 +1270,7 @@ func TestClient_SendErrorNoEncoding(t *testing.T) {
 			return
 		}
 	}()
-	time.Sleep(time.Millisecond * 300) // wait until tcp server has been settled
+	time.Sleep(time.Millisecond * 300)
 
 	message := NewMsg()
 	if err := message.From("valid-from@domain.tld"); err != nil {
@@ -1336,7 +1336,7 @@ func TestClient_SendErrorMailFrom(t *testing.T) {
 			return
 		}
 	}()
-	time.Sleep(time.Millisecond * 300) // wait until tcp server has been settled
+	time.Sleep(time.Millisecond * 300)
 
 	message := NewMsg()
 	if err := message.From("invalid-from@domain.tld"); err != nil {
@@ -1401,7 +1401,7 @@ func TestClient_SendErrorMailFromReset(t *testing.T) {
 			return
 		}
 	}()
-	time.Sleep(time.Millisecond * 300) // wait until tcp server has been settled
+	time.Sleep(time.Millisecond * 300)
 
 	message := NewMsg()
 	if err := message.From("invalid-from@domain.tld"); err != nil {
@@ -1475,7 +1475,7 @@ func TestClient_SendErrorToReset(t *testing.T) {
 			return
 		}
 	}()
-	time.Sleep(time.Millisecond * 300) // wait until tcp server has been settled
+	time.Sleep(time.Millisecond * 300)
 
 	message := NewMsg()
 	if err := message.From("valid-from@domain.tld"); err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -2097,7 +2097,7 @@ func handleTestServerConnection(connection net.Conn, featureSet string, failRese
 	for {
 		data, err = reader.ReadString('\n')
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			fmt.Println("Error reading data:", err)
@@ -2158,17 +2158,14 @@ func handleTestServerConnection(connection net.Conn, featureSet string, failRese
 		case strings.EqualFold(data, "noop"),
 			strings.EqualFold(data, "vrfy"):
 			writeOK()
-			break
 		case strings.EqualFold(data, "rset"):
 			if failReset {
 				_ = writeLine("500 5.1.2 Error: reset failed")
 				break
 			}
 			writeOK()
-			break
 		case strings.EqualFold(data, "quit"):
 			_ = writeLine("221 2.0.0 Bye")
-			break
 		default:
 			_ = writeLine("500 5.5.2 Error: bad syntax")
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -31,8 +31,8 @@ const (
 	TestServerProto = "tcp"
 	// TestServerAddr is the address the simple SMTP test server listens on
 	TestServerAddr = "127.0.0.1"
-	// TestServerPort is the port the simple SMTP test server listens on
-	TestServerPort = 2526
+	// TestServerPortBase is the base port for the simple SMTP test server
+	TestServerPortBase = 2025
 )
 
 // TestNewClient tests the NewClient() method with its default options
@@ -1264,8 +1264,9 @@ func TestClient_SendErrorNoEncoding(t *testing.T) {
 	defer cancel()
 
 	featureSet := "250-AUTH PLAIN\r\n250-DSN\r\n250 SMTPUTF8"
+	serverPort := TestServerPortBase + 1
 	go func() {
-		if err := simpleSMTPServer(ctx, featureSet, false); err != nil {
+		if err := simpleSMTPServer(ctx, featureSet, false, serverPort); err != nil {
 			t.Errorf("failed to start test server: %s", err)
 			return
 		}
@@ -1286,7 +1287,7 @@ func TestClient_SendErrorNoEncoding(t *testing.T) {
 	message.SetMessageIDWithValue("this.is.a.message.id")
 	message.SetEncoding(NoEncoding)
 
-	client, err := NewClient(TestServerAddr, WithPort(TestServerPort),
+	client, err := NewClient(TestServerAddr, WithPort(serverPort),
 		WithTLSPortPolicy(NoTLS), WithSMTPAuth(SMTPAuthPlain),
 		WithUsername("toni@tester.com"),
 		WithPassword("V3ryS3cr3t+"))
@@ -1329,9 +1330,10 @@ func TestClient_SendErrorMailFrom(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	serverPort := TestServerPortBase + 2
 	featureSet := "250-AUTH PLAIN\r\n250-8BITMIME\r\n250-DSN\r\n250 SMTPUTF8"
 	go func() {
-		if err := simpleSMTPServer(ctx, featureSet, false); err != nil {
+		if err := simpleSMTPServer(ctx, featureSet, false, serverPort); err != nil {
 			t.Errorf("failed to start test server: %s", err)
 			return
 		}
@@ -1351,7 +1353,7 @@ func TestClient_SendErrorMailFrom(t *testing.T) {
 	message.SetBodyString(TypeTextPlain, "Test body")
 	message.SetMessageIDWithValue("this.is.a.message.id")
 
-	client, err := NewClient(TestServerAddr, WithPort(TestServerPort),
+	client, err := NewClient(TestServerAddr, WithPort(serverPort),
 		WithTLSPortPolicy(NoTLS), WithSMTPAuth(SMTPAuthPlain),
 		WithUsername("toni@tester.com"),
 		WithPassword("V3ryS3cr3t+"))
@@ -1394,9 +1396,10 @@ func TestClient_SendErrorMailFromReset(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	serverPort := TestServerPortBase + 3
 	featureSet := "250-AUTH PLAIN\r\n250-8BITMIME\r\n250-DSN\r\n250 SMTPUTF8"
 	go func() {
-		if err := simpleSMTPServer(ctx, featureSet, true); err != nil {
+		if err := simpleSMTPServer(ctx, featureSet, true, serverPort); err != nil {
 			t.Errorf("failed to start test server: %s", err)
 			return
 		}
@@ -1416,7 +1419,7 @@ func TestClient_SendErrorMailFromReset(t *testing.T) {
 	message.SetBodyString(TypeTextPlain, "Test body")
 	message.SetMessageIDWithValue("this.is.a.message.id")
 
-	client, err := NewClient(TestServerAddr, WithPort(TestServerPort),
+	client, err := NewClient(TestServerAddr, WithPort(serverPort),
 		WithTLSPortPolicy(NoTLS), WithSMTPAuth(SMTPAuthPlain),
 		WithUsername("toni@tester.com"),
 		WithPassword("V3ryS3cr3t+"))
@@ -1468,9 +1471,10 @@ func TestClient_SendErrorToReset(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	serverPort := TestServerPortBase + 4
 	featureSet := "250-AUTH PLAIN\r\n250-8BITMIME\r\n250-DSN\r\n250 SMTPUTF8"
 	go func() {
-		if err := simpleSMTPServer(ctx, featureSet, true); err != nil {
+		if err := simpleSMTPServer(ctx, featureSet, true, serverPort); err != nil {
 			t.Errorf("failed to start test server: %s", err)
 			return
 		}
@@ -1490,7 +1494,7 @@ func TestClient_SendErrorToReset(t *testing.T) {
 	message.SetBodyString(TypeTextPlain, "Test body")
 	message.SetMessageIDWithValue("this.is.a.message.id")
 
-	client, err := NewClient(TestServerAddr, WithPort(TestServerPort),
+	client, err := NewClient(TestServerAddr, WithPort(serverPort),
 		WithTLSPortPolicy(NoTLS), WithSMTPAuth(SMTPAuthPlain),
 		WithUsername("toni@tester.com"),
 		WithPassword("V3ryS3cr3t+"))
@@ -1542,9 +1546,10 @@ func TestClient_SendErrorDataClose(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	serverPort := TestServerPortBase + 5
 	featureSet := "250-AUTH PLAIN\r\n250-8BITMIME\r\n250-DSN\r\n250 SMTPUTF8"
 	go func() {
-		if err := simpleSMTPServer(ctx, featureSet, false); err != nil {
+		if err := simpleSMTPServer(ctx, featureSet, false, serverPort); err != nil {
 			t.Errorf("failed to start test server: %s", err)
 			return
 		}
@@ -1564,7 +1569,7 @@ func TestClient_SendErrorDataClose(t *testing.T) {
 	message.SetBodyString(TypeTextPlain, "DATA close should fail")
 	message.SetMessageIDWithValue("this.is.a.message.id")
 
-	client, err := NewClient(TestServerAddr, WithPort(TestServerPort),
+	client, err := NewClient(TestServerAddr, WithPort(serverPort),
 		WithTLSPortPolicy(NoTLS), WithSMTPAuth(SMTPAuthPlain),
 		WithUsername("toni@tester.com"),
 		WithPassword("V3ryS3cr3t+"))
@@ -1604,9 +1609,10 @@ func TestClient_SendErrorDataWrite(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	serverPort := TestServerPortBase + 6
 	featureSet := "250-AUTH PLAIN\r\n250-8BITMIME\r\n250-DSN\r\n250 SMTPUTF8"
 	go func() {
-		if err := simpleSMTPServer(ctx, featureSet, false); err != nil {
+		if err := simpleSMTPServer(ctx, featureSet, false, serverPort); err != nil {
 			t.Errorf("failed to start test server: %s", err)
 			return
 		}
@@ -1627,7 +1633,7 @@ func TestClient_SendErrorDataWrite(t *testing.T) {
 	message.SetMessageIDWithValue("this.is.a.message.id")
 	message.SetGenHeader("X-Test-Header", "DATA write should fail")
 
-	client, err := NewClient(TestServerAddr, WithPort(TestServerPort),
+	client, err := NewClient(TestServerAddr, WithPort(serverPort),
 		WithTLSPortPolicy(NoTLS), WithSMTPAuth(SMTPAuthPlain),
 		WithUsername("toni@tester.com"),
 		WithPassword("V3ryS3cr3t+"))
@@ -1657,19 +1663,16 @@ func TestClient_SendErrorDataWrite(t *testing.T) {
 				sendErr.MessageID())
 		}
 	}
-
-	if err = client.Close(); err != nil {
-		t.Errorf("failed to close server connection: %s", err)
-	}
 }
 
 func TestClient_SendErrorReset(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	serverPort := TestServerPortBase + 7
 	featureSet := "250-AUTH PLAIN\r\n250-8BITMIME\r\n250-DSN\r\n250 SMTPUTF8"
 	go func() {
-		if err := simpleSMTPServer(ctx, featureSet, true); err != nil {
+		if err := simpleSMTPServer(ctx, featureSet, true, serverPort); err != nil {
 			t.Errorf("failed to start test server: %s", err)
 			return
 		}
@@ -1689,7 +1692,7 @@ func TestClient_SendErrorReset(t *testing.T) {
 	message.SetBodyString(TypeTextPlain, "Test body")
 	message.SetMessageIDWithValue("this.is.a.message.id")
 
-	client, err := NewClient(TestServerAddr, WithPort(TestServerPort),
+	client, err := NewClient(TestServerAddr, WithPort(serverPort),
 		WithTLSPortPolicy(NoTLS), WithSMTPAuth(SMTPAuthPlain),
 		WithUsername("toni@tester.com"),
 		WithPassword("V3ryS3cr3t+"))
@@ -2023,8 +2026,8 @@ func (f faker) SetWriteDeadline(time.Time) error { return nil }
 // simpleSMTPServer starts a simple TCP server that resonds to SMTP commands.
 // The provided featureSet represents in what the server responds to EHLO command
 // failReset controls if a RSET succeeds
-func simpleSMTPServer(ctx context.Context, featureSet string, failReset bool) error {
-	listener, err := net.Listen(TestServerProto, fmt.Sprintf("%s:%d", TestServerAddr, TestServerPort))
+func simpleSMTPServer(ctx context.Context, featureSet string, failReset bool, port int) error {
+	listener, err := net.Listen(TestServerProto, fmt.Sprintf("%s:%d", TestServerAddr, port))
 	if err != nil {
 		return fmt.Errorf("unable to listen on %s://%s: %w", TestServerProto, TestServerAddr, err)
 	}

--- a/senderror.go
+++ b/senderror.go
@@ -118,6 +118,23 @@ func (e *SendError) IsTemp() bool {
 	return e.isTemp
 }
 
+// MessageID returns the message ID of the affected Msg that caused the error
+// If no message ID was set for the Msg, an empty string will be returned
+func (e *SendError) MessageID() string {
+	if e == nil || e.affectedMsg == nil {
+		return ""
+	}
+	return e.affectedMsg.GetMessageID()
+}
+
+// Msg returns the pointer to the affected message that caused the error
+func (e *SendError) Msg() *Msg {
+	if e == nil || e.affectedMsg == nil {
+		return nil
+	}
+	return e.affectedMsg
+}
+
 // String implements the Stringer interface for the SendErrReason
 func (r SendErrReason) String() string {
 	switch r {

--- a/senderror_test.go
+++ b/senderror_test.go
@@ -90,7 +90,55 @@ func TestSendError_IsTempNil(t *testing.T) {
 	}
 }
 
+func TestSendError_MessageID(t *testing.T) {
+	var se *SendError
+	err := returnSendError(ErrAmbiguous, false)
+	if !errors.As(err, &se) {
+		t.Errorf("error mismatch, expected error to be of type *SendError")
+		return
+	}
+	if errors.As(err, &se) {
+		if se.MessageID() == "" {
+			t.Errorf("sendError expected message-id, but got empty string")
+		}
+		if !strings.EqualFold(se.MessageID(), "<this.is.a.message.id>") {
+			t.Errorf("sendError message-id expected: %s, but got: %s", "<this.is.a.message.id>",
+				se.MessageID())
+		}
+	}
+}
+
+func TestSendError_Msg(t *testing.T) {
+	var se *SendError
+	err := returnSendError(ErrAmbiguous, false)
+	if !errors.As(err, &se) {
+		t.Errorf("error mismatch, expected error to be of type *SendError")
+		return
+	}
+	if errors.As(err, &se) {
+		if se.Msg() == nil {
+			t.Errorf("sendError expected msg pointer, but got nil")
+		}
+		from := se.Msg().GetFromString()
+		if len(from) == 0 {
+			t.Errorf("sendError expected msg from, but got empty string")
+			return
+		}
+		if !strings.EqualFold(from[0], "<toni.tester@domain.tld>") {
+			t.Errorf("sendError message from expected: %s, but got: %s", "<toni.tester@domain.tld>",
+				from[0])
+		}
+	}
+}
+
 // returnSendError is a helper method to retunr a SendError with a specific reason
 func returnSendError(r SendErrReason, t bool) error {
-	return &SendError{Reason: r, isTemp: t}
+	message := NewMsg()
+	_ = message.From("toni.tester@domain.tld")
+	_ = message.To("tina.tester@domain.tld")
+	message.Subject("This is the subject")
+	message.SetBodyString(TypeTextPlain, "This is the message body")
+	message.SetMessageIDWithValue("this.is.a.message.id")
+
+	return &SendError{Reason: r, isTemp: t, affectedMsg: message}
 }


### PR DESCRIPTION
This PR introduces a simple test SMTP server that can be used to more granuarly test different error scenarios, that are hard to simulate with a real mail server. More tests for the `Client` have been added as well, these should also test some `SendError` functionality.

Additionally two new `SendError` methods have been added (as suggested by @mitar in https://github.com/wneessen/go-mail/pull/301#issuecomment-2363265243) : 

- `MessageID()`: returns the message ID of the affected `Msg`
- `Msg()`: returns a pointer to the affectes `Msg`
