### PR TITLE
BREAKING CHANGE: Refactor Reply-To header handling.

### DIFF
--- a/header.go
+++ b/header.go
@@ -76,9 +76,6 @@ const (
 	// HeaderReferences is the "References" header field.
 	HeaderReferences Header = "References"
 
-	// HeaderReplyTo is the "Reply-To" header field.
-	HeaderReplyTo Header = "Reply-To"
-
 	// HeaderSubject is the "Subject" header field.
 	HeaderSubject Header = "Subject"
 
@@ -114,6 +111,9 @@ const (
 
 	// HeaderFrom is the "From" header field.
 	HeaderFrom AddrHeader = "From"
+
+	// HeaderReplyTo is the "Reply-To" header field.
+	HeaderReplyTo AddrHeader = "Reply-To"
 
 	// HeaderTo is the "Receipient" header field.
 	HeaderTo AddrHeader = "To"

--- a/header_test.go
+++ b/header_test.go
@@ -36,7 +36,6 @@ var (
 		{"Header: Precedence", HeaderPrecedence, "Precedence"},
 		{"Header: Priority", HeaderPriority, "Priority"},
 		{"Header: References", HeaderReferences, "References"},
-		{"Header: Reply-To", HeaderReplyTo, "Reply-To"},
 		{"Header: Subject", HeaderSubject, "Subject"},
 		{"Header: User-Agent", HeaderUserAgent, "User-Agent"},
 		{"Header: X-Auto-Response-Suppress", HeaderXAutoResponseSuppress, "X-Auto-Response-Suppress"},
@@ -53,6 +52,7 @@ var (
 		{"To", HeaderTo, "To"},
 		{"Cc", HeaderCc, "Cc"},
 		{"Bcc", HeaderBcc, "Bcc"},
+		{"Reply-To", HeaderReplyTo, "Reply-To"},
 	}
 )
 

--- a/msg.go
+++ b/msg.go
@@ -988,12 +988,7 @@ func (m *Msg) BccFromString(rcpts string) error {
 // References:
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.2
 func (m *Msg) ReplyTo(addr string) error {
-	replyTo, err := mail.ParseAddress(addr)
-	if err != nil {
-		return fmt.Errorf("failed to parse reply-to address: %w", err)
-	}
-	m.SetGenHeader(HeaderReplyTo, replyTo.String())
-	return nil
+	return m.SetAddrHeader(HeaderReplyTo, addr)
 }
 
 // ReplyToFormat sets the "Reply-To" address for the Msg using the provided name and email address, specifying

--- a/msgwriter.go
+++ b/msgwriter.go
@@ -118,7 +118,7 @@ func (mw *msgWriter) writeMsg(msg *Msg) {
 	}
 
 	// Set the rest of the address headers
-	for _, to := range []AddrHeader{HeaderTo, HeaderCc} {
+	for _, to := range []AddrHeader{HeaderTo, HeaderCc, HeaderReplyTo} {
 		if addresses, ok := msg.addrHeader[to]; ok {
 			var val []string
 			for _, addr := range addresses {


### PR DESCRIPTION
Changed `Reply-To` header to an `AddrHeader` type. Since `Reply-To` is actually an address header which formats the mail address accordingly, and not a generic header, this could lead to potential double encoding if the address and name contain special characters. 

This PR is potentially a breaking change, since we are changing a public type, but as long as the user makes use of `msg.ReplyTo()` or `msg.ReplyToFormat()` this should not cause any problems.

This PR fixes #440.