### PR TITLE
Add default SMTP authentication type to NewClient

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -47,7 +47,7 @@ const (
 	// SMTPAuthNoAuth is equivalent to performing no authentication at all. It is a convenience
 	// option and should not be used. Instead, for mail servers that do no support/require
 	// authentication, the Client should not be passed the WithSMTPAuth option at all.
-	SMTPAuthNoAuth SMTPAuthType = ""
+	SMTPAuthNoAuth SMTPAuthType = "NOAUTH"
 
 	// SMTPAuthPlain is the "PLAIN" authentication mechanism as described in RFC 4616.
 	//

--- a/client_test.go
+++ b/client_test.go
@@ -1162,6 +1162,81 @@ func TestClient_Send_withBrokenRecipient(t *testing.T) {
 	}
 }
 
+func TestClient_DialWithContext_switchAuth(t *testing.T) {
+	if os.Getenv("TEST_ALLOW_SEND") == "" {
+		t.Skipf("TEST_ALLOW_SEND is not set. Skipping mail sending test")
+	}
+
+	// We start with no auth explicitly set
+	client, err := NewClient(
+		os.Getenv("TEST_HOST"),
+		WithTLSPortPolicy(TLSMandatory),
+	)
+	defer func() {
+		_ = client.Close()
+	}()
+	if err != nil {
+		t.Errorf("failed to create client: %s", err)
+		return
+	}
+	if err = client.DialWithContext(context.Background()); err != nil {
+		t.Errorf("failed to dial to sending server: %s", err)
+	}
+	if err = client.Close(); err != nil {
+		t.Errorf("failed to close client connection: %s", err)
+	}
+
+	// We switch to LOGIN auth, which the server supports
+	client.SetSMTPAuth(SMTPAuthLogin)
+	client.SetUsername(os.Getenv("TEST_USER"))
+	client.SetPassword(os.Getenv("TEST_PASS"))
+	if err = client.DialWithContext(context.Background()); err != nil {
+		t.Errorf("failed to dial to sending server: %s", err)
+	}
+	if err = client.Close(); err != nil {
+		t.Errorf("failed to close client connection: %s", err)
+	}
+
+	// We switch to CRAM-MD5, which the server does not support - error expected
+	client.SetSMTPAuth(SMTPAuthCramMD5)
+	if err = client.DialWithContext(context.Background()); err == nil {
+		t.Errorf("expected error when dialing with unsupported auth mechanism, got nil")
+		return
+	}
+	if !errors.Is(err, ErrCramMD5AuthNotSupported) {
+		t.Errorf("expected dial error: %s, but got: %s", ErrCramMD5AuthNotSupported, err)
+	}
+
+	// We switch to CUSTOM by providing PLAIN auth as function - the server supports this
+	client.SetSMTPAuthCustom(smtp.PlainAuth("", os.Getenv("TEST_USER"), os.Getenv("TEST_PASS"),
+		os.Getenv("TEST_HOST")))
+	if client.smtpAuthType != SMTPAuthCustom {
+		t.Errorf("expected auth type to be Custom, got: %s", client.smtpAuthType)
+	}
+	if err = client.DialWithContext(context.Background()); err != nil {
+		t.Errorf("failed to dial to sending server: %s", err)
+	}
+	if err = client.Close(); err != nil {
+		t.Errorf("failed to close client connection: %s", err)
+	}
+
+	// We switch back to explicit no authenticaiton
+	client.SetSMTPAuth(SMTPAuthNoAuth)
+	if err = client.DialWithContext(context.Background()); err != nil {
+		t.Errorf("failed to dial to sending server: %s", err)
+	}
+	if err = client.Close(); err != nil {
+		t.Errorf("failed to close client connection: %s", err)
+	}
+
+	// Finally we set an empty string as SMTPAuthType and expect and error. This way we can
+	// verify that we do not accidentaly skip authentication with an empty string SMTPAuthType
+	client.SetSMTPAuth("")
+	if err = client.DialWithContext(context.Background()); err == nil {
+		t.Errorf("expected error when dialing with empty auth mechanism, got nil")
+	}
+}
+
 // TestClient_auth tests the Dial(), Send() and Close() method of Client with broken settings
 func TestClient_auth(t *testing.T) {
 	tests := []struct {

--- a/client_test.go
+++ b/client_test.go
@@ -1188,8 +1188,8 @@ func TestClient_DialWithContext_switchAuth(t *testing.T) {
 
 	// We switch to LOGIN auth, which the server supports
 	client.SetSMTPAuth(SMTPAuthLogin)
-	client.SetUsername(os.Getenv("TEST_USER"))
-	client.SetPassword(os.Getenv("TEST_PASS"))
+	client.SetUsername(os.Getenv("TEST_SMTPAUTH_USER"))
+	client.SetPassword(os.Getenv("TEST_SMTPAUTH_PASS"))
 	if err = client.DialWithContext(context.Background()); err != nil {
 		t.Errorf("failed to dial to sending server: %s", err)
 	}
@@ -1208,8 +1208,8 @@ func TestClient_DialWithContext_switchAuth(t *testing.T) {
 	}
 
 	// We switch to CUSTOM by providing PLAIN auth as function - the server supports this
-	client.SetSMTPAuthCustom(smtp.PlainAuth("", os.Getenv("TEST_USER"), os.Getenv("TEST_PASS"),
-		os.Getenv("TEST_HOST")))
+	client.SetSMTPAuthCustom(smtp.PlainAuth("", os.Getenv("TEST_SMTPAUTH_USER"),
+		os.Getenv("TEST_SMTPAUTH_PASS"), os.Getenv("TEST_HOST")))
 	if client.smtpAuthType != SMTPAuthCustom {
 		t.Errorf("expected auth type to be Custom, got: %s", client.smtpAuthType)
 	}


### PR DESCRIPTION
This PR fixes a regression introduced in v0.5.0. `SMTPAuthNoAuth` is now changed from an empty string to "NOAUTH". This value is set as default for the Client in `NewClient`. This way we always have a fixed assignment and an empty string would not skip authentication. The `auth()` method has been updated to either assign the `smtp.Auth` function if `SMTPAuthType` is not set to "NOAUTH" or skip the part there is already an auth function set (this would only happen when `SetSMTPAuthCustom` or `"WithSMTPAuthCustom` were used.

If `SMTPAuthType` is set to an empty string, the authentication assignment would fail as it is a not supported mechanism, therefore making sure that the client wouldn't accidentaly skip the authentication at all.

A test has been added to test different auth switching scenarios (using supported, unsupported and custom auth functions). The documentation for `auth()` has been updated accordingly to make it more clear, what's happening.

This should fix the regression described in #332 and #328 but should also address the "empty string" issue, we had before.