### PR TITLE
Update version to 0.6.2 and fix typo in documentation

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -5,10 +5,10 @@
 // Package mail provides an easy to use interface for formating and sending mails. go-mail follows idiomatic Go style
 // and best practice. It has a small dependency footprint by mainly relying on the Go Standard Library and the Go
 // extended packages. It combines a lot of functionality from the standard library to give easy and convenient access
-// to mail and SMTP related tasks. It works like a programatic email client and provides lots of methods and
+// to mail and SMTP related tasks. It works like a programmatic email client and provides lots of methods and
 // functionalities you would consider standard in a MUA.
 package mail
 
 // VERSION indicates the current version of the package. It is also attached to the default user
 // agent string.
-const VERSION = "0.6.1"
+const VERSION = "0.6.2"


### PR DESCRIPTION
Corrected a spelling error in the package description ("programmatic") for improved clarity. Bumped the package version from 0.6.1 to 0.6.2 to reflect this change.