### PR TITLE
Feature(sendError): add unwrap interface

### DIFF
--- a/senderror.go
+++ b/senderror.go
@@ -133,6 +133,10 @@ func (e *SendError) Is(errType error) bool {
 	return false
 }
 
+func (e *SendError) Unwrap() []error {
+	return e.errlist
+}
+
 // IsTemp returns true if the delivery error is of a temporary nature and can be retried.
 //
 // This function checks whether the SendError indicates a temporary error, which suggests
@@ -224,3 +228,5 @@ func (r SendErrReason) String() string {
 func isTempError(err error) bool {
 	return err.Error()[0] == '4'
 }
+
+var _ interface{ Unwrap() []error } = &SendError{}


### PR DESCRIPTION
Just a brief description of my problem:

I'm trying to validate if a FROM address is valid, and I'm looking into the SMTP Error codes.
I noticed that you receive the error codes, and hide then behind the SendError struct.

It would be helpful for me to have a direct access to these error codes through textproto.Error, instead of parsing them from the error message.

We Have the errors.As function, that tries to go error to error from the error stack, until the type assertion Matches.
I'm implementing the Unwrap interface on SendError for that reason, so we can do errors.As and extract any internal error from the SendError struct.

Another possible solution would be if you also stored the ErrorCode on the SendError struct.