### PR TITLE
Improve filename sanitization in MIME headers

### DIFF
--- a/msgwriter_test.go
+++ b/msgwriter_test.go
@@ -676,3 +676,33 @@ func TestMsgWriter_writeBody(t *testing.T) {
 		}
 	})
 }
+
+func TestMsgWriter_sanitizeFilename(t *testing.T) {
+	tests := []struct {
+		given string
+		want  string
+	}{
+		{"test.txt", "test.txt"},
+		{"test file.txt", "test file.txt"},
+		{"test\\ file.txt", "test_ file.txt"},
+		{`"test" file.txt`, "_test_ file.txt"},
+		{`test	file	.txt`, "test_file_.txt"},
+		{"test\r\nfile.txt", "test__file.txt"},
+		{"test\x22file.txt", "test_file.txt"},
+		{"test\x2ffile.txt", "test_file.txt"},
+		{"test\x3afile.txt", "test_file.txt"},
+		{"test\x3cfile.txt", "test_file.txt"},
+		{"test\x3efile.txt", "test_file.txt"},
+		{"test\x3ffile.txt", "test_file.txt"},
+		{"test\x5cfile.txt", "test_file.txt"},
+		{"test\x7cfile.txt", "test_file.txt"},
+		{"test\x7ffile.txt", "test_file.txt"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.given+"=>"+tt.want, func(t *testing.T) {
+			if got := sanitizeFilename(tt.given); got != tt.want {
+				t.Errorf("sanitizeFilename failed, expected: %q, got: %q", tt.want, got)
+			}
+		})
+	}
+}

--- a/msgwriter_test.go
+++ b/msgwriter_test.go
@@ -346,8 +346,15 @@ func TestMsgWriter_addFiles(t *testing.T) {
 			if msgwriter.err != nil {
 				t.Errorf("msgWriter failed to write: %s", msgwriter.err)
 			}
-			ctExpect := fmt.Sprintf(`Content-Type: text/plain; charset=utf-8; name="%s"`, tt.expect)
+
+			var ctExpect string
 			cdExpect := fmt.Sprintf(`Content-Disposition: attachment; filename="%s"`, tt.expect)
+			switch runtime.GOOS {
+			case "freebsd":
+				ctExpect = fmt.Sprintf(`Content-Type: application/octet-stream; charset=utf-8; name="%s"`, tt.expect)
+			default:
+				ctExpect = fmt.Sprintf(`Content-Type: text/plain; charset=utf-8; name="%s"`, tt.expect)
+			}
 			if !strings.Contains(buffer.String(), ctExpect) {
 				t.Errorf("expected content-type: %q, got: %q", ctExpect, buffer.String())
 			}

--- a/msgwriter_test.go
+++ b/msgwriter_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"mime"
-	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -342,30 +341,7 @@ func TestMsgWriter_addFiles(t *testing.T) {
 			buffer := bytes.NewBuffer(nil)
 			msgwriter.writer = buffer
 			message := testMessage(t)
-			tmpfile, err := os.CreateTemp("", "attachment.*.tmp")
-			if err != nil {
-				t.Fatalf("failed to create tempfile: %s", err)
-			}
-			t.Cleanup(func() {
-				if err = os.Remove(tmpfile.Name()); err != nil {
-					t.Errorf("failed to remove tempfile: %s", err)
-				}
-			})
-
-			source, err := os.Open("testdata/attachment.txt")
-			if err != nil {
-				t.Fatalf("failed to open source file: %s", err)
-			}
-			if _, err = io.Copy(tmpfile, source); err != nil {
-				t.Fatalf("failed to copy source file: %s", err)
-			}
-			if err = tmpfile.Close(); err != nil {
-				t.Fatalf("failed to close tempfile: %s", err)
-			}
-			if err = source.Close(); err != nil {
-				t.Fatalf("failed to close source file: %s", err)
-			}
-			message.AttachFile(tmpfile.Name(), WithFileName(tt.filename))
+			message.AttachFile("testdata/attachment.txt", WithFileName(tt.filename))
 			msgwriter.writeMsg(message)
 			if msgwriter.err != nil {
 				t.Errorf("msgWriter failed to write: %s", msgwriter.err)

--- a/msgwriter_test.go
+++ b/msgwriter_test.go
@@ -351,7 +351,7 @@ func TestMsgWriter_addFiles(t *testing.T) {
 			cdExpect := fmt.Sprintf(`Content-Disposition: attachment; filename="%s"`, tt.expect)
 			switch runtime.GOOS {
 			case "freebsd":
-				ctExpect = fmt.Sprintf(`Content-Type: application/octet-stream; charset=utf-8; name="%s"`, tt.expect)
+				ctExpect = fmt.Sprintf(`Content-Type: application/octet-stream; name="%s"`, tt.expect)
 			default:
 				ctExpect = fmt.Sprintf(`Content-Type: text/plain; charset=utf-8; name="%s"`, tt.expect)
 			}


### PR DESCRIPTION
This PR introduces proper filename sanitization for attachments and embedded files. It will repace invalid characters with underscore `_` characters before encoding them. This prevents control (like new lines) and special characters like backslash or quotes from causing issues in MIME headers and file systems.

As a side effect this prevents newline characters from introducing a potential vulnerability by using filenames with newlines characters in it. 

We also make sure that the `Content-Description` header is properly encoded.