### PR TITLE
Fix regression in multipart boundary writing

### DIFF
--- a/msgwriter.go
+++ b/msgwriter.go
@@ -141,19 +141,19 @@ func (mw *msgWriter) writeMsg(msg *Msg) {
 	}
 	if msg.hasMixed() {
 		mw.startMP(MIMEMixed, msg.boundary)
-		if mw.depth == 0 || (msg.hasSMIME() && mw.depth == 1) {
+		if mw.depth == 1 {
 			mw.writeString(DoubleNewLine)
 		}
 	}
 	if msg.hasRelated() {
 		mw.startMP(MIMERelated, msg.boundary)
-		if mw.depth == 0 || (msg.hasSMIME() && mw.depth == 1) {
+		if mw.depth == 1 {
 			mw.writeString(DoubleNewLine)
 		}
 	}
 	if msg.hasAlt() {
 		mw.startMP(MIMEAlternative, msg.boundary)
-		if mw.depth == 0 || (msg.hasSMIME() && mw.depth == 1) {
+		if mw.depth == 1 {
 			mw.writeString(DoubleNewLine)
 		}
 	}


### PR DESCRIPTION
This PR fixes a regression that was introduced in the S/MIME signing code of v0.6.0 which caused the msgwriter to not add a newline between the first boundary and the multipart causing the mail to be unable to render in mail clients.

Fixes #412 