### PR TITLE
Prepare 0.6.0 release

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Winni Neessen <winni@neessen.dev>
+# SPDX-FileCopyrightText: The go-mail Authors
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Winni Neessen <winni@neessen.dev>
+# SPDX-FileCopyrightText: The go-mail Authors
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Winni Neessen <winni@neessen.dev>
+# SPDX-FileCopyrightText: The go-mail Authors
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Winni Neessen <winni@neessen.dev>
+# SPDX-FileCopyrightText: The go-mail Authors
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+# SPDX-FileCopyrightText: The go-mail Authors
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 The go-mail Authors
+# SPDX-FileCopyrightText: The go-mail Authors
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Winni Neessen <winni@neessen.dev>
+# SPDX-FileCopyrightText: The go-mail Authors
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+# SPDX-FileCopyrightText: The go-mail Authors
 #
 # SPDX-License-Identifier: MIT
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Winni Neessen <winni@neessen.dev>
+# SPDX-FileCopyrightText: The go-mail Authors
 #
 # SPDX-License-Identifier: MIT
 

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,4 +1,4 @@
-## SPDX-FileCopyrightText: 2022 Winni Neessen <winni@neessen.dev>
+## SPDX-FileCopyrightText: The go-mail Authors
 ##
 ## SPDX-License-Identifier: MIT
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 Winni Neessen <winni@neessen.dev>
+SPDX-FileCopyrightText: Winni Neessen <winni@neessen.dev>
 
 SPDX-License-Identifier: MIT
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+SPDX-FileCopyrightText: The go-mail Authors
 
 SPDX-License-Identifier: MIT
 -->

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2023 The go-mail Authors
+Copyright (c) 2022-2025 The go-mail Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2023 The go-mail Authors
+Copyright (c) 2022-2025 The go-mail Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the "Software"), to deal in the Software without restriction, including without

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Here are some highlights of go-mail's featureset:
 * [X] Custom error types for delivery errors
 * [X] Custom dial-context functions for more control over the connection (proxing, DNS hooking, etc.)
 * [X] Output a go-mail message as EML file and parse EML file into a go-mail message
-* [X] S/MIME message signing support (Experimental)
+* [X] S/MIME message signing support (RSA and ECDSA)
+* [X] UNIX domain socket support
 
 go-mail works like a programatic email client and provides lots of methods and functionalities you would consider
 standard in a MUA.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+SPDX-FileCopyrightText: The go-mail Authors
 
 SPDX-License-Identifier: MIT
 -->

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 The go-mail Authors
+# SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 #
 # SPDX-License-Identifier: MIT
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+SPDX-FileCopyrightText: The go-mail Authors
 
 SPDX-License-Identifier: MIT
 -->

--- a/assets/gopher2.svg.license
+++ b/assets/gopher2.svg.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 Maria Letta, the go-mail Team
+SPDX-FileCopyrightText: Maria Letta, the go-mail Team
 
 SPDX-License-Identifier: CC-BY-ND-4.0

--- a/auth.go
+++ b/auth.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/b64linebreaker.go
+++ b/b64linebreaker.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/b64linebreaker_test.go
+++ b/b64linebreaker_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/client.go
+++ b/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/client.go
+++ b/client.go
@@ -257,10 +257,12 @@ var (
 //
 // This function initializes a Client with default values, such as connection timeout, port, TLS settings,
 // and the HELO/EHLO hostname. Option functions, if provided, can override the default configuration.
-// It ensures that essential values, like the host, are set. An error is returned if critical defaults are unset.
+// It ensures that essential values, like the host, are set. The function also supports connections to
+// UNIX domain sockets by recognizing a "unix://" prefix in the host string and adjusting the configuration
+// accordingly. An error is returned if critical defaults are unset.
 //
 // Parameters:
-//   - host: The hostname of the SMTP server to connect to.
+//   - host: The hostname of the SMTP server to connect to, or a UNIX domain socket prefixed with "unix://".
 //   - opts: Optional configuration functions to override default settings.
 //
 // Returns:

--- a/client_119.go
+++ b/client_119.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/client_120.go
+++ b/client_120.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/client_121_test.go
+++ b/client_121_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/client_test.go
+++ b/client_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+# SPDX-FileCopyrightText: The go-mail Authors
 #
 # SPDX-License-Identifier: MIT
 

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/doc.go
+++ b/doc.go
@@ -11,4 +11,4 @@ package mail
 
 // VERSION indicates the current version of the package. It is also attached to the default user
 // agent string.
-const VERSION = "0.5.2"
+const VERSION = "0.6.0"

--- a/doc_test.go
+++ b/doc_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/eml.go
+++ b/eml.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/eml_test.go
+++ b/eml_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/encoding.go
+++ b/encoding.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/file.go
+++ b/file.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/file_test.go
+++ b/file_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/go.sum.license
+++ b/go.sum.license
@@ -1,3 +1,3 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022-2024 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // SPDX-License-Identifier: MIT

--- a/header.go
+++ b/header.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/header_test.go
+++ b/header_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/internal/pkcs7/pkcs7.go
+++ b/internal/pkcs7/pkcs7.go
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2015 Andrew Smith
 // SPDX-FileCopyrightText: Copyright (c) 2017-2024 The mozilla services project (https://github.com/mozilla-services)
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // Partially forked from https://github.com/mozilla-services/pkcs7, which in turn is also a fork
 // of https://github.com/fullsailor/pkcs7.

--- a/internal/pkcs7/pkcs7_test.go
+++ b/internal/pkcs7/pkcs7_test.go
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2015 Andrew Smith
 // SPDX-FileCopyrightText: Copyright (c) 2017-2024 The mozilla services project (https://github.com/mozilla-services)
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // Partially forked from https://github.com/mozilla-services/pkcs7, which in turn is also a fork
 // of https://github.com/fullsailor/pkcs7.

--- a/log/jsonlog.go
+++ b/log/jsonlog.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2023 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/log/jsonlog_test.go
+++ b/log/jsonlog_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2023 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/log/log.go
+++ b/log/log.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/log/stdlog.go
+++ b/log/stdlog.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2023 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/log/stdlog_test.go
+++ b/log/stdlog_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2023 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/msg.go
+++ b/msg.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/msg_test.go
+++ b/msg_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/msg_totmpfile.go
+++ b/msg_totmpfile.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/msg_totmpfile_116.go
+++ b/msg_totmpfile_116.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/msg_unix_test.go
+++ b/msg_unix_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/msgwriter.go
+++ b/msgwriter.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/msgwriter_test.go
+++ b/msgwriter_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/part.go
+++ b/part.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/part_test.go
+++ b/part_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/quicksend.go
+++ b/quicksend.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/quicksend_test.go
+++ b/quicksend_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/random.go
+++ b/random.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/random_test.go
+++ b/random_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/reader.go
+++ b/reader.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/reader_test.go
+++ b/reader_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/senderror.go
+++ b/senderror.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/senderror_test.go
+++ b/senderror_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/smime.go
+++ b/smime.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/smime_test.go
+++ b/smime_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/smtp/auth.go
+++ b/smtp/auth.go
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright 2010 The Go Authors. All rights reserved.
-// SPDX-FileCopyrightText: Copyright (c) 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // Original net/smtp code from the Go stdlib by the Go Authors.
 // Use of this source code is governed by a BSD-style

--- a/smtp/auth_cram_md5.go
+++ b/smtp/auth_cram_md5.go
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright 2010 The Go Authors. All rights reserved.
-// SPDX-FileCopyrightText: Copyright (c) 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // Original net/smtp code from the Go stdlib by the Go Authors.
 // Use of this source code is governed by a BSD-style

--- a/smtp/auth_cram_md5_118.go
+++ b/smtp/auth_cram_md5_118.go
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright 2010 The Go Authors. All rights reserved.
-// SPDX-FileCopyrightText: Copyright (c) 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // Original net/smtp code from the Go stdlib by the Go Authors.
 // Use of this source code is governed by a BSD-style

--- a/smtp/auth_login.go
+++ b/smtp/auth_login.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022-2024 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/smtp/auth_plain.go
+++ b/smtp/auth_plain.go
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright 2010 The Go Authors. All rights reserved.
-// SPDX-FileCopyrightText: Copyright (c) 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // Original net/smtp code from the Go stdlib by the Go Authors.
 // Use of this source code is governed by a BSD-style

--- a/smtp/auth_scram.go
+++ b/smtp/auth_scram.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/smtp/auth_xoauth2.go
+++ b/smtp/auth_xoauth2.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2023 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/smtp/example_test.go
+++ b/smtp/example_test.go
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright 2010 The Go Authors. All rights reserved.
-// SPDX-FileCopyrightText: Copyright (c) 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // Original net/smtp code from the Go stdlib by the Go Authors.
 // Use of this source code is governed by a BSD-style

--- a/smtp/smtp.go
+++ b/smtp/smtp.go
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright 2010 The Go Authors. All rights reserved.
-// SPDX-FileCopyrightText: Copyright (c) 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // Original net/smtp code from the Go stdlib by the Go Authors.
 // Use of this source code is governed by a BSD-style

--- a/smtp/smtp_121_test.go
+++ b/smtp/smtp_121_test.go
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright 2010 The Go Authors. All rights reserved.
-// SPDX-FileCopyrightText: Copyright (c) 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // Original net/smtp code from the Go stdlib by the Go Authors.
 // Use of this source code is governed by a BSD-style

--- a/smtp/smtp_ehlo.go
+++ b/smtp/smtp_ehlo.go
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright 2010 The Go Authors. All rights reserved.
-// SPDX-FileCopyrightText: Copyright (c) 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // Original net/smtp code from the Go stdlib by the Go Authors.
 // Use of this source code is governed by a BSD-style

--- a/smtp/smtp_ehlo_117.go
+++ b/smtp/smtp_ehlo_117.go
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright 2010 The Go Authors. All rights reserved.
-// SPDX-FileCopyrightText: Copyright (c) 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // Original net/smtp code from the Go stdlib by the Go Authors.
 // Use of this source code is governed by a BSD-style

--- a/smtp/smtp_test.go
+++ b/smtp/smtp_test.go
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright 2010 The Go Authors. All rights reserved.
-// SPDX-FileCopyrightText: Copyright (c) 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // Original net/smtp code from the Go stdlib by the Go Authors.
 // Use of this source code is governed by a BSD-style

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+# SPDX-FileCopyrightText: The go-mail Authors
 #
 # SPDX-License-Identifier: MIT
 

--- a/testdata/RFC5322-A1-1-invalid-from.eml.license
+++ b/testdata/RFC5322-A1-1-invalid-from.eml.license
@@ -1,3 +1,3 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022-2024 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // SPDX-License-Identifier: MIT

--- a/testdata/RFC5322-A1-1.eml.license
+++ b/testdata/RFC5322-A1-1.eml.license
@@ -1,3 +1,3 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022-2024 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // SPDX-License-Identifier: MIT

--- a/testdata/attachment.license
+++ b/testdata/attachment.license
@@ -1,3 +1,3 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022-2024 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // SPDX-License-Identifier: MIT

--- a/testdata/attachment.txt.license
+++ b/testdata/attachment.txt.license
@@ -1,3 +1,3 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022-2024 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // SPDX-License-Identifier: MIT

--- a/testdata/dummy-chain-cert-ecdsa.pem.license
+++ b/testdata/dummy-chain-cert-ecdsa.pem.license
@@ -1,3 +1,3 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022-2024 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // SPDX-License-Identifier: MIT

--- a/testdata/dummy-chain-cert-rsa.pem.license
+++ b/testdata/dummy-chain-cert-rsa.pem.license
@@ -1,3 +1,3 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022-2024 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // SPDX-License-Identifier: MIT

--- a/testdata/dummy-child-key-ecdsa.pem.license
+++ b/testdata/dummy-child-key-ecdsa.pem.license
@@ -1,3 +1,3 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022-2024 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // SPDX-License-Identifier: MIT

--- a/testdata/dummy-child-key-rsa.pem.license
+++ b/testdata/dummy-child-key-rsa.pem.license
@@ -1,3 +1,3 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022-2024 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // SPDX-License-Identifier: MIT

--- a/testdata/embed.txt.license
+++ b/testdata/embed.txt.license
@@ -1,3 +1,3 @@
-// SPDX-FileCopyrightText: Copyright (c) 2022-2024 The go-mail Authors
+// SPDX-FileCopyrightText: Copyright (c) The go-mail Authors
 //
 // SPDX-License-Identifier: MIT

--- a/testdata/logo.svg.base64.license
+++ b/testdata/logo.svg.base64.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 Maria Letta, the go-mail Team
+SPDX-FileCopyrightText: Maria Letta, the go-mail Team
 
 SPDX-License-Identifier: CC-BY-ND-4.0

--- a/testdata/logo.svg.license
+++ b/testdata/logo.svg.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 Maria Letta, the go-mail Team
+SPDX-FileCopyrightText: Maria Letta, the go-mail Team
 
 SPDX-License-Identifier: CC-BY-ND-4.0

--- a/tls.go
+++ b/tls.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/tls_test.go
+++ b/tls_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 The go-mail Authors
+// SPDX-FileCopyrightText: The go-mail Authors
 //
 // SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
This PR does not change any code but only performs changes on comments and documentaiton:

- Update NewClient GoDoc to reflect the UNIX domain support introduced in #408 
- Bump version in doc.go to 0.6.0
- Update README
- Remove years from copyright lines (Following the cURL project (https://daniel.haxx.se/blog/2023/01/08/copyright-without-years/) 