### PR TITLE
Update GitHub Actions paths for Go and workflow files

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -10,7 +10,7 @@ on:
     paths:
       - '**.go'
       - 'go.*'
-      - '.github/**'
+      - '.github/workflows/codecov.yml'
       - 'codecov.yml'
   pull_request:
     branches:
@@ -18,7 +18,7 @@ on:
     paths:
       - '**.go'
       - 'go.*'
-      - '.github/**'
+      - '.github/workflows/codecov.yml'
       - 'codecov.yml'
 env:
   TEST_HOST: ${{ secrets.TEST_HOST }}

--- a/.github/workflows/offline-tests.yml
+++ b/.github/workflows/offline-tests.yml
@@ -10,16 +10,14 @@ on:
     paths:
       - '**.go'
       - 'go.*'
-      - '.github/**'
-      - 'codecov.yml'
+      - '.github/workflows/offline-tests.yml'
   pull_request:
     branches:
       - main
     paths:
       - '**.go'
       - 'go.*'
-      - '.github/**'
-      - 'codecov.yml'
+      - '.github/workflows/offline-tests.yml'
 permissions:
   contents: read
 

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -10,10 +10,18 @@ permissions:
 on:
   push:
     branches:
-      - main # or the name of your main branch
+      - main
+    paths:
+      - '**.go'
+      - 'go.*'
+      - '.github/workflows/sonarqube.yml'
   pull_request:
     branches:
-      - main # or the name of your main branch
+      - main
+    paths:
+      - '**.go'
+      - 'go.*'
+      - '.github/workflows/sonarqube.yml'
 jobs:
   build:
     name: Build


### PR DESCRIPTION
This PR refines the paths in GitHub Actions workflows to more precisely track changes in Go-related files and specific workflow files. General `.github/**` paths have been replaced with explicit references to relevant workflow files within `.github/workflows`.