### PR TITLE
Update test recipient email in client tests

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -27,7 +27,7 @@ const (
 	// DefaultHost is used as default hostname for the Client
 	DefaultHost = "localhost"
 	// TestRcpt is a trash mail address to send test mails to
-	TestRcpt = "go-mail@mytrashmailer.com"
+	TestRcpt = "couttifaddebro-1473@yopmail.com"
 	// TestServerProto is the protocol used for the simple SMTP test server
 	TestServerProto = "tcp"
 	// TestServerAddr is the address the simple SMTP test server listens on


### PR DESCRIPTION
Changed the test email address from go-mail@mytrashmailer.com to couttifaddebro-1473@yopmail.com. This new address is expected to be used for sending test mails.