### PR TITLE
Add support for SMTP auto-discovery authentication

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -196,6 +196,8 @@ var (
 // https://pkg.go.dev/github.com/kkyr/fig#StringUnmarshaler
 func (sa *SMTPAuthType) UnmarshalString(value string) error {
 	switch strings.ToLower(value) {
+	case "auto", "autodiscover", "autodiscovery":
+		*sa = SMTPAuthAutoDiscover
 	case "cram-md5", "crammd5", "cram":
 		*sa = SMTPAuthCramMD5
 	case "custom":

--- a/auth_test.go
+++ b/auth_test.go
@@ -12,6 +12,9 @@ func TestSMTPAuthType_UnmarshalString(t *testing.T) {
 		authString string
 		expected   SMTPAuthType
 	}{
+		{"AUTODISCOVER: auto", "auto", SMTPAuthAutoDiscover},
+		{"AUTODISCOVER: autodiscover", "autodiscover", SMTPAuthAutoDiscover},
+		{"AUTODISCOVER: autodiscovery", "autodiscovery", SMTPAuthAutoDiscover},
 		{"CRAM-MD5: cram-md5", "cram-md5", SMTPAuthCramMD5},
 		{"CRAM-MD5: crammd5", "crammd5", SMTPAuthCramMD5},
 		{"CRAM-MD5: cram", "cram", SMTPAuthCramMD5},


### PR DESCRIPTION
Extended the `UnmarshalString` function in `auth.go` to recognize "auto", "autodiscover", and "autodiscovery" as `SMTPAuthAutoDiscover`. Corresponding test cases were also added to `auth_test.go` to ensure proper functionality.