### PR TITLE
Make Base64LineBreaker private

### DIFF
--- a/b64linebreaker.go
+++ b/b64linebreaker.go
@@ -13,10 +13,7 @@ import (
 // in encoding processes.
 var newlineBytes = []byte(SingleNewLine)
 
-// ErrNoOutWriter is the error returned when no io.Writer is set for Base64LineBreaker.
-var ErrNoOutWriter = errors.New("no io.Writer set for Base64LineBreaker")
-
-// Base64LineBreaker handles base64 encoding with the insertion of new lines after a certain number
+// base64LineBreaker handles base64 encoding with the insertion of new lines after a certain number
 // of characters.
 //
 // This struct is used to manage base64 encoding while ensuring that new lines are inserted after
@@ -24,15 +21,15 @@ var ErrNoOutWriter = errors.New("no io.Writer set for Base64LineBreaker")
 //
 // References:
 //   - https://datatracker.ietf.org/doc/html/rfc2045 (Base64 and line length limitations)
-type Base64LineBreaker struct {
+type base64LineBreaker struct {
 	line [MaxBodyLength]byte
 	used int
 	out  io.Writer
 }
 
-// Write writes data to the Base64LineBreaker, ensuring lines do not exceed MaxBodyLength.
+// Write writes data to the base64LineBreaker, ensuring lines do not exceed MaxBodyLength.
 //
-// This method writes the provided data to the Base64LineBreaker. It ensures that the written
+// This method writes the provided data to the base64LineBreaker. It ensures that the written
 // lines do not exceed the MaxBodyLength. If the data exceeds the limit, it handles the
 // continuation by splitting the data and writing new lines as necessary.
 //
@@ -42,9 +39,9 @@ type Base64LineBreaker struct {
 // Returns:
 //   - numBytes: The number of bytes written.
 //   - err: An error if one occurred during the write operation.
-func (l *Base64LineBreaker) Write(data []byte) (numBytes int, err error) {
+func (l *base64LineBreaker) Write(data []byte) (numBytes int, err error) {
 	if l.out == nil {
-		err = ErrNoOutWriter
+		err = errors.New("no io.Writer set for base64LineBreaker")
 		return
 	}
 	if l.used+len(data) < MaxBodyLength {
@@ -73,15 +70,15 @@ func (l *Base64LineBreaker) Write(data []byte) (numBytes int, err error) {
 	return l.Write(data[excess:])
 }
 
-// Close finalizes the Base64LineBreaker, writing any remaining buffered data and appending a newline.
+// Close finalizes the base64LineBreaker, writing any remaining buffered data and appending a newline.
 //
 // This method ensures that any remaining data in the buffer is written to the output and appends
-// a newline. It is used to finalize the Base64LineBreaker and should be called when no more data
+// a newline. It is used to finalize the base64LineBreaker and should be called when no more data
 // is expected to be written.
 //
 // Returns:
 //   - err: An error if one occurred during the final write operation.
-func (l *Base64LineBreaker) Close() (err error) {
+func (l *base64LineBreaker) Close() (err error) {
 	if l.used > 0 {
 		_, err = l.out.Write(l.line[0:l.used])
 		if err != nil {

--- a/b64linebreaker_test.go
+++ b/b64linebreaker_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -22,7 +23,7 @@ var (
 func TestBase64LineBreaker(t *testing.T) {
 	t.Run("write, copy and close", func(t *testing.T) {
 		logoWriter := bytes.NewBuffer(nil)
-		lineBreaker := &Base64LineBreaker{out: logoWriter}
+		lineBreaker := &base64LineBreaker{out: logoWriter}
 		t.Cleanup(func() {
 			if err := lineBreaker.Close(); err != nil {
 				t.Errorf("failed to close line breaker: %s", err)
@@ -44,7 +45,7 @@ func TestBase64LineBreaker(t *testing.T) {
 		})
 
 		logoWriter := bytes.NewBuffer(nil)
-		lineBreaker := &Base64LineBreaker{out: logoWriter}
+		lineBreaker := &base64LineBreaker{out: logoWriter}
 		t.Cleanup(func() {
 			if err := lineBreaker.Close(); err != nil {
 				t.Errorf("failed to close line breaker: %s", err)
@@ -86,16 +87,17 @@ func TestBase64LineBreaker(t *testing.T) {
 		}
 	})
 	t.Run("fail with no writer defined", func(t *testing.T) {
-		lineBreaker := &Base64LineBreaker{}
+		lineBreaker := &base64LineBreaker{}
 		_, err := lineBreaker.Write([]byte("testdata"))
 		if err == nil {
-			t.Errorf("writing to Base64LineBreaker with no output io.Writer was supposed to failed, but didn't")
+			t.Errorf("writing to base64LineBreaker with no output io.Writer was supposed to failed, but didn't")
 		}
-		if !errors.Is(err, ErrNoOutWriter) {
-			t.Errorf("unexpected error while writing to empty Base64LineBreaker: %s", err)
+		expErr := "no io.Writer set for base64LineBreaker"
+		if !strings.Contains(err.Error(), expErr) {
+			t.Errorf("unexpected error while writing to empty base64LineBreaker: %s", err)
 		}
-		if err := lineBreaker.Close(); err != nil {
-			t.Errorf("failed to close Base64LineBreaker: %s", err)
+		if err = lineBreaker.Close(); err != nil {
+			t.Errorf("failed to close base64LineBreaker: %s", err)
 		}
 	})
 	t.Run("write on an already closed output writer", func(t *testing.T) {
@@ -110,14 +112,14 @@ func TestBase64LineBreaker(t *testing.T) {
 		})
 
 		writeBuffer := &errorWriter{}
-		lineBreaker := &Base64LineBreaker{out: writeBuffer}
+		lineBreaker := &base64LineBreaker{out: writeBuffer}
 		_, err = io.Copy(lineBreaker, logo)
 		if err == nil {
-			t.Errorf("writing to Base64LineBreaker with an already closed output io.Writer was " +
+			t.Errorf("writing to base64LineBreaker with an already closed output io.Writer was " +
 				"supposed to failed, but didn't")
 		}
 		if !errors.Is(err, errClosedWriter) {
-			t.Errorf("unexpected error while writing to Base64LineBreaker: %s", err)
+			t.Errorf("unexpected error while writing to base64LineBreaker: %s", err)
 		}
 	})
 	t.Run("fail on different scenarios with mock writer", func(t *testing.T) {
@@ -146,7 +148,7 @@ func TestBase64LineBreaker(t *testing.T) {
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				lineBreaker := &Base64LineBreaker{out: tt.writer}
+				lineBreaker := &base64LineBreaker{out: tt.writer}
 
 				_, err := lineBreaker.Write(tt.data)
 				if err != nil && !errors.Is(err, errMockDefault) && !errors.Is(err, errMockNewline) {
@@ -242,7 +244,7 @@ func FuzzBase64LineBreaker(f *testing.F) {
 			return
 		}
 		buffer := bytes.NewBuffer(nil)
-		lineBreaker := &Base64LineBreaker{
+		lineBreaker := &base64LineBreaker{
 			out: buffer,
 		}
 		base64Encoder := base64.NewEncoder(base64.StdEncoding, lineBreaker)

--- a/msgwriter.go
+++ b/msgwriter.go
@@ -518,7 +518,7 @@ func (mw *msgWriter) writeBody(writeFunc func(io.Writer) (int64, error), encodin
 		writer = mw.partWriter
 	}
 	writeBuffer := bytes.Buffer{}
-	lineBreaker := Base64LineBreaker{}
+	lineBreaker := base64LineBreaker{}
 	lineBreaker.out = &writeBuffer
 
 	switch encoding {


### PR DESCRIPTION
Rename `Base64LineBreaker` to `base64LineBreaker` and update associated methods, variables, and error messages. As Olivier Mengué pointed out in #444, making the API public was a poor choice by myself, since the struct has no public fields and since the `io.Writer` is required, nobody except go-mail would ever be able to use the API. This is a breaking change, but since nobody would be able to use the API anyways, it should not affect any user. This PR closes #444.