### PR TITLE
Add test for closing a nil smtpclient

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1647,6 +1647,15 @@ func TestClient_Close(t *testing.T) {
 			t.Errorf("close was supposed to fail, but didn't")
 		}
 	})
+	t.Run("close on a nil smtpclient should return nil", func(t *testing.T) {
+		client, err := NewClient(DefaultHost)
+		if err != nil {
+			t.Fatalf("failed to create new client: %s", err)
+		}
+		if err = client.Close(); err != nil {
+			t.Errorf("failed to close the client: %s", err)
+		}
+	})
 }
 
 func TestClient_DialWithContext(t *testing.T) {


### PR DESCRIPTION
Introduce a unit test to ensure that invoking Close on a nil smtpclient instance returns nil without errors. This test accompanies the fix provided with PR #353