### PR TITLE
Refactor header count logic for accurate line tracking

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -118,7 +118,7 @@ type Msg struct {
 
 	// headerCount is an indicate for how many headers have been written during the mail rendering process.
 	// This count can be helpful to identify where the mail header ends and the mail body starts
-	headerCount uint
+	headerCount int
 
 	// isDelivered indicates whether the Msg has been delivered.
 	isDelivered bool
@@ -3080,7 +3080,7 @@ func (m *Msg) signMessage() error {
 
 	// Since we only want to sign the message body, we need to find the position within
 	// the mail body from where we start reading.
-	var linecount uint = 0
+	linecount := 0
 	pos := 0
 	for linecount < m.headerCount {
 		nextIndex := bytes.Index(buf.Bytes()[pos:], []byte("\r\n"))


### PR DESCRIPTION
Changed `headerCount` from `uint` to `int` and updated its logic to accurately count lines written in headers. Modified `writeHeader` to return the number of lines written, ensuring better alignment between header tracking and actual output. This fixes a bug with S/MIME signing if a header line spanned over more than one line.