### PR TITLE
Skip tests for broken rand.Reader on Go 1.24+.

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The go-mail Authors
+//
+// SPDX-License-Identifier: MIT
+
 package mail
 
 import (

--- a/helper_test.go
+++ b/helper_test.go
@@ -1,0 +1,22 @@
+package mail
+
+import (
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// getGoVersion returns the current Go runtime version as a float64. It fails the test if the version
+// parsing encounters an error.
+func getGoVersion(t *testing.T) float64 {
+	t.Helper()
+	version := runtime.Version()
+	version = version[2:]
+	version = version[:strings.LastIndex(version, ".")]
+	vernum, err := strconv.ParseFloat(version, 64)
+	if err != nil {
+		t.Fatalf("failed to parse Go version: %s", err)
+	}
+	return vernum
+}

--- a/msg_test.go
+++ b/msg_test.go
@@ -5925,6 +5925,10 @@ func TestMsg_WriteTo(t *testing.T) {
 		}
 	})
 	t.Run("WriteTo with S/MIME signing fails with broken rand.Reader", func(t *testing.T) {
+		version := getGoVersion(t)
+		if version >= 1.24 {
+			t.Skip("Go 1.24+ never fails on broken rand Reader. See: https://github.com/golang/go/issues/66821")
+		}
 		defaultRandReader := rand.Reader
 		t.Cleanup(func() { rand.Reader = defaultRandReader })
 		rand.Reader = &randReader{failon: 1}

--- a/msgwriter_test.go
+++ b/msgwriter_test.go
@@ -282,6 +282,10 @@ func TestMsgWriter_writeMsg(t *testing.T) {
 		}
 	})
 	t.Run("msgWriter fails on S/MIME signing with broken rand.Reader", func(t *testing.T) {
+		version := getGoVersion(t)
+		if version >= 1.24 {
+			t.Skip("Go 1.24+ never fails on broken rand Reader. See: https://github.com/golang/go/issues/66821")
+		}
 		defaultRandReader := rand.Reader
 		t.Cleanup(func() { rand.Reader = defaultRandReader })
 		rand.Reader = &randReader{failon: 1}

--- a/random_test.go
+++ b/random_test.go
@@ -41,6 +41,10 @@ func TestRandomStringSecure(t *testing.T) {
 		}
 	})
 	t.Run("randomStringSecure fails on broken rand Reader (first read)", func(t *testing.T) {
+		version := getGoVersion(t)
+		if version >= 1.24 {
+			t.Skip("Go 1.24+ never fails on broken rand Reader. See: https://github.com/golang/go/issues/66821")
+		}
 		defaultRandReader := rand.Reader
 		t.Cleanup(func() { rand.Reader = defaultRandReader })
 		rand.Reader = &randReader{failon: 1}
@@ -49,6 +53,10 @@ func TestRandomStringSecure(t *testing.T) {
 		}
 	})
 	t.Run("randomStringSecure fails on broken rand Reader (second read)", func(t *testing.T) {
+		version := getGoVersion(t)
+		if version >= 1.24 {
+			t.Skip("Go 1.24+ never fails on broken rand Reader. See: https://github.com/golang/go/issues/66821")
+		}
 		defaultRandReader := rand.Reader
 		t.Cleanup(func() { rand.Reader = defaultRandReader })
 		rand.Reader = &randReader{failon: 0}
@@ -69,6 +77,10 @@ func TestRandomBoundary(t *testing.T) {
 		}
 	})
 	t.Run("randomBoundary fails on broken rand Reader", func(t *testing.T) {
+		version := getGoVersion(t)
+		if version >= 1.24 {
+			t.Skip("Go 1.24+ never fails on broken rand Reader. See: https://github.com/golang/go/issues/66821")
+		}
 		defaultRandReader := rand.Reader
 		t.Cleanup(func() { rand.Reader = defaultRandReader })
 		rand.Reader = &randReader{failon: 1}


### PR DESCRIPTION
Tests involving broken rand.Reader are skipped for Go 1.24 and above due to upstream changes that prevent failures. A `getGoVersion` helper function is added to determine the runtime version, ensuring test compatibility and reducing false negatives. This PR closes #432.