### PR TITLE
Support attachments/embeds via io/fs.FS

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Here are some highlights of go-mail's featureset:
 * [X] RFC5322 compliant mail address validation
 * [X] Support for common mail header field generation (Message-ID, Date, Bulk-Precedence, Priority, etc.)
 * [X] Concurrency-safe reusing the same SMTP connection to send multiple mails
-* [X] Support for attachments and inline embeds (from file system, `io.Reader` or `embed.FS`)
+* [X] Support for attachments and inline embeds (from file system, `io.Reader`, `embed.FS` or `fs.FS`)
 * [X] Support for different encodings
 * [X] Middleware support for 3rd-party libraries to alter mail messages
 * [X] Support sending mails via a local sendmail command

--- a/msg.go
+++ b/msg.go
@@ -1963,9 +1963,28 @@ func (m *Msg) AttachTextTemplate(
 //   - https://datatracker.ietf.org/doc/html/rfc2183
 func (m *Msg) AttachFromEmbedFS(name string, fs *embed.FS, opts ...FileOption) error {
 	if fs == nil {
-		return fmt.Errorf("embed.FS must not be nil")
+		return errors.New("embed.FS must not be nil")
 	}
-	file, err := fileFromIOFS(name, fs)
+	return m.AttachFromIOFS(name, *fs, opts...)
+}
+
+// AttachFromIOFS attaches a file from a generic file system to the message.
+//
+// This function retrieves a file by name from an fs.FS instance, processes it, and appends it to the
+// message's attachment collection. Additional file options can be provided for further customization.
+//
+// Parameters:
+//   - name: The name of the file to retrieve from the file system.
+//   - iofs: The file system (must not be nil).
+//   - opts: Optional file options to customize the attachment process.
+//
+// Returns:
+//   - An error if the file cannot be retrieved, the fs.FS is nil, or any other issue occurs.
+func (m *Msg) AttachFromIOFS(name string, iofs fs.FS, opts ...FileOption) error {
+	if iofs == nil {
+		return errors.New("fs.FS must not be nil")
+	}
+	file, err := fileFromIOFS(name, iofs)
 	if err != nil {
 		return err
 	}
@@ -2109,9 +2128,28 @@ func (m *Msg) EmbedTextTemplate(
 //   - https://datatracker.ietf.org/doc/html/rfc2183
 func (m *Msg) EmbedFromEmbedFS(name string, fs *embed.FS, opts ...FileOption) error {
 	if fs == nil {
-		return fmt.Errorf("embed.FS must not be nil")
+		return errors.New("embed.FS must not be nil")
 	}
-	file, err := fileFromIOFS(name, fs)
+	return m.EmbedFromIOFS(name, *fs, opts...)
+}
+
+// EmbedFromIOFS embeds a file from a generic file system into the message.
+//
+// This function retrieves a file by name from an fs.FS instance, processes it, and appends it to the
+// message's embed collection. Additional file options can be provided for further customization.
+//
+// Parameters:
+//   - name: The name of the file to retrieve from the file system.
+//   - iofs: The file system (must not be nil).
+//   - opts: Optional file options to customize the embedding process.
+//
+// Returns:
+//   - An error if the file cannot be retrieved, the fs.FS is nil, or any other issue occurs.
+func (m *Msg) EmbedFromIOFS(name string, iofs fs.FS, opts ...FileOption) error {
+	if iofs == nil {
+		return errors.New("fs.FS must not be nil")
+	}
+	file, err := fileFromIOFS(name, iofs)
 	if err != nil {
 		return err
 	}
@@ -2684,22 +2722,26 @@ func (m *Msg) addDefaultHeader() {
 // References:
 //   - https://datatracker.ietf.org/doc/html/rfc2183
 func fileFromIOFS(name string, iofs fs.FS) (*File, error) {
+	if iofs == nil {
+		return nil, errors.New("fs.FS is nil")
+	}
+
 	_, err := iofs.Open(name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open file from embed.FS: %w", err)
+		return nil, fmt.Errorf("failed to open file from fs.FS: %w", err)
 	}
 	return &File{
 		Name:   filepath.Base(name),
 		Header: make(map[string][]string),
 		Writer: func(writer io.Writer) (int64, error) {
-			file, err := iofs.Open(name)
-			if err != nil {
-				return 0, err
+			file, ferr := iofs.Open(name)
+			if ferr != nil {
+				return 0, fmt.Errorf("failed to open file from fs.FS: %w", ferr)
 			}
-			numBytes, err := io.Copy(writer, file)
-			if err != nil {
+			numBytes, ferr := io.Copy(writer, file)
+			if ferr != nil {
 				_ = file.Close()
-				return numBytes, fmt.Errorf("failed to copy file to io.Writer: %w", err)
+				return numBytes, fmt.Errorf("failed to copy file from fs.FS to io.Writer: %w", ferr)
 			}
 			return numBytes, file.Close()
 		},


### PR DESCRIPTION
This PR adds support for generic file systems  that satisfy the `fs.FS` interface. Since `embed.FS` is such a file system, the `embed.FS` has been refactored to make use of the more generic `fs.FS` code. It also introduces two new methods `Msg.AttachFromIOFS` and `Msg.EmbedFromIOFS`. Documentation and tests have been updated accordingly.