### PR TITLE
Fix concurrency issue in DialAndSendWithContext

### DIFF
--- a/client.go
+++ b/client.go
@@ -142,9 +142,6 @@ type (
 		// host is the hostname of the SMTP server we are connecting to.
 		host string
 
-		// isEncrypted indicates wether the Client connection is encrypted or not.
-		isEncrypted bool
-
 		// logAuthData indicates whether authentication-related data should be logged.
 		logAuthData bool
 
@@ -931,62 +928,131 @@ func (c *Client) SetLogAuthData(logAuth bool) {
 // Returns:
 //   - An error if the connection to the SMTP server fails or any subsequent command fails.
 func (c *Client) DialWithContext(dialCtx context.Context) error {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	ctx, cancel := context.WithDeadline(dialCtx, time.Now().Add(c.connTimeout))
-	defer cancel()
-
-	if c.dialContextFunc == nil {
-		netDialer := net.Dialer{}
-		c.dialContextFunc = netDialer.DialContext
-
-		if c.useSSL {
-			tlsDialer := tls.Dialer{NetDialer: &netDialer, Config: c.tlsconfig}
-			c.isEncrypted = true
-			c.dialContextFunc = tlsDialer.DialContext
-		}
-	}
-	connection, err := c.dialContextFunc(ctx, "tcp", c.ServerAddr())
-	if err != nil && c.fallbackPort != 0 {
-		// TODO: should we somehow log or append the previous error?
-		connection, err = c.dialContextFunc(ctx, "tcp", c.serverFallbackAddr())
-	}
+	client, err := c.SMTPClientFromDialWithContext(dialCtx)
 	if err != nil {
 		return err
+	}
+	c.mutex.Lock()
+	c.smtpClient = client
+	c.mutex.Unlock()
+	/*
+		ctx, cancel := context.WithDeadline(dialCtx, time.Now().Add(c.connTimeout))
+		defer cancel()
+
+		isEncrypted := false
+		if c.dialContextFunc == nil {
+			netDialer := net.Dialer{}
+			c.dialContextFunc = netDialer.DialContext
+
+			if c.useSSL {
+				tlsDialer := tls.Dialer{NetDialer: &netDialer, Config: c.tlsconfig}
+				isEncrypted = true
+				c.dialContextFunc = tlsDialer.DialContext
+			}
+		}
+		connection, err := c.dialContextFunc(ctx, "tcp", c.ServerAddr())
+		if err != nil && c.fallbackPort != 0 {
+			// TODO: should we somehow log or append the previous error?
+			connection, err = c.dialContextFunc(ctx, "tcp", c.serverFallbackAddr())
+		}
+		if err != nil {
+			return err
+		}
+
+		client, err := smtp.NewClient(connection, c.host)
+		if err != nil {
+			return err
+		}
+		if client == nil {
+			return fmt.Errorf("SMTP client is nil")
+		}
+		c.smtpClient = client
+
+		if c.logger != nil {
+			c.smtpClient.SetLogger(c.logger)
+		}
+		if c.useDebugLog {
+			c.smtpClient.SetDebugLog(true)
+		}
+		if c.logAuthData {
+			c.smtpClient.SetLogAuthData()
+		}
+		if err = c.smtpClient.Hello(c.helo); err != nil {
+			return err
+		}
+
+		if err = c.tls(c.smtpClient, &isEncrypted); err != nil {
+			return err
+		}
+
+		if err = c.auth(c.smtpClient, isEncrypted); err != nil {
+			return err
+		}
+
+	*/
+
+	return nil
+}
+
+// SMTPClientFromDialWithContext is similar to DialWithContext but instead of storing the smtp.Client
+// on the Client it will return the smtp.Client instead.
+func (c *Client) SMTPClientFromDialWithContext(ctxDial context.Context) (*smtp.Client, error) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	ctx, cancel := context.WithDeadline(ctxDial, time.Now().Add(c.connTimeout))
+	defer cancel()
+
+	isEncrypted := false
+	dialContextFunc := c.dialContextFunc
+	if c.dialContextFunc == nil {
+		netDialer := net.Dialer{}
+		dialContextFunc = netDialer.DialContext
+		if c.useSSL {
+			tlsDialer := tls.Dialer{NetDialer: &netDialer, Config: c.tlsconfig}
+			isEncrypted = true
+			dialContextFunc = tlsDialer.DialContext
+		}
+	}
+	connection, err := dialContextFunc(ctx, "tcp", c.ServerAddr())
+	if err != nil && c.fallbackPort != 0 {
+		// TODO: should we somehow log or append the previous error?
+		connection, err = dialContextFunc(ctx, "tcp", c.serverFallbackAddr())
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	client, err := smtp.NewClient(connection, c.host)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if client == nil {
-		return fmt.Errorf("SMTP client is nil")
+		return nil, fmt.Errorf("SMTP client is nil")
 	}
-	c.smtpClient = client
 
 	if c.logger != nil {
-		c.smtpClient.SetLogger(c.logger)
+		client.SetLogger(c.logger)
 	}
 	if c.useDebugLog {
-		c.smtpClient.SetDebugLog(true)
+		client.SetDebugLog(true)
 	}
 	if c.logAuthData {
-		c.smtpClient.SetLogAuthData()
+		client.SetLogAuthData()
 	}
-	if err = c.smtpClient.Hello(c.helo); err != nil {
-		return err
-	}
-
-	if err = c.tls(); err != nil {
-		return err
+	if err = client.Hello(c.helo); err != nil {
+		return nil, err
 	}
 
-	if err = c.auth(); err != nil {
-		return err
+	if err = c.tls(client, &isEncrypted); err != nil {
+		return nil, err
 	}
 
-	return nil
+	if err = c.auth(client, isEncrypted); err != nil {
+		return nil, err
+	}
+
+	return client, nil
 }
 
 // Close terminates the connection to the SMTP server, returning an error if the disconnection
@@ -999,10 +1065,14 @@ func (c *Client) DialWithContext(dialCtx context.Context) error {
 // Returns:
 //   - An error if the disconnection fails; otherwise, returns nil.
 func (c *Client) Close() error {
-	if c.smtpClient == nil || !c.smtpClient.HasConnection() {
+	return c.CloseWithSMTPClient(c.smtpClient)
+}
+
+func (c *Client) CloseWithSMTPClient(client *smtp.Client) error {
+	if client == nil || !client.HasConnection() {
 		return nil
 	}
-	if err := c.smtpClient.Quit(); err != nil {
+	if err := client.Quit(); err != nil {
 		return fmt.Errorf("failed to close SMTP client: %w", err)
 	}
 
@@ -1018,10 +1088,14 @@ func (c *Client) Close() error {
 // Returns:
 //   - An error if the connection check fails or if sending the RSET command fails; otherwise, returns nil.
 func (c *Client) Reset() error {
-	if err := c.checkConn(); err != nil {
+	return c.ResetWithSMTPClient(c.smtpClient)
+}
+
+func (c *Client) ResetWithSMTPClient(client *smtp.Client) error {
+	if err := c.checkConn(client); err != nil {
 		return err
 	}
-	if err := c.smtpClient.Reset(); err != nil {
+	if err := client.Reset(); err != nil {
 		return fmt.Errorf("failed to send RSET to SMTP client: %w", err)
 	}
 
@@ -1061,19 +1135,20 @@ func (c *Client) DialAndSend(messages ...*Msg) error {
 //   - An error if the connection fails, if sending the messages fails, or if closing the
 //     connection fails; otherwise, returns nil.
 func (c *Client) DialAndSendWithContext(ctx context.Context, messages ...*Msg) error {
-	c.sendMutex.Lock()
-	defer c.sendMutex.Unlock()
-	if err := c.DialWithContext(ctx); err != nil {
+	//c.sendMutex.Lock()
+	//defer c.sendMutex.Unlock()
+	client, err := c.SMTPClientFromDialWithContext(ctx)
+	if err != nil {
 		return fmt.Errorf("dial failed: %w", err)
 	}
 	defer func() {
-		_ = c.Close()
+		_ = c.CloseWithSMTPClient(client)
 	}()
 
-	if err := c.Send(messages...); err != nil {
+	if err := c.SendWithSMTPClient(client, messages...); err != nil {
 		return fmt.Errorf("send failed: %w", err)
 	}
-	if err := c.Close(); err != nil {
+	if err := c.CloseWithSMTPClient(client); err != nil {
 		return fmt.Errorf("failed to close connection: %w", err)
 	}
 	return nil
@@ -1098,16 +1173,17 @@ func (c *Client) DialAndSendWithContext(ctx context.Context, messages ...*Msg) e
 // Returns:
 //   - An error if the connection check fails, if no supported authentication method is found,
 //     or if the authentication process fails.
-func (c *Client) auth() error {
+func (c *Client) auth(client *smtp.Client, isEnc bool) error {
+	var smtpAuth smtp.Auth
 	if c.smtpAuth == nil && c.smtpAuthType != SMTPAuthNoAuth {
-		hasSMTPAuth, smtpAuthType := c.smtpClient.Extension("AUTH")
+		hasSMTPAuth, smtpAuthType := client.Extension("AUTH")
 		if !hasSMTPAuth {
 			return fmt.Errorf("server does not support SMTP AUTH")
 		}
 
 		authType := c.smtpAuthType
 		if c.smtpAuthType == SMTPAuthAutoDiscover {
-			discoveredType, err := c.authTypeAutoDiscover(smtpAuthType)
+			discoveredType, err := c.authTypeAutoDiscover(smtpAuthType, isEnc)
 			if err != nil {
 				return err
 			}
@@ -1119,74 +1195,74 @@ func (c *Client) auth() error {
 			if !strings.Contains(smtpAuthType, string(SMTPAuthPlain)) {
 				return ErrPlainAuthNotSupported
 			}
-			c.smtpAuth = smtp.PlainAuth("", c.user, c.pass, c.host, false)
+			smtpAuth = smtp.PlainAuth("", c.user, c.pass, c.host, false)
 		case SMTPAuthPlainNoEnc:
 			if !strings.Contains(smtpAuthType, string(SMTPAuthPlain)) {
 				return ErrPlainAuthNotSupported
 			}
-			c.smtpAuth = smtp.PlainAuth("", c.user, c.pass, c.host, true)
+			smtpAuth = smtp.PlainAuth("", c.user, c.pass, c.host, true)
 		case SMTPAuthLogin:
 			if !strings.Contains(smtpAuthType, string(SMTPAuthLogin)) {
 				return ErrLoginAuthNotSupported
 			}
-			c.smtpAuth = smtp.LoginAuth(c.user, c.pass, c.host, false)
+			smtpAuth = smtp.LoginAuth(c.user, c.pass, c.host, false)
 		case SMTPAuthLoginNoEnc:
 			if !strings.Contains(smtpAuthType, string(SMTPAuthLogin)) {
 				return ErrLoginAuthNotSupported
 			}
-			c.smtpAuth = smtp.LoginAuth(c.user, c.pass, c.host, true)
+			smtpAuth = smtp.LoginAuth(c.user, c.pass, c.host, true)
 		case SMTPAuthCramMD5:
 			if !strings.Contains(smtpAuthType, string(SMTPAuthCramMD5)) {
 				return ErrCramMD5AuthNotSupported
 			}
-			c.smtpAuth = smtp.CRAMMD5Auth(c.user, c.pass)
+			smtpAuth = smtp.CRAMMD5Auth(c.user, c.pass)
 		case SMTPAuthXOAUTH2:
 			if !strings.Contains(smtpAuthType, string(SMTPAuthXOAUTH2)) {
 				return ErrXOauth2AuthNotSupported
 			}
-			c.smtpAuth = smtp.XOAuth2Auth(c.user, c.pass)
+			smtpAuth = smtp.XOAuth2Auth(c.user, c.pass)
 		case SMTPAuthSCRAMSHA1:
 			if !strings.Contains(smtpAuthType, string(SMTPAuthSCRAMSHA1)) {
 				return ErrSCRAMSHA1AuthNotSupported
 			}
-			c.smtpAuth = smtp.ScramSHA1Auth(c.user, c.pass)
+			smtpAuth = smtp.ScramSHA1Auth(c.user, c.pass)
 		case SMTPAuthSCRAMSHA256:
 			if !strings.Contains(smtpAuthType, string(SMTPAuthSCRAMSHA256)) {
 				return ErrSCRAMSHA256AuthNotSupported
 			}
-			c.smtpAuth = smtp.ScramSHA256Auth(c.user, c.pass)
+			smtpAuth = smtp.ScramSHA256Auth(c.user, c.pass)
 		case SMTPAuthSCRAMSHA1PLUS:
 			if !strings.Contains(smtpAuthType, string(SMTPAuthSCRAMSHA1PLUS)) {
 				return ErrSCRAMSHA1PLUSAuthNotSupported
 			}
-			tlsConnState, err := c.smtpClient.GetTLSConnectionState()
+			tlsConnState, err := client.GetTLSConnectionState()
 			if err != nil {
 				return err
 			}
-			c.smtpAuth = smtp.ScramSHA1PlusAuth(c.user, c.pass, tlsConnState)
+			smtpAuth = smtp.ScramSHA1PlusAuth(c.user, c.pass, tlsConnState)
 		case SMTPAuthSCRAMSHA256PLUS:
 			if !strings.Contains(smtpAuthType, string(SMTPAuthSCRAMSHA256PLUS)) {
 				return ErrSCRAMSHA256PLUSAuthNotSupported
 			}
-			tlsConnState, err := c.smtpClient.GetTLSConnectionState()
+			tlsConnState, err := client.GetTLSConnectionState()
 			if err != nil {
 				return err
 			}
-			c.smtpAuth = smtp.ScramSHA256PlusAuth(c.user, c.pass, tlsConnState)
+			smtpAuth = smtp.ScramSHA256PlusAuth(c.user, c.pass, tlsConnState)
 		default:
 			return fmt.Errorf("unsupported SMTP AUTH type %q", c.smtpAuthType)
 		}
 	}
 
-	if c.smtpAuth != nil {
-		if err := c.smtpClient.Auth(c.smtpAuth); err != nil {
+	if smtpAuth != nil {
+		if err := client.Auth(smtpAuth); err != nil {
 			return fmt.Errorf("SMTP AUTH failed: %w", err)
 		}
 	}
 	return nil
 }
 
-func (c *Client) authTypeAutoDiscover(supported string) (SMTPAuthType, error) {
+func (c *Client) authTypeAutoDiscover(supported string, isEnc bool) (SMTPAuthType, error) {
 	if supported == "" {
 		return "", ErrNoSupportedAuthDiscovered
 	}
@@ -1194,7 +1270,7 @@ func (c *Client) authTypeAutoDiscover(supported string) (SMTPAuthType, error) {
 		SMTPAuthSCRAMSHA256PLUS, SMTPAuthSCRAMSHA256, SMTPAuthSCRAMSHA1PLUS, SMTPAuthSCRAMSHA1,
 		SMTPAuthXOAUTH2, SMTPAuthCramMD5, SMTPAuthPlain, SMTPAuthLogin,
 	}
-	if !c.isEncrypted {
+	if !isEnc {
 		preferList = []SMTPAuthType{SMTPAuthSCRAMSHA256, SMTPAuthSCRAMSHA1, SMTPAuthXOAUTH2, SMTPAuthCramMD5}
 	}
 	mechs := strings.Split(supported, " ")
@@ -1231,13 +1307,13 @@ func sliceContains(slice []string, item string) bool {
 //
 // Returns:
 //   - An error if any part of the sending process fails; otherwise, returns nil.
-func (c *Client) sendSingleMsg(message *Msg) error {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-	escSupport, _ := c.smtpClient.Extension("ENHANCEDSTATUSCODES")
+func (c *Client) sendSingleMsg(client *smtp.Client, message *Msg) error {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	escSupport, _ := client.Extension("ENHANCEDSTATUSCODES")
 
 	if message.encoding == NoEncoding {
-		if ok, _ := c.smtpClient.Extension("8BITMIME"); !ok {
+		if ok, _ := client.Extension("8BITMIME"); !ok {
 			return &SendError{Reason: ErrNoUnencoded, isTemp: false, affectedMsg: message}
 		}
 	}
@@ -1260,16 +1336,16 @@ func (c *Client) sendSingleMsg(message *Msg) error {
 
 	if c.requestDSN {
 		if c.dsnReturnType != "" {
-			c.smtpClient.SetDSNMailReturnOption(string(c.dsnReturnType))
+			client.SetDSNMailReturnOption(string(c.dsnReturnType))
 		}
 	}
-	if err = c.smtpClient.Mail(from); err != nil {
+	if err = client.Mail(from); err != nil {
 		retError := &SendError{
 			Reason: ErrSMTPMailFrom, errlist: []error{err}, isTemp: isTempError(err),
 			affectedMsg: message, errcode: errorCode(err),
 			enhancedStatusCode: enhancedStatusCode(err, escSupport),
 		}
-		if resetSendErr := c.smtpClient.Reset(); resetSendErr != nil {
+		if resetSendErr := client.Reset(); resetSendErr != nil {
 			retError.errlist = append(retError.errlist, resetSendErr)
 		}
 		return retError
@@ -1279,9 +1355,9 @@ func (c *Client) sendSingleMsg(message *Msg) error {
 	rcptSendErr.errlist = make([]error, 0)
 	rcptSendErr.rcpt = make([]string, 0)
 	rcptNotifyOpt := strings.Join(c.dsnRcptNotifyType, ",")
-	c.smtpClient.SetDSNRcptNotifyOption(rcptNotifyOpt)
+	client.SetDSNRcptNotifyOption(rcptNotifyOpt)
 	for _, rcpt := range rcpts {
-		if err = c.smtpClient.Rcpt(rcpt); err != nil {
+		if err = client.Rcpt(rcpt); err != nil {
 			rcptSendErr.Reason = ErrSMTPRcptTo
 			rcptSendErr.errlist = append(rcptSendErr.errlist, err)
 			rcptSendErr.rcpt = append(rcptSendErr.rcpt, rcpt)
@@ -1292,12 +1368,12 @@ func (c *Client) sendSingleMsg(message *Msg) error {
 		}
 	}
 	if hasError {
-		if resetSendErr := c.smtpClient.Reset(); resetSendErr != nil {
+		if resetSendErr := client.Reset(); resetSendErr != nil {
 			rcptSendErr.errlist = append(rcptSendErr.errlist, resetSendErr)
 		}
 		return rcptSendErr
 	}
-	writer, err := c.smtpClient.Data()
+	writer, err := client.Data()
 	if err != nil {
 		return &SendError{
 			Reason: ErrSMTPData, errlist: []error{err}, isTemp: isTempError(err),
@@ -1322,7 +1398,7 @@ func (c *Client) sendSingleMsg(message *Msg) error {
 	}
 	message.isDelivered = true
 
-	if err = c.Reset(); err != nil {
+	if err = c.ResetWithSMTPClient(client); err != nil {
 		return &SendError{
 			Reason: ErrSMTPReset, errlist: []error{err}, isTemp: isTempError(err),
 			affectedMsg: message, errcode: errorCode(err),
@@ -1344,21 +1420,24 @@ func (c *Client) sendSingleMsg(message *Msg) error {
 // Returns:
 //   - An error if there is no active connection, if the NOOP command fails, or if extending
 //     the deadline fails; otherwise, returns nil.
-func (c *Client) checkConn() error {
-	if c.smtpClient == nil {
+func (c *Client) checkConn(client *smtp.Client) error {
+	if client == nil {
 		return ErrNoActiveConnection
 	}
-	if !c.smtpClient.HasConnection() {
+	if !client.HasConnection() {
 		return ErrNoActiveConnection
 	}
 
-	if !c.noNoop {
-		if err := c.smtpClient.Noop(); err != nil {
+	c.mutex.RLock()
+	noNoop := c.noNoop
+	c.mutex.RUnlock()
+	if !noNoop {
+		if err := client.Noop(); err != nil {
 			return ErrNoActiveConnection
 		}
 	}
 
-	if err := c.smtpClient.UpdateDeadline(c.connTimeout); err != nil {
+	if err := client.UpdateDeadline(c.connTimeout); err != nil {
 		return ErrDeadlineExtendFailed
 	}
 	return nil
@@ -1405,10 +1484,10 @@ func (c *Client) setDefaultHelo() error {
 // Returns:
 //   - An error if there is no active connection, if STARTTLS is required but not supported,
 //     or if there are issues during the TLS handshake; otherwise, returns nil.
-func (c *Client) tls() error {
+func (c *Client) tls(client *smtp.Client, isEnc *bool) error {
 	if !c.useSSL && c.tlspolicy != NoTLS {
 		hasStartTLS := false
-		extension, _ := c.smtpClient.Extension("STARTTLS")
+		extension, _ := client.Extension("STARTTLS")
 		if c.tlspolicy == TLSMandatory {
 			hasStartTLS = true
 			if !extension {
@@ -1422,21 +1501,21 @@ func (c *Client) tls() error {
 			}
 		}
 		if hasStartTLS {
-			if err := c.smtpClient.StartTLS(c.tlsconfig); err != nil {
+			if err := client.StartTLS(c.tlsconfig); err != nil {
 				return err
 			}
 		}
-		tlsConnState, err := c.smtpClient.GetTLSConnectionState()
+		tlsConnState, err := client.GetTLSConnectionState()
 		if err != nil {
 			switch {
 			case errors.Is(err, smtp.ErrNonTLSConnection):
-				c.isEncrypted = false
+				*isEnc = false
 				return nil
 			default:
 				return fmt.Errorf("failed to get TLS connection state: %w", err)
 			}
 		}
-		c.isEncrypted = tlsConnState.HandshakeComplete
+		*isEnc = tlsConnState.HandshakeComplete
 	}
 	return nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1772,11 +1772,8 @@ func TestClient_DialWithContext(t *testing.T) {
 				t.Errorf("failed to close the client: %s", err)
 			}
 		})
-		if client.smtpClient == nil {
-			t.Errorf("client with invalid HELO should still have a smtp client, got nil")
-		}
-		if !client.smtpClient.HasConnection() {
-			t.Errorf("client with invalid HELO should still have a smtp client connection, got nil")
+		if client.smtpClient != nil {
+			t.Error("client with invalid HELO should not have a smtp client")
 		}
 	})
 	t.Run("fail on base port and fallback", func(t *testing.T) {
@@ -1825,11 +1822,8 @@ func TestClient_DialWithContext(t *testing.T) {
 		if err = client.DialWithContext(ctxDial); err == nil {
 			t.Fatalf("connection was supposed to fail, but didn't")
 		}
-		if client.smtpClient == nil {
-			t.Fatalf("client has no smtp client")
-		}
-		if !client.smtpClient.HasConnection() {
-			t.Errorf("client has no connection")
+		if client.smtpClient != nil {
+			t.Fatalf("client is not supposed to have a smtp client")
 		}
 	})
 	t.Run("connect with failing auth", func(t *testing.T) {
@@ -2297,6 +2291,7 @@ func TestClient_DialAndSendWithContext(t *testing.T) {
 			t.Errorf("client was supposed to fail on dial")
 		}
 	})
+	// https://github.com/wneessen/go-mail/issues/380
 	t.Run("concurrent sending via DialAndSendWithContext", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -2331,6 +2326,44 @@ func TestClient_DialAndSendWithContext(t *testing.T) {
 				defer cancelDial()
 				if goroutineErr := client.DialAndSendWithContext(ctxDial, msg); goroutineErr != nil {
 					t.Errorf("failed to dial and send message: %s", goroutineErr)
+				}
+			}()
+		}
+		wg.Wait()
+	})
+	// https://github.com/wneessen/go-mail/issues/385
+	t.Run("concurrent sending via DialAndSendWithContext on receiver func", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		PortAdder.Add(1)
+		serverPort := int(TestServerPortBase + PortAdder.Load())
+		featureSet := "250-8BITMIME\r\n250-DSN\r\n250 SMTPUTF8"
+		go func() {
+			if err := simpleSMTPServer(ctx, t, &serverProps{
+				FeatureSet: featureSet,
+				ListenPort: serverPort,
+			}); err != nil {
+				t.Errorf("failed to start test server: %s", err)
+				return
+			}
+		}()
+		time.Sleep(time.Millisecond * 30)
+
+		client, err := NewClient(DefaultHost, WithPort(serverPort), WithTLSPolicy(NoTLS))
+		if err != nil {
+			t.Fatalf("failed to create new client: %s", err)
+		}
+		sender := testSender{client}
+
+		ctxDial := context.Background()
+		wg := sync.WaitGroup{}
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			msg := testMessage(t)
+			go func() {
+				defer wg.Done()
+				if goroutineErr := sender.Send(ctxDial, msg); goroutineErr != nil {
+					t.Errorf("failed to send message: %s", goroutineErr)
 				}
 			}()
 		}
@@ -2574,8 +2607,8 @@ func TestClient_authTypeAutoDiscover(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run("AutoDiscover selects the strongest auth type: "+string(tt.expect), func(t *testing.T) {
-			client := &Client{smtpAuthType: SMTPAuthAutoDiscover, isEncrypted: tt.tls}
-			authType, err := client.authTypeAutoDiscover(tt.supported)
+			client := &Client{smtpAuthType: SMTPAuthAutoDiscover}
+			authType, err := client.authTypeAutoDiscover(tt.supported, tt.tls)
 			if err != nil && !tt.shouldFail {
 				t.Fatalf("failed to auto discover auth type: %s", err)
 			}
@@ -2748,7 +2781,7 @@ func TestClient_sendSingleMsg(t *testing.T) {
 				t.Errorf("failed to close client: %s", err)
 			}
 		})
-		if err = client.sendSingleMsg(message); err != nil {
+		if err = client.sendSingleMsg(client.smtpClient, message); err != nil {
 			t.Errorf("failed to send message: %s", err)
 		}
 	})
@@ -2791,7 +2824,7 @@ func TestClient_sendSingleMsg(t *testing.T) {
 				t.Errorf("failed to close client: %s", err)
 			}
 		})
-		if err = client.sendSingleMsg(message); err == nil {
+		if err = client.sendSingleMsg(client.smtpClient, message); err == nil {
 			t.Errorf("client should have failed to send message")
 		}
 	})
@@ -2836,7 +2869,7 @@ func TestClient_sendSingleMsg(t *testing.T) {
 				t.Errorf("failed to close client: %s", err)
 			}
 		})
-		if err = client.sendSingleMsg(message); err == nil {
+		if err = client.sendSingleMsg(client.smtpClient, message); err == nil {
 			t.Errorf("client should have failed to send message")
 		}
 		var sendErr *SendError
@@ -2886,7 +2919,7 @@ func TestClient_sendSingleMsg(t *testing.T) {
 				t.Errorf("failed to close client: %s", err)
 			}
 		})
-		if err = client.sendSingleMsg(message); err == nil {
+		if err = client.sendSingleMsg(client.smtpClient, message); err == nil {
 			t.Errorf("client should have failed to send message")
 		}
 		var sendErr *SendError
@@ -2936,7 +2969,7 @@ func TestClient_sendSingleMsg(t *testing.T) {
 				t.Errorf("failed to close client: %s", err)
 			}
 		})
-		if err = client.sendSingleMsg(message); err == nil {
+		if err = client.sendSingleMsg(client.smtpClient, message); err == nil {
 			t.Errorf("client should have failed to send message")
 		}
 		var sendErr *SendError
@@ -2986,7 +3019,7 @@ func TestClient_sendSingleMsg(t *testing.T) {
 				t.Errorf("failed to close client: %s", err)
 			}
 		})
-		if err = client.sendSingleMsg(message); err != nil {
+		if err = client.sendSingleMsg(client.smtpClient, message); err != nil {
 			t.Errorf("failed to send message: %s", err)
 		}
 	})
@@ -3029,7 +3062,7 @@ func TestClient_sendSingleMsg(t *testing.T) {
 				t.Errorf("failed to close client: %s", err)
 			}
 		})
-		if err = client.sendSingleMsg(message); err == nil {
+		if err = client.sendSingleMsg(client.smtpClient, message); err == nil {
 			t.Errorf("client should have failed to send message")
 		}
 		var sendErr *SendError
@@ -3080,7 +3113,7 @@ func TestClient_sendSingleMsg(t *testing.T) {
 				t.Errorf("failed to close client: %s", err)
 			}
 		})
-		if err = client.sendSingleMsg(message); err == nil {
+		if err = client.sendSingleMsg(client.smtpClient, message); err == nil {
 			t.Errorf("client should have failed to send message")
 		}
 		var sendErr *SendError
@@ -3131,7 +3164,7 @@ func TestClient_sendSingleMsg(t *testing.T) {
 				t.Errorf("failed to close client: %s", err)
 			}
 		})
-		if err = client.sendSingleMsg(message); err == nil {
+		if err = client.sendSingleMsg(client.smtpClient, message); err == nil {
 			t.Errorf("client should have failed to send message")
 		}
 		var sendErr *SendError
@@ -3181,7 +3214,7 @@ func TestClient_sendSingleMsg(t *testing.T) {
 				t.Errorf("failed to close client: %s", err)
 			}
 		})
-		if err = client.sendSingleMsg(message); err == nil {
+		if err = client.sendSingleMsg(client.smtpClient, message); err == nil {
 			t.Errorf("client should have failed to send message")
 		}
 		var sendErr *SendError
@@ -3231,7 +3264,7 @@ func TestClient_sendSingleMsg(t *testing.T) {
 				t.Errorf("failed to close client: %s", err)
 			}
 		})
-		if err = client.sendSingleMsg(message); err == nil {
+		if err = client.sendSingleMsg(client.smtpClient, message); err == nil {
 			t.Errorf("client should have failed to send message")
 		}
 		var sendErr *SendError
@@ -3281,7 +3314,7 @@ func TestClient_sendSingleMsg(t *testing.T) {
 				t.Errorf("failed to close client: %s", err)
 			}
 		})
-		if err = client.sendSingleMsg(message); err == nil {
+		if err = client.sendSingleMsg(client.smtpClient, message); err == nil {
 			t.Error("expected mail delivery to fail")
 		}
 		var sendErr *SendError
@@ -3334,7 +3367,7 @@ func TestClient_checkConn(t *testing.T) {
 				t.Errorf("failed to close client: %s", err)
 			}
 		})
-		if err = client.checkConn(); err != nil {
+		if err = client.checkConn(client.smtpClient); err != nil {
 			t.Errorf("failed to check connection: %s", err)
 		}
 	})
@@ -3375,7 +3408,7 @@ func TestClient_checkConn(t *testing.T) {
 				t.Errorf("failed to close client: %s", err)
 			}
 		})
-		if err = client.checkConn(); err == nil {
+		if err = client.checkConn(client.smtpClient); err == nil {
 			t.Errorf("client should have failed on connection check")
 		}
 		if !errors.Is(err, ErrNoActiveConnection) {
@@ -3387,7 +3420,7 @@ func TestClient_checkConn(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to create new client: %s", err)
 		}
-		if err = client.checkConn(); err == nil {
+		if err = client.checkConn(client.smtpClient); err == nil {
 			t.Errorf("client should have failed on connection check")
 		}
 		if !errors.Is(err, ErrNoActiveConnection) {
@@ -3611,23 +3644,19 @@ func TestClient_XOAuth2OnFaker(t *testing.T) {
 		}
 		if err = c.DialWithContext(context.Background()); err == nil {
 			t.Fatal("expected dial error got nil")
-		} else {
-			if !errors.Is(err, ErrXOauth2AuthNotSupported) {
-				t.Fatalf("expected %v; got %v", ErrXOauth2AuthNotSupported, err)
-			}
+		}
+		if !errors.Is(err, ErrXOauth2AuthNotSupported) {
+			t.Fatalf("expected %v; got %v", ErrXOauth2AuthNotSupported, err)
 		}
 		if err = c.Close(); err != nil {
 			t.Fatalf("disconnect from test server failed: %v", err)
 		}
 		client := strings.Split(wrote.String(), "\r\n")
-		if len(client) != 3 {
-			t.Fatalf("unexpected number of client requests got %d; want 3", len(client))
+		if len(client) != 2 {
+			t.Fatalf("unexpected number of client requests got %d; want 2", len(client))
 		}
 		if !strings.HasPrefix(client[0], "EHLO") {
 			t.Fatalf("expected EHLO, got %q", client[0])
-		}
-		if client[1] != "QUIT" {
-			t.Fatalf("expected QUIT, got %q", client[3])
 		}
 	})
 }
@@ -3651,6 +3680,17 @@ func (f faker) RemoteAddr() net.Addr             { return nil }
 func (f faker) SetDeadline(time.Time) error      { return nil }
 func (f faker) SetReadDeadline(time.Time) error  { return nil }
 func (f faker) SetWriteDeadline(time.Time) error { return nil }
+
+type testSender struct {
+	client *Client
+}
+
+func (t *testSender) Send(ctx context.Context, m *Msg) error {
+	if err := t.client.DialAndSendWithContext(ctx, m); err != nil {
+		return fmt.Errorf("failed to dial and send mail: %w", err)
+	}
+	return nil
+}
 
 // parseJSONLog parses a JSON encoded log from the provided buffer and returns a slice of logLine structs.
 // In case of a decode error, it reports the error to the testing framework.

--- a/smtp/smtp.go
+++ b/smtp/smtp.go
@@ -601,12 +601,16 @@ func (c *Client) SetLogAuthData() {
 
 // SetDSNMailReturnOption sets the DSN mail return option for the Mail method
 func (c *Client) SetDSNMailReturnOption(d string) {
+	c.mutex.Lock()
 	c.dsnmrtype = d
+	c.mutex.Unlock()
 }
 
 // SetDSNRcptNotifyOption sets the DSN recipient notify option for the Mail method
 func (c *Client) SetDSNRcptNotifyOption(d string) {
+	c.mutex.Lock()
 	c.dsnrntype = d
+	c.mutex.Unlock()
 }
 
 // HasConnection checks if the client has an active connection.


### PR DESCRIPTION
The whole dial and send mechanic was refactored to use a local SMTP client per `DialAndSendWithContext` call. This fixes concurrency issues that would arrise when the `Client` access the client stored in the `Client` struct. For this several methods have been added to accept a `smtp.Client` pointer and use this instead of the `Client.smtpClient` shared on the `Client` struct. 

To avoid breaking any current code, the old methods have been refactored in a way that they make use of the `smtp.Client` accepting methods but they will hand the `Client.smtpClient` to these function. This way we should provide full compatibility with any code that was written before this code change.

This addresses #385.

Work still in progress, PR created to get better coverage visiblity with CodeCov.