### PR TITLE
Update GH test workflows

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,12 +14,10 @@ freebsd_task:
         image_family: freebsd-14-0
 
   env:
-    TEST_ALLOW_SEND: 0
     TEST_SKIP_SENDMAIL: 1
 
   pkginstall_script:
-    - pkg update -f
     - pkg install -y go
 
   test_script:
-    - go test -v -race -cover -shuffle=on ./...
+    - go test -race -cover -shuffle=on ./...

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.19', '1.20', '1.23']
+        go: ['1.23']
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1

--- a/.github/workflows/offline-tests.yml
+++ b/.github/workflows/offline-tests.yml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2022 Winni Neessen <winni@neessen.dev>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: Offline tests workflow
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.go'
+      - 'go.*'
+      - '.github/**'
+      - 'codecov.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**.go'
+      - 'go.*'
+      - '.github/**'
+      - 'codecov.yml'
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go: ['1.19', '1.20', '1.21', '1.22', '1.23']
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+      with:
+        egress-policy: audit
+
+    - name: Checkout Code
+      uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
+    - name: Setup go
+      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+      with:
+        go-version: ${{ matrix.go }}
+    - name: Run Tests
+      run: |
+        go test -race -shuffle=on ./...

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -14,17 +14,6 @@ on:
   pull_request:
     branches:
       - main # or the name of your main branch
-env:
-  TEST_HOST: ${{ secrets.TEST_HOST }}
-  TEST_FROM: ${{ secrets.TEST_USER }}
-  TEST_ALLOW_SEND: "1"
-  TEST_SMTPAUTH_USER: ${{ secrets.TEST_USER }}
-  TEST_SMTPAUTH_PASS: ${{ secrets.TEST_PASS }}
-  TEST_SMTPAUTH_TYPE: "LOGIN"
-  TEST_ONLINE_SCRAM: "1"
-  TEST_HOST_SCRAM: ${{ secrets.TEST_HOST_SCRAM }}
-  TEST_USER_SCRAM: ${{ secrets.TEST_USER_SCRAM }}
-  TEST_PASS_SCRAM: ${{ secrets.TEST_PASS_SCRAM }}
 jobs:
   build:
     name: Build
@@ -42,7 +31,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: '1.23.x'
+          go-version: '1.23'
           
       - name: Run unit Tests
         run: |


### PR DESCRIPTION
We are currently running tests for all OS and 3 Go versions with actual connections to real mail servers. These cause a lot of traffic and are therefore much likely to fail due to connection timeouts. The actual online tests are much to redundant right now.

This PR updates the workflow to only run "online" tests on the latest Go version for each of Linux, Windows and MacOS. The Sonarqube test has been converted to "offline" tests as well. Additionally we now run "offline" tests for the latest 4 Go releases on all OSes instead.