### PR TITLE
Fix(close): Access to nil variable causes panic

### DIFF
--- a/client.go
+++ b/client.go
@@ -996,7 +996,7 @@ func (c *Client) DialWithContext(dialCtx context.Context) error {
 // Returns:
 //   - An error if the disconnection fails; otherwise, returns nil.
 func (c *Client) Close() error {
-	if !c.smtpClient.HasConnection() {
+	if c.smtpClient == nil || !c.smtpClient.HasConnection() {
 		return nil
 	}
 	if err := c.smtpClient.Quit(); err != nil {


### PR DESCRIPTION
Please, accept this review for fixing a panic on the `.Close()` method.