### PR TITLE
Fix regression of custom smtp.Auth not working

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -3,7 +3,7 @@
 ## SPDX-License-Identifier: MIT
 
 [run]
-go = "1.23"
+go = "1.24"
 tests = true
 exclude-dirs = ["examples"]
 

--- a/client.go
+++ b/client.go
@@ -1230,6 +1230,9 @@ func (c *Client) Send(messages ...*Msg) (returnErr error) {
 //     or if the authentication process fails.
 func (c *Client) auth(client *smtp.Client, isEnc bool) error {
 	var smtpAuth smtp.Auth
+	if c.smtpAuthType == SMTPAuthCustom {
+		smtpAuth = c.smtpAuth
+	}
 	if c.smtpAuth == nil && c.smtpAuthType != SMTPAuthNoAuth {
 		hasSMTPAuth, smtpAuthType := client.Extension("AUTH")
 		if !hasSMTPAuth {

--- a/client_test.go
+++ b/client_test.go
@@ -2630,6 +2630,101 @@ func TestClient_auth(t *testing.T) {
 			t.Fatalf("client should have failed to connect")
 		}
 	})
+	// https://github.com/wneessen/go-mail/issues/428
+	t.Run("auth with custom auth type should succeed", func(t *testing.T) {
+		PortAdder.Add(1)
+		serverPort := int(TestServerPortBase + PortAdder.Load())
+		featureSet := "250-AUTH CUSTOM\r\n250-8BITMIME\r\n250-STARTTLS\r\n250-DSN\r\n250 SMTPUTF8"
+		go func() {
+			if err := simpleSMTPServer(t.Context(), t, &serverProps{
+				FeatureSet: featureSet,
+				ListenPort: serverPort,
+			}); err != nil {
+				t.Errorf("failed to start test server: %s", err)
+				return
+			}
+		}()
+		time.Sleep(time.Millisecond * 30)
+
+		ctxDial, cancelDial := context.WithTimeout(t.Context(), time.Millisecond*500)
+		t.Cleanup(cancelDial)
+
+		message := testMessage(t)
+		client, err := NewClient(DefaultHost, WithPort(serverPort),
+			WithTLSPolicy(TLSMandatory), WithSMTPAuthCustom(newTestCustomAuth()), WithTLSConfig(&tlsConfig),
+			WithUsername("test"), WithPassword("password"))
+		if err != nil {
+			t.Fatalf("failed to create new client: %s", err)
+		}
+		if err = client.DialWithContext(ctxDial); err != nil {
+			t.Fatalf("failed to connect to test server: %s", err)
+		}
+		if err = client.Send(message); err != nil {
+			t.Errorf("failed to send message: %s", err)
+		}
+	})
+	// https://github.com/wneessen/go-mail/issues/428
+	t.Run("auth with custom auth type should fail", func(t *testing.T) {
+		PortAdder.Add(1)
+		serverPort := int(TestServerPortBase + PortAdder.Load())
+		featureSet := "250-AUTH UNKNOWN\r\n250-8BITMIME\r\n250-STARTTLS\r\n250-DSN\r\n250 SMTPUTF8"
+		go func() {
+			if err := simpleSMTPServer(t.Context(), t, &serverProps{
+				FeatureSet: featureSet,
+				ListenPort: serverPort,
+			}); err != nil {
+				t.Errorf("failed to start test server: %s", err)
+				return
+			}
+		}()
+		time.Sleep(time.Millisecond * 30)
+
+		ctxDial, cancelDial := context.WithTimeout(t.Context(), time.Millisecond*500)
+		t.Cleanup(cancelDial)
+
+		client, err := NewClient(DefaultHost, WithPort(serverPort),
+			WithTLSPolicy(TLSMandatory), WithSMTPAuthCustom(newTestCustomAuth()), WithTLSConfig(&tlsConfig),
+			WithUsername("test"), WithPassword("password"))
+		if err != nil {
+			t.Fatalf("failed to create new client: %s", err)
+		}
+		if err = client.DialWithContext(ctxDial); err == nil {
+			t.Fatalf("client should have failed to connect")
+		}
+	})
+	// https://github.com/wneessen/go-mail/issues/428
+	t.Run("auth with custom auth type overridden by SetCustomAuth", func(t *testing.T) {
+		PortAdder.Add(1)
+		serverPort := int(TestServerPortBase + PortAdder.Load())
+		featureSet := "250-AUTH CUSTOM\r\n250-8BITMIME\r\n250-STARTTLS\r\n250-DSN\r\n250 SMTPUTF8"
+		go func() {
+			if err := simpleSMTPServer(t.Context(), t, &serverProps{
+				FeatureSet: featureSet,
+				ListenPort: serverPort,
+			}); err != nil {
+				t.Errorf("failed to start test server: %s", err)
+				return
+			}
+		}()
+		time.Sleep(time.Millisecond * 30)
+
+		ctxDial, cancelDial := context.WithTimeout(t.Context(), time.Millisecond*500)
+		t.Cleanup(cancelDial)
+
+		message := testMessage(t)
+		client, err := NewClient(DefaultHost, WithPort(serverPort),
+			WithTLSPolicy(TLSMandatory), WithSMTPAuth(SMTPAuthPlain), WithTLSConfig(&tlsConfig))
+		if err != nil {
+			t.Fatalf("failed to create new client: %s", err)
+		}
+		client.SetSMTPAuthCustom(newTestCustomAuth())
+		if err = client.DialWithContext(ctxDial); err != nil {
+			t.Fatalf("failed to connect to test server: %s", err)
+		}
+		if err = client.Send(message); err != nil {
+			t.Errorf("failed to send message: %s", err)
+		}
+	})
 }
 
 func TestClient_authTypeAutoDiscover(t *testing.T) {
@@ -3911,6 +4006,39 @@ func (t *testSender) Send(ctx context.Context, m *Msg) error {
 		return fmt.Errorf("failed to dial and send mail: %w", err)
 	}
 	return nil
+}
+
+// testCustomAuth is a custom authentication mechanism implementation that satisfies the smtp.Auth
+// interface. It is used to test the SMTPAuthCustom type.
+type testCustomAuth struct{}
+
+// newTestCustomAuth initializes and returns a new testCustomAuth instance for use in testing
+// custom authentication.
+func newTestCustomAuth() *testCustomAuth {
+	return &testCustomAuth{}
+}
+
+// Start begins the custom authentication process, verifying if the "CUSTOM" method is supported
+// by the SMTP server.
+func (a *testCustomAuth) Start(info *smtp.ServerInfo) (proto string, toServer []byte, err error) {
+	if len(info.Auth) > 0 {
+		supported := false
+		for _, method := range info.Auth {
+			if method == "CUSTOM" {
+				supported = true
+			}
+		}
+		if !supported {
+			return "", nil, fmt.Errorf("custom auth method not supported")
+		}
+	}
+	return "CUSTOM", nil, nil
+}
+
+// Next processes the next step in the authentication exchange, returning data to send to the server
+// or an error.
+func (a *testCustomAuth) Next([]byte, bool) (toServer []byte, err error) {
+	return nil, nil
 }
 
 // parseJSONLog parses a JSON encoded log from the provided buffer and returns a slice of logLine structs.

--- a/client_test.go
+++ b/client_test.go
@@ -2632,11 +2632,13 @@ func TestClient_auth(t *testing.T) {
 	})
 	// https://github.com/wneessen/go-mail/issues/428
 	t.Run("auth with custom auth type should succeed", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		PortAdder.Add(1)
 		serverPort := int(TestServerPortBase + PortAdder.Load())
 		featureSet := "250-AUTH CUSTOM\r\n250-8BITMIME\r\n250-STARTTLS\r\n250-DSN\r\n250 SMTPUTF8"
 		go func() {
-			if err := simpleSMTPServer(t.Context(), t, &serverProps{
+			if err := simpleSMTPServer(ctx, t, &serverProps{
 				FeatureSet: featureSet,
 				ListenPort: serverPort,
 			}); err != nil {
@@ -2646,7 +2648,7 @@ func TestClient_auth(t *testing.T) {
 		}()
 		time.Sleep(time.Millisecond * 30)
 
-		ctxDial, cancelDial := context.WithTimeout(t.Context(), time.Millisecond*500)
+		ctxDial, cancelDial := context.WithTimeout(ctx, time.Millisecond*500)
 		t.Cleanup(cancelDial)
 
 		message := testMessage(t)
@@ -2665,11 +2667,13 @@ func TestClient_auth(t *testing.T) {
 	})
 	// https://github.com/wneessen/go-mail/issues/428
 	t.Run("auth with custom auth type should fail", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		PortAdder.Add(1)
 		serverPort := int(TestServerPortBase + PortAdder.Load())
 		featureSet := "250-AUTH UNKNOWN\r\n250-8BITMIME\r\n250-STARTTLS\r\n250-DSN\r\n250 SMTPUTF8"
 		go func() {
-			if err := simpleSMTPServer(t.Context(), t, &serverProps{
+			if err := simpleSMTPServer(ctx, t, &serverProps{
 				FeatureSet: featureSet,
 				ListenPort: serverPort,
 			}); err != nil {
@@ -2679,7 +2683,7 @@ func TestClient_auth(t *testing.T) {
 		}()
 		time.Sleep(time.Millisecond * 30)
 
-		ctxDial, cancelDial := context.WithTimeout(t.Context(), time.Millisecond*500)
+		ctxDial, cancelDial := context.WithTimeout(ctx, time.Millisecond*500)
 		t.Cleanup(cancelDial)
 
 		client, err := NewClient(DefaultHost, WithPort(serverPort),
@@ -2694,11 +2698,13 @@ func TestClient_auth(t *testing.T) {
 	})
 	// https://github.com/wneessen/go-mail/issues/428
 	t.Run("auth with custom auth type overridden by SetCustomAuth", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		PortAdder.Add(1)
 		serverPort := int(TestServerPortBase + PortAdder.Load())
 		featureSet := "250-AUTH CUSTOM\r\n250-8BITMIME\r\n250-STARTTLS\r\n250-DSN\r\n250 SMTPUTF8"
 		go func() {
-			if err := simpleSMTPServer(t.Context(), t, &serverProps{
+			if err := simpleSMTPServer(ctx, t, &serverProps{
 				FeatureSet: featureSet,
 				ListenPort: serverPort,
 			}); err != nil {
@@ -2708,7 +2714,7 @@ func TestClient_auth(t *testing.T) {
 		}()
 		time.Sleep(time.Millisecond * 30)
 
-		ctxDial, cancelDial := context.WithTimeout(t.Context(), time.Millisecond*500)
+		ctxDial, cancelDial := context.WithTimeout(ctx, time.Millisecond*500)
 		t.Cleanup(cancelDial)
 
 		message := testMessage(t)

--- a/msg_test.go
+++ b/msg_test.go
@@ -7314,7 +7314,7 @@ func (mw uppercaseMiddleware) Handle(m *Msg) *Msg {
 	if !ok {
 		fmt.Println("can't find the subject header")
 	}
-	if s == nil || len(s) < 1 {
+	if len(s) < 1 {
 		s = append(s, "")
 	}
 	m.Subject(strings.ToUpper(s[0]))
@@ -7335,7 +7335,7 @@ func (mw encodeMiddleware) Handle(m *Msg) *Msg {
 	if !ok {
 		fmt.Println("can't find the subject header")
 	}
-	if s == nil || len(s) < 1 {
+	if len(s) < 1 {
 		s = append(s, "")
 	}
 	m.Subject(strings.Replace(s[0], "a", "@", -1))


### PR DESCRIPTION
This change re-introduces custom smtp.Auth support, which has been removed by accident. See #428. To make sure this does not happen again, a couple of tests have been added that make sure the custom auth is working as intended. This includes a `testCustomAuth` struct to verify the "CUSTOM" method and enhancements in the client to handle custom auth types. Resolves issue #428.