### PR TITLE
Fix "short writes" in Base64LineBreaker.Write

### DIFF
--- a/b64linebreaker.go
+++ b/b64linebreaker.go
@@ -53,7 +53,7 @@ func (l *Base64LineBreaker) Write(data []byte) (numBytes int, err error) {
 		return len(data), nil
 	}
 
-	numBytes, err = l.out.Write(l.line[0:l.used])
+	_, err = l.out.Write(l.line[0:l.used])
 	if err != nil {
 		return
 	}
@@ -65,12 +65,15 @@ func (l *Base64LineBreaker) Write(data []byte) (numBytes int, err error) {
 		return
 	}
 
-	numBytes, err = l.out.Write(newlineBytes)
+	_, err = l.out.Write(newlineBytes)
 	if err != nil {
 		return
 	}
 
-	return l.Write(data[excess:])
+	var n int
+	n, err = l.Write(data[excess:]) // recurse
+	numBytes += n
+	return
 }
 
 // Close finalizes the Base64LineBreaker, writing any remaining buffered data and appending a newline.


### PR DESCRIPTION
The count of bytes written is incorrectly reported by [`Base64LineBreaker.Write`](https://pkg.go.dev/github.com/wneessen/go-mail#Base64LineBreaker.Write). This issue is not visible externally as `Base64LineBreaker.Write` is only called via `encoding/base64.Encoder.Write` (like in the original implementation in stdlib `encoding/pem.lineBreaker`) which ignores the returned bytes count.

The issue is not visible either with the test suite (not even via the current fuzzing tests) because the tests also use `Base64LineBreaker` through the [`encoding/base64.Encoder`](https://pkg.go.dev/encoding/base64#Encoder).

So we could just keep the existing code. The only risk is if `encoding/base64` behavior changes in the future.

See also [CL 653675](https://go.dev/cl/653675) which aims to fix the same issue in `encoding/pem`.