### PR TITLE
Add support for mail.Address instances

### DIFF
--- a/header.go
+++ b/header.go
@@ -4,6 +4,8 @@
 
 package mail
 
+import "strings"
+
 // Header is a type wrapper for a string and represents email header fields in a Msg.
 type Header string
 
@@ -221,4 +223,19 @@ func (h Header) String() string {
 //   - A string representing the AddrHeader.
 func (a AddrHeader) String() string {
 	return string(a)
+}
+
+// IsAddrHeader checks if the provided string is an address header. It returns true on a valid AddrHeader
+// and false for any other string.
+//
+// Parameters:
+//   - header: The string to check.
+func IsAddrHeader(header string) bool {
+	addrHeaderList := []string{"bcc", "cc", "envelopefrom", "from", "reply-to", "to"}
+	for _, addrHeader := range addrHeaderList {
+		if addrHeader == strings.ToLower(header) {
+			return true
+		}
+	}
+	return false
 }

--- a/header.go
+++ b/header.go
@@ -115,7 +115,7 @@ const (
 	// HeaderReplyTo is the "Reply-To" header field.
 	HeaderReplyTo AddrHeader = "Reply-To"
 
-	// HeaderTo is the "Receipient" header field.
+	// HeaderTo is the "Recipient" header field.
 	HeaderTo AddrHeader = "To"
 )
 

--- a/msg.go
+++ b/msg.go
@@ -621,7 +621,7 @@ func (m *Msg) SetAddrHeaderFromMailAddress(header AddrHeader, values ...*mail.Ad
 	}
 
 	switch header {
-	case HeaderFrom, HeaderReplyTo:
+	case HeaderEnvelopeFrom, HeaderFrom, HeaderReplyTo:
 		if len(addresses) > 0 {
 			m.addrHeader[header] = []*mail.Address{addresses[0]}
 		}
@@ -699,6 +699,23 @@ func (m *Msg) EnvelopeFrom(from string) error {
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.4
 func (m *Msg) EnvelopeFromFormat(name, addr string) error {
 	return m.SetAddrHeader(HeaderEnvelopeFrom, fmt.Sprintf(`"%s" <%s>`, name, addr))
+}
+
+// EnvelopeFromMailAddress sets the "FROM" address in the mail body for the Msg using a mail.Address instance.
+//
+// The HeaderEnvelopeFrom address is generally not included in the mail body but only used by the
+// Client for communication with the SMTP server. If the Msg has no "FROM" address set in the mail
+// body, the msgWriter will try to use the envelope from address if it has been set for the Msg.
+// The provided name and address are validated according to RFC 5322 and will return an error if
+// the validation fails.
+//
+// Parameters:
+//   - addr: The address as mail.Address instance to be set as envelope from address.
+//
+// References:
+//   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.2
+func (m *Msg) EnvelopeFromMailAddress(addr *mail.Address) {
+	m.SetAddrHeaderFromMailAddress(HeaderEnvelopeFrom, addr)
 }
 
 // From sets the "FROM" address in the mail body for the Msg.
@@ -1153,7 +1170,7 @@ func (m *Msg) ReplyTo(addr string) error {
 // address for responses.
 //
 // Parameters:
-//   - rcpts: The mail.Address instance to set as the "Reply-To" address.
+//   - addr: The mail.Address instance to set as the "Reply-To" address.
 //
 // References:
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3

--- a/msg.go
+++ b/msg.go
@@ -804,8 +804,8 @@ func (m *Msg) AddTo(rcpt string) error {
 //
 // This method allows you to add a single recipient to the "TO" field without replacing any previously set
 // "TO" addresses. The "TO" address specifies the primary recipient(s) of the message and is visible in the mail
-// client. The provided address is validated according to RFC 5322, and an error will be returned if the
-// validation fails.
+// client. Since the provided mail.Address has already been validated, no further validation is performed in
+// this method and the values are used as given.
 //
 // Parameters:
 //   - rcpt: The recipient email address as *mail.Address to add to the "TO" field.
@@ -924,6 +924,23 @@ func (m *Msg) CcMailAddress(rcpts ...*mail.Address) {
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
 func (m *Msg) AddCc(rcpt string) error {
 	return m.addAddr(HeaderCc, rcpt)
+}
+
+// AddCcMailAddress adds a single "CC" address to the existing list of recipients in the mail body for the Msg.
+//
+// This method allows you to add a single recipient to the "CC" field without replacing any previously set "CC"
+// addresses. The "CC" address specifies secondary recipient(s) and is visible to all recipients, including those
+// in the "TO" field. Since the provided mail.Address has already been validated, no further validation is
+// performed in this method and the values are used as given.
+//
+// Parameters:
+//   - rcpt: The recipient email address as *mail.Address to add to the "CC" field.
+//
+// References:
+//   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
+func (m *Msg) AddCcMailAddress(rcpt *mail.Address) {
+	addresses := append(m.addrHeader[HeaderCc], rcpt)
+	m.SetAddrHeaderFromMailAddress(HeaderCc, addresses...)
 }
 
 // AddCcFormat adds a single "CC" (carbon copy) address with the provided name and email to the existing list

--- a/msg.go
+++ b/msg.go
@@ -591,7 +591,7 @@ func (m *Msg) SetAddrHeader(header AddrHeader, values ...string) error {
 	return nil
 }
 
-// SetAddrHeaderFromAddr sets the specified AddrHeader for the Msg to the given mail.Address values.
+// SetAddrHeaderFromMailAddress sets the specified AddrHeader for the Msg to the given mail.Address values.
 //
 // This method allows you to set address-related headers for the message, with mail.Address instances
 // as input. Using this method helps maintain the integrity of the email addresses within the message.
@@ -602,12 +602,12 @@ func (m *Msg) SetAddrHeader(header AddrHeader, values ...string) error {
 //
 // Parameters:
 //   - header: The AddrHeader to set in the Msg (e.g., "From", "To", "Cc", "Bcc").
-//   - addresses: One or more mail.Address instances representing the email addresses to associate with
+//   - addresses: One or more mail.Address pointers representing the email addresses to associate with
 //     the specified header.
 //
 // References:
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.4
-func (m *Msg) SetAddrHeaderFromAddr(header AddrHeader, values ...*mail.Address) {
+func (m *Msg) SetAddrHeaderFromMailAddress(header AddrHeader, values ...*mail.Address) {
 	if m.addrHeader == nil {
 		m.addrHeader = make(map[AddrHeader][]*mail.Address)
 	}
@@ -718,7 +718,7 @@ func (m *Msg) From(from string) error {
 	return m.SetAddrHeader(HeaderFrom, from)
 }
 
-// FromAddr sets the "FROM" address in the mail body for the Msg using a mail.Address instance.
+// FromMailAddress sets the "FROM" address in the mail body for the Msg using a mail.Address instance.
 //
 // The "FROM" address is included in the mail body and indicates the sender of the message to
 // the recipient. This address is visible in the email client and is typically displayed to the
@@ -730,8 +730,8 @@ func (m *Msg) From(from string) error {
 //
 // References:
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.2
-func (m *Msg) FromAddr(from *mail.Address) {
-	m.SetAddrHeaderFromAddr(HeaderFrom, from)
+func (m *Msg) FromMailAddress(from *mail.Address) {
+	m.SetAddrHeaderFromMailAddress(HeaderFrom, from)
 }
 
 // FromFormat sets the provided name and mail address as the "FROM" address in the mail body for the Msg.
@@ -768,7 +768,7 @@ func (m *Msg) To(rcpts ...string) error {
 	return m.SetAddrHeader(HeaderTo, rcpts...)
 }
 
-// ToAddr sets one or more "TO" addresses in the mail body for the Msg.
+// ToMailAddress sets one or more "TO" addresses in the mail body for the Msg.
 //
 // The "TO" address specifies the primary recipient(s) of the message and is included in the mail body.
 // This address is visible to the recipient and any other recipients of the message. Multiple "TO" addresses
@@ -780,8 +780,8 @@ func (m *Msg) To(rcpts ...string) error {
 //
 // References:
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
-func (m *Msg) ToAddr(rcpts ...*mail.Address) {
-	m.SetAddrHeaderFromAddr(HeaderTo, rcpts...)
+func (m *Msg) ToMailAddress(rcpts ...*mail.Address) {
+	m.SetAddrHeaderFromMailAddress(HeaderTo, rcpts...)
 }
 
 // AddTo adds a single "TO" address to the existing list of recipients in the mail body for the Msg.
@@ -800,7 +800,7 @@ func (m *Msg) AddTo(rcpt string) error {
 	return m.addAddr(HeaderTo, rcpt)
 }
 
-// AddToAddr adds a single "TO" address to the existing list of recipients in the mail body for the Msg.
+// AddToMailAddress adds a single "TO" address to the existing list of recipients in the mail body for the Msg.
 //
 // This method allows you to add a single recipient to the "TO" field without replacing any previously set
 // "TO" addresses. The "TO" address specifies the primary recipient(s) of the message and is visible in the mail
@@ -812,9 +812,9 @@ func (m *Msg) AddTo(rcpt string) error {
 //
 // References:
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
-func (m *Msg) AddToAddr(rcpt *mail.Address) {
+func (m *Msg) AddToMailAddress(rcpt *mail.Address) {
 	addresses := append(m.addrHeader[HeaderTo], rcpt)
-	m.SetAddrHeaderFromAddr(HeaderTo, addresses...)
+	m.SetAddrHeaderFromMailAddress(HeaderTo, addresses...)
 }
 
 // AddToFormat adds a single "TO" address with the provided name and email to the existing list of recipients
@@ -893,7 +893,7 @@ func (m *Msg) Cc(rcpts ...string) error {
 	return m.SetAddrHeader(HeaderCc, rcpts...)
 }
 
-// CcAddr sets one or more "CC" (carbon copy) addresses in the mail body for the Msg.
+// CcMailAddress sets one or more "CC" (carbon copy) addresses in the mail body for the Msg.
 //
 // The "CC" address specifies secondary recipient(s) of the message, and is included in the mail body.
 // This address is visible to the recipient and any other recipients of the message. Multiple "CC" addresses
@@ -905,8 +905,8 @@ func (m *Msg) Cc(rcpts ...string) error {
 //
 // References:
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
-func (m *Msg) CcAddr(rcpts ...*mail.Address) {
-	m.SetAddrHeaderFromAddr(HeaderCc, rcpts...)
+func (m *Msg) CcMailAddress(rcpts ...*mail.Address) {
+	m.SetAddrHeaderFromMailAddress(HeaderCc, rcpts...)
 }
 
 // AddCc adds a single "CC" (carbon copy) address to the existing list of "CC" recipients in the mail body

--- a/msg.go
+++ b/msg.go
@@ -604,12 +604,9 @@ func (m *Msg) SetAddrHeader(header AddrHeader, values ...string) error {
 //   - addresses: One or more mail.Address instances representing the email addresses to associate with
 //     the specified header.
 //
-// Returns:
-//   - An error if parsing the address according to RFC 5322 fails
-//
 // References:
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.4
-func (m *Msg) SetAddrHeaderFromAddr(header AddrHeader, values ...*mail.Address) error {
+func (m *Msg) SetAddrHeaderFromAddr(header AddrHeader, values ...*mail.Address) {
 	if m.addrHeader == nil {
 		m.addrHeader = make(map[AddrHeader][]*mail.Address)
 	}
@@ -630,7 +627,6 @@ func (m *Msg) SetAddrHeaderFromAddr(header AddrHeader, values ...*mail.Address) 
 	default:
 		m.addrHeader[header] = addresses
 	}
-	return nil
 }
 
 // SetAddrHeaderIgnoreInvalid sets the specified AddrHeader for the Msg to the given values.
@@ -767,8 +763,8 @@ func (m *Msg) To(rcpts ...string) error {
 //
 // References:
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
-func (m *Msg) ToAddr(rcpts ...*mail.Address) error {
-	return m.SetAddrHeaderFromAddr(HeaderTo, rcpts...)
+func (m *Msg) ToAddr(rcpts ...*mail.Address) {
+	m.SetAddrHeaderFromAddr(HeaderTo, rcpts...)
 }
 
 // AddTo adds a single "TO" address to the existing list of recipients in the mail body for the Msg.

--- a/msg.go
+++ b/msg.go
@@ -930,7 +930,7 @@ func (m *Msg) AddCc(rcpt string) error {
 //
 // This method allows you to add a single recipient to the "CC" field without replacing any previously set "CC"
 // addresses. The "CC" address specifies secondary recipient(s) and is visible to all recipients, including those
-// in the "TO" field. Since the provided mail.Address has already been validated, no further validation is
+// in the "CC" field. Since the provided mail.Address has already been validated, no further validation is
 // performed in this method and the values are used as given.
 //
 // Parameters:
@@ -1052,6 +1052,22 @@ func (m *Msg) BccMailAddress(rcpts ...*mail.Address) {
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
 func (m *Msg) AddBcc(rcpt string) error {
 	return m.addAddr(HeaderBcc, rcpt)
+}
+
+// AddBccMailAddress adds a single "BCC" address to the existing list of recipients in the mail body for the Msg.
+//
+// This method allows you to add a single recipient to the "BCC" field without replacing any previously set
+// "BCC" addresses. The "BCC" address specifies recipient(s) of the message who will receive a copy without other
+// recipients being aware of it.
+//
+// Parameters:
+//   - rcpt: The recipient email address as *mail.Address to add to the "BCC" field.
+//
+// References:
+//   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
+func (m *Msg) AddBccMailAddress(rcpt *mail.Address) {
+	addresses := append(m.addrHeader[HeaderBcc], rcpt)
+	m.SetAddrHeaderFromMailAddress(HeaderBcc, addresses...)
 }
 
 // AddBccFormat adds a single "BCC" (blind carbon copy) address with the provided name and email to the existing

--- a/msg.go
+++ b/msg.go
@@ -621,7 +621,7 @@ func (m *Msg) SetAddrHeaderFromMailAddress(header AddrHeader, values ...*mail.Ad
 	}
 
 	switch header {
-	case HeaderFrom:
+	case HeaderFrom, HeaderReplyTo:
 		if len(addresses) > 0 {
 			m.addrHeader[header] = []*mail.Address{addresses[0]}
 		}
@@ -1023,9 +1023,9 @@ func (m *Msg) Bcc(rcpts ...string) error {
 
 // BccMailAddress sets one or more "BCC" (blind carbon copy) addresses in the mail body for the Msg.
 //
-// The "CC" address specifies secondary recipient(s) of the message, and is included in the mail body.
-// These addresses are not visible in the mail body or to any other recipients, ensuring
-// the privacy of BCC'd recipients. Multiple "BCC" addresses can be set by passing them as variadic
+// The "BCC" address specifies recipient(s) of the message who will receive a copy without other recipients
+// being aware of it. These addresses are not visible in the mail body or to any other recipients, ensuring
+// the privacy of BCC'd recipients. Multiple "BCC" addresses can be set by passing them as variadic arguments
 // arguments to this method.
 //
 // Parameters:
@@ -1145,6 +1145,20 @@ func (m *Msg) BccFromString(rcpts string) error {
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.2
 func (m *Msg) ReplyTo(addr string) error {
 	return m.SetAddrHeader(HeaderReplyTo, addr)
+}
+
+// ReplyToMailAddress sets one or more "BCC" (blind carbon copy) addresses in the mail body for the Msg.
+//
+// The "Reply-To" address can be different from the "From" address, allowing the sender to specify an alternate
+// address for responses.
+//
+// Parameters:
+//   - rcpts: The mail.Address instance to set as the "Reply-To" address.
+//
+// References:
+//   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
+func (m *Msg) ReplyToMailAddress(addr *mail.Address) {
+	m.SetAddrHeaderFromMailAddress(HeaderReplyTo, addr)
 }
 
 // ReplyToFormat sets the "Reply-To" address for the Msg using the provided name and email address, specifying

--- a/msg.go
+++ b/msg.go
@@ -563,6 +563,9 @@ func (m *Msg) SetGenHeaderPreformatted(header Header, value string) {
 //   - values: One or more string values representing the email addresses to associate with
 //     the specified header.
 //
+// Returns:
+//   - An error if parsing the address according to RFC 5322 fails
+//
 // References:
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.4
 func (m *Msg) SetAddrHeader(header AddrHeader, values ...string) error {
@@ -601,12 +604,24 @@ func (m *Msg) SetAddrHeader(header AddrHeader, values ...string) error {
 //   - addresses: One or more mail.Address instances representing the email addresses to associate with
 //     the specified header.
 //
+// Returns:
+//   - An error if parsing the address according to RFC 5322 fails
+//
 // References:
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.4
-func (m *Msg) SetAddrHeaderFromAddr(header AddrHeader, addresses ...*mail.Address) {
+func (m *Msg) SetAddrHeaderFromAddr(header AddrHeader, values ...*mail.Address) error {
 	if m.addrHeader == nil {
 		m.addrHeader = make(map[AddrHeader][]*mail.Address)
 	}
+
+	var addresses []*mail.Address
+	for _, addrVal := range values {
+		if addrVal == nil {
+			continue
+		}
+		addresses = append(addresses, addrVal)
+	}
+
 	switch header {
 	case HeaderFrom:
 		if len(addresses) > 0 {
@@ -615,6 +630,7 @@ func (m *Msg) SetAddrHeaderFromAddr(header AddrHeader, addresses ...*mail.Addres
 	default:
 		m.addrHeader[header] = addresses
 	}
+	return nil
 }
 
 // SetAddrHeaderIgnoreInvalid sets the specified AddrHeader for the Msg to the given values.
@@ -751,8 +767,8 @@ func (m *Msg) To(rcpts ...string) error {
 //
 // References:
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
-func (m *Msg) ToAddr(rcpts ...*mail.Address) {
-	m.SetAddrHeaderFromAddr(HeaderTo, rcpts...)
+func (m *Msg) ToAddr(rcpts ...*mail.Address) error {
+	return m.SetAddrHeaderFromAddr(HeaderTo, rcpts...)
 }
 
 // AddTo adds a single "TO" address to the existing list of recipients in the mail body for the Msg.

--- a/msg.go
+++ b/msg.go
@@ -596,8 +596,9 @@ func (m *Msg) SetAddrHeader(header AddrHeader, values ...string) error {
 // This method allows you to set address-related headers for the message, with mail.Address instances
 // as input. Using this method helps maintain the integrity of the email addresses within the message.
 //
-// Since mail.Address instances are already parsed according to RFC 5322, this method will not
-// attempt to perform any parsing and therefore no error will be returned.
+// Since we expect the mail.Address instances to be already parsed according to RFC 5322, this method
+// will not attempt to perform any sanity checks except of nil pointers and therefore no error will
+// be returned. Nil pointers will be silently ignored.
 //
 // Parameters:
 //   - header: The AddrHeader to set in the Msg (e.g., "From", "To", "Cc", "Bcc").
@@ -781,6 +782,23 @@ func (m *Msg) ToAddr(rcpts ...*mail.Address) {
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
 func (m *Msg) AddTo(rcpt string) error {
 	return m.addAddr(HeaderTo, rcpt)
+}
+
+// AddToAddr adds a single "TO" address to the existing list of recipients in the mail body for the Msg.
+//
+// This method allows you to add a single recipient to the "TO" field without replacing any previously set
+// "TO" addresses. The "TO" address specifies the primary recipient(s) of the message and is visible in the mail
+// client. The provided address is validated according to RFC 5322, and an error will be returned if the
+// validation fails.
+//
+// Parameters:
+//   - rcpt: The recipient email address as *mail.Address to add to the "TO" field.
+//
+// References:
+//   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
+func (m *Msg) AddToAddr(rcpt *mail.Address) {
+	addresses := append(m.addrHeader[HeaderTo], rcpt)
+	m.SetAddrHeaderFromAddr(HeaderTo, addresses...)
 }
 
 // AddToFormat adds a single "TO" address with the provided name and email to the existing list of recipients

--- a/msg.go
+++ b/msg.go
@@ -718,6 +718,22 @@ func (m *Msg) From(from string) error {
 	return m.SetAddrHeader(HeaderFrom, from)
 }
 
+// FromAddr sets the "FROM" address in the mail body for the Msg using a mail.Address instance.
+//
+// The "FROM" address is included in the mail body and indicates the sender of the message to
+// the recipient. This address is visible in the email client and is typically displayed to the
+// recipient. If the "FROM" address is not set, the msgWriter may attempt to use the envelope
+// from address (if available) for sending.
+//
+// Parameters:
+//   - from: The "FROM" address to set in the mail body as *mail.Address.
+//
+// References:
+//   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.2
+func (m *Msg) FromAddr(from *mail.Address) {
+	m.SetAddrHeaderFromAddr(HeaderFrom, from)
+}
+
 // FromFormat sets the provided name and mail address as the "FROM" address in the mail body for the Msg.
 //
 // The "FROM" address is included in the mail body and indicates the sender of the message to

--- a/msg.go
+++ b/msg.go
@@ -1004,6 +1004,22 @@ func (m *Msg) Bcc(rcpts ...string) error {
 	return m.SetAddrHeader(HeaderBcc, rcpts...)
 }
 
+// BccMailAddress sets one or more "BCC" (blind carbon copy) addresses in the mail body for the Msg.
+//
+// The "CC" address specifies secondary recipient(s) of the message, and is included in the mail body.
+// These addresses are not visible in the mail body or to any other recipients, ensuring
+// the privacy of BCC'd recipients. Multiple "BCC" addresses can be set by passing them as variadic
+// arguments to this method.
+//
+// Parameters:
+//   - rcpts: One or more recipient email addresses as mail.Address instance to include in the "BCC" field.
+//
+// References:
+//   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
+func (m *Msg) BccMailAddress(rcpts ...*mail.Address) {
+	m.SetAddrHeaderFromMailAddress(HeaderBcc, rcpts...)
+}
+
 // AddBcc adds a single "BCC" (blind carbon copy) address to the existing list of "BCC" recipients in the mail
 // body for the Msg.
 //

--- a/msg.go
+++ b/msg.go
@@ -588,6 +588,35 @@ func (m *Msg) SetAddrHeader(header AddrHeader, values ...string) error {
 	return nil
 }
 
+// SetAddrHeaderFromAddr sets the specified AddrHeader for the Msg to the given mail.Address values.
+//
+// This method allows you to set address-related headers for the message, with mail.Address instances
+// as input. Using this method helps maintain the integrity of the email addresses within the message.
+//
+// Since mail.Address instances are already parsed according to RFC 5322, this method will not
+// attempt to perform any parsing and therefore no error will be returned.
+//
+// Parameters:
+//   - header: The AddrHeader to set in the Msg (e.g., "From", "To", "Cc", "Bcc").
+//   - addresses: One or more mail.Address instances representing the email addresses to associate with
+//     the specified header.
+//
+// References:
+//   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.4
+func (m *Msg) SetAddrHeaderFromAddr(header AddrHeader, addresses ...*mail.Address) {
+	if m.addrHeader == nil {
+		m.addrHeader = make(map[AddrHeader][]*mail.Address)
+	}
+	switch header {
+	case HeaderFrom:
+		if len(addresses) > 0 {
+			m.addrHeader[header] = []*mail.Address{addresses[0]}
+		}
+	default:
+		m.addrHeader[header] = addresses
+	}
+}
+
 // SetAddrHeaderIgnoreInvalid sets the specified AddrHeader for the Msg to the given values.
 //
 // Addresses are parsed according to RFC 5322. If parsing of any of the provided values fails,
@@ -708,6 +737,22 @@ func (m *Msg) FromFormat(name, addr string) error {
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
 func (m *Msg) To(rcpts ...string) error {
 	return m.SetAddrHeader(HeaderTo, rcpts...)
+}
+
+// ToAddr sets one or more "TO" addresses in the mail body for the Msg.
+//
+// The "TO" address specifies the primary recipient(s) of the message and is included in the mail body.
+// This address is visible to the recipient and any other recipients of the message. Multiple "TO" addresses
+// can be set by passing them as variadic arguments to this method.
+//
+// Parameters:
+//   - rcpts: One or more recipient email addresses as mail.Address instance to include
+//     in the "TO" field.
+//
+// References:
+//   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
+func (m *Msg) ToAddr(rcpts ...*mail.Address) {
+	m.SetAddrHeaderFromAddr(HeaderTo, rcpts...)
 }
 
 // AddTo adds a single "TO" address to the existing list of recipients in the mail body for the Msg.

--- a/msg.go
+++ b/msg.go
@@ -877,6 +877,22 @@ func (m *Msg) Cc(rcpts ...string) error {
 	return m.SetAddrHeader(HeaderCc, rcpts...)
 }
 
+// CcAddr sets one or more "CC" (carbon copy) addresses in the mail body for the Msg.
+//
+// The "CC" address specifies secondary recipient(s) of the message, and is included in the mail body.
+// This address is visible to the recipient and any other recipients of the message. Multiple "CC" addresses
+// can be set by passing them as variadic arguments to this method.
+//
+// Parameters:
+//   - rcpts: One or more recipient email addresses as mail.Address instance to include
+//     in the "CC" field.
+//
+// References:
+//   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
+func (m *Msg) CcAddr(rcpts ...*mail.Address) {
+	m.SetAddrHeaderFromAddr(HeaderCc, rcpts...)
+}
+
 // AddCc adds a single "CC" (carbon copy) address to the existing list of "CC" recipients in the mail body
 // for the Msg.
 //

--- a/msg_test.go
+++ b/msg_test.go
@@ -1055,9 +1055,7 @@ func TestMsg_ToAddr(t *testing.T) {
 			t.Fatal("message is nil")
 		}
 		addr := &mail.Address{Address: "toni.tester@example.com"}
-		if err := message.ToAddr(addr); err != nil {
-			t.Fatalf("failed to set TO address: %s", err)
-		}
+		message.ToAddr(addr)
 		checkAddrHeader(t, message, HeaderTo, "ToAddr", 0, 1, "toni.tester@example.com", "")
 	})
 	t.Run("ToAddr with single address (full)", func(t *testing.T) {
@@ -1066,9 +1064,7 @@ func TestMsg_ToAddr(t *testing.T) {
 			t.Fatal("message is nil")
 		}
 		addr := &mail.Address{Name: "Toni Tester", Address: "toni.tester@example.com"}
-		if err := message.ToAddr(addr); err != nil {
-			t.Fatalf("failed to set TO address: %s", err)
-		}
+		message.ToAddr(addr)
 		checkAddrHeader(t, message, HeaderTo, "ToAddr", 0, 1, "toni.tester@example.com", "Toni Tester")
 	})
 	t.Run("ToAddr with multiple addresses (mail only)", func(t *testing.T) {
@@ -1077,9 +1073,7 @@ func TestMsg_ToAddr(t *testing.T) {
 			t.Fatal("message is nil")
 		}
 		addresses := []*mail.Address{{Address: "toni.tester@example.com"}, {Address: "tina.tester@example.com"}}
-		if err := message.ToAddr(addresses...); err != nil {
-			t.Fatalf("failed to set TO address: %s", err)
-		}
+		message.ToAddr(addresses...)
 		checkAddrHeader(t, message, HeaderTo, "ToAddr", 0, 2, "toni.tester@example.com", "")
 		checkAddrHeader(t, message, HeaderTo, "ToAddr", 1, 2, "tina.tester@example.com", "")
 	})
@@ -1092,9 +1086,7 @@ func TestMsg_ToAddr(t *testing.T) {
 			{Address: "toni.tester@example.com", Name: "Toni Tester"},
 			{Address: "tina.tester@example.com", Name: "Tina Tester"},
 		}
-		if err := message.ToAddr(addresses...); err != nil {
-			t.Fatalf("failed to set TO address: %s", err)
-		}
+		message.ToAddr(addresses...)
 		checkAddrHeader(t, message, HeaderTo, "ToAddr", 0, 2, "toni.tester@example.com", "Toni Tester")
 		checkAddrHeader(t, message, HeaderTo, "ToAddr", 1, 2, "tina.tester@example.com", "Tina Tester")
 	})
@@ -1103,31 +1095,8 @@ func TestMsg_ToAddr(t *testing.T) {
 		if message == nil {
 			t.Fatal("message is nil")
 		}
-		if err := message.ToAddr(nil); err != nil {
-			t.Fatalf("failed to set TO address: %s", err)
-		}
+		message.ToAddr(nil)
 		checkAddrHeader(t, message, HeaderTo, "ToAddr", 0, 0, "", "")
-	})
-	t.Run("ToAddr with different RFC5322 addresses", func(t *testing.T) {
-		message := NewMsg()
-		if message == nil {
-			t.Fatal("message is nil")
-		}
-		for _, tt := range rfc5322Test {
-			t.Run(tt.value, func(t *testing.T) {
-				if !tt.valid {
-					t.Skipf("skipping invalid address: %s", tt.value)
-				}
-				addr, _ := mail.ParseAddress(tt.value)
-				err := message.ToAddr(addr)
-				if err != nil && tt.valid {
-					t.Errorf("To on address %s should succeed, but failed with: %s", tt.value, err)
-				}
-				if err == nil && !tt.valid {
-					t.Errorf("To on address %s should fail, but succeeded", tt.value)
-				}
-			})
-		}
 	})
 }
 

--- a/msg_test.go
+++ b/msg_test.go
@@ -879,6 +879,36 @@ func TestMsg_EnvelopeFrom(t *testing.T) {
 	})
 }
 
+func TestMsg_EnvelopeFromMailAddress(t *testing.T) {
+	addresses := mailAddresses(t)
+	t.Run("EnvelopeFromMailAddress with valid address", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.EnvelopeFromMailAddress(addresses[0])
+		checkAddrHeader(t, message, HeaderEnvelopeFrom, "EnvelopeFromMailAddress", 0, 1, "toni.tester@example.com", "")
+	})
+	t.Run("EnvelopeFromMailAddress with valid address and name", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.EnvelopeFromMailAddress(addresses[1])
+		checkAddrHeader(t, message, HeaderEnvelopeFrom, "EnvelopeFromMailAddress", 0, 1, "tina.tester@example.com", "Tina Tester")
+	})
+	t.Run("EnvelopeFromMailAddress with nil", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.EnvelopeFromMailAddress(nil)
+		if from, ok := message.addrHeader[HeaderEnvelopeFrom]; ok {
+			t.Errorf("EnvelopeFrom address header should not be set, got: %v", from)
+		}
+	})
+}
+
 func TestMsg_EnvelopeFromFormat(t *testing.T) {
 	t.Run("EnvelopeFromFormat with valid address", func(t *testing.T) {
 		message := NewMsg()

--- a/msg_test.go
+++ b/msg_test.go
@@ -958,6 +958,36 @@ func TestMsg_From(t *testing.T) {
 	})
 }
 
+func TestMsg_FromAddr(t *testing.T) {
+	addresses := mailAddresses(t)
+	t.Run("FromAddr with valid address", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.FromAddr(addresses[0])
+		checkAddrHeader(t, message, HeaderFrom, "FromAddr", 0, 1, "toni.tester@example.com", "")
+	})
+	t.Run("FromAddr with valid address and name", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.FromAddr(addresses[1])
+		checkAddrHeader(t, message, HeaderFrom, "FromAddr", 0, 1, "tina.tester@example.com", "Tina Tester")
+	})
+	t.Run("FromAddr with nil", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.FromAddr(nil)
+		if from, ok := message.addrHeader[HeaderFrom]; ok {
+			t.Errorf("From address header should not be set, got: %v", from)
+		}
+	})
+}
+
 func TestMsg_FromFormat(t *testing.T) {
 	t.Run("FromFormat with valid address", func(t *testing.T) {
 		message := NewMsg()
@@ -7664,6 +7694,22 @@ func checkMessageContent(t *testing.T, buffer *bytes.Buffer, wants []msgContentT
 			}
 		}
 	}
+}
+
+func mailAddresses(t *testing.T) []*mail.Address {
+	var addresses []*mail.Address
+	for _, address := range []string{
+		"toni.tester@example.com",
+		`"Tina Tester" <tina.tester@example.com>`,
+		"michael.tester@example.com",
+	} {
+		addr, err := mail.ParseAddress(address)
+		if err != nil {
+			t.Fatalf("failed to parse test address: %s", err)
+		}
+		addresses = append(addresses, addr)
+	}
+	return addresses
 }
 
 // Fuzzing tests

--- a/msg_test.go
+++ b/msg_test.go
@@ -1892,6 +1892,36 @@ func TestMsg_ReplyTo(t *testing.T) {
 	})
 }
 
+func TestMsg_ReplyToMailAddress(t *testing.T) {
+	addresses := mailAddresses(t)
+	t.Run("ReplyToMailAddress with valid address", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.ReplyToMailAddress(addresses[0])
+		checkAddrHeader(t, message, HeaderReplyTo, "ReplyToMailAddress", 0, 1, "toni.tester@example.com", "")
+	})
+	t.Run("ReplyToMailAddress with valid address and name", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.ReplyToMailAddress(addresses[1])
+		checkAddrHeader(t, message, HeaderReplyTo, "ReplyToMailAddress", 0, 1, "tina.tester@example.com", "Tina Tester")
+	})
+	t.Run("ReplyToMailAddress with nil", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.ReplyToMailAddress(nil)
+		if replyto, ok := message.addrHeader[HeaderReplyTo]; ok {
+			t.Errorf("ReplyTo address header should not be set, got: %v", replyto)
+		}
+	})
+}
+
 func TestMsg_ReplyToFormat(t *testing.T) {
 	t.Run("ReplyToFormat with valid address", func(t *testing.T) {
 		message := NewMsg()

--- a/msg_test.go
+++ b/msg_test.go
@@ -958,30 +958,30 @@ func TestMsg_From(t *testing.T) {
 	})
 }
 
-func TestMsg_FromAddr(t *testing.T) {
+func TestMsg_FromMailAddress(t *testing.T) {
 	addresses := mailAddresses(t)
-	t.Run("FromAddr with valid address", func(t *testing.T) {
+	t.Run("FromMailAddress with valid address", func(t *testing.T) {
 		message := NewMsg()
 		if message == nil {
 			t.Fatal("message is nil")
 		}
-		message.FromAddr(addresses[0])
-		checkAddrHeader(t, message, HeaderFrom, "FromAddr", 0, 1, "toni.tester@example.com", "")
+		message.FromMailAddress(addresses[0])
+		checkAddrHeader(t, message, HeaderFrom, "FromMailAddress", 0, 1, "toni.tester@example.com", "")
 	})
-	t.Run("FromAddr with valid address and name", func(t *testing.T) {
+	t.Run("FromMailAddress with valid address and name", func(t *testing.T) {
 		message := NewMsg()
 		if message == nil {
 			t.Fatal("message is nil")
 		}
-		message.FromAddr(addresses[1])
-		checkAddrHeader(t, message, HeaderFrom, "FromAddr", 0, 1, "tina.tester@example.com", "Tina Tester")
+		message.FromMailAddress(addresses[1])
+		checkAddrHeader(t, message, HeaderFrom, "FromMailAddress", 0, 1, "tina.tester@example.com", "Tina Tester")
 	})
-	t.Run("FromAddr with nil", func(t *testing.T) {
+	t.Run("FromMailAddress with nil", func(t *testing.T) {
 		message := NewMsg()
 		if message == nil {
 			t.Fatal("message is nil")
 		}
-		message.FromAddr(nil)
+		message.FromMailAddress(nil)
 		if from, ok := message.addrHeader[HeaderFrom]; ok {
 			t.Errorf("From address header should not be set, got: %v", from)
 		}
@@ -1078,7 +1078,7 @@ func TestMsg_To(t *testing.T) {
 	})
 }
 
-func TestMsg_ToAddr(t *testing.T) {
+func TestMsg_ToMailAddress(t *testing.T) {
 	var addresses []*mail.Address
 	for _, address := range []string{"toni.tester@example.com", `"Tina Tester" <tina.tester@example.com>`,
 		"michael.tester@example.com"} {
@@ -1088,31 +1088,31 @@ func TestMsg_ToAddr(t *testing.T) {
 		}
 		addresses = append(addresses, addr)
 	}
-	t.Run("ToAddr with single address", func(t *testing.T) {
+	t.Run("ToMailAddress with single address", func(t *testing.T) {
 		message := NewMsg()
 		if message == nil {
 			t.Fatal("message is nil")
 		}
-		message.ToAddr(addresses[0])
-		checkAddrHeader(t, message, HeaderTo, "ToAddr", 0, 1, "toni.tester@example.com", "")
+		message.ToMailAddress(addresses[0])
+		checkAddrHeader(t, message, HeaderTo, "ToMailAddress", 0, 1, "toni.tester@example.com", "")
 	})
-	t.Run("ToAddr with multiple addresses", func(t *testing.T) {
+	t.Run("ToMailAddress with multiple addresses", func(t *testing.T) {
 		message := NewMsg()
 		if message == nil {
 			t.Fatal("message is nil")
 		}
-		message.ToAddr(addresses...)
-		checkAddrHeader(t, message, HeaderTo, "ToAddr", 0, 3, "toni.tester@example.com", "")
-		checkAddrHeader(t, message, HeaderTo, "ToAddr", 1, 3, "tina.tester@example.com", "Tina Tester")
-		checkAddrHeader(t, message, HeaderTo, "ToAddr", 2, 3, "michael.tester@example.com", "")
+		message.ToMailAddress(addresses...)
+		checkAddrHeader(t, message, HeaderTo, "ToMailAddress", 0, 3, "toni.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderTo, "ToMailAddress", 1, 3, "tina.tester@example.com", "Tina Tester")
+		checkAddrHeader(t, message, HeaderTo, "ToMailAddress", 2, 3, "michael.tester@example.com", "")
 	})
-	t.Run("ToAddr with nil address", func(t *testing.T) {
+	t.Run("ToMailAddress with nil address", func(t *testing.T) {
 		message := NewMsg()
 		if message == nil {
 			t.Fatal("message is nil")
 		}
-		message.ToAddr(nil)
-		checkAddrHeader(t, message, HeaderTo, "ToAddr", 0, 0, "", "")
+		message.ToMailAddress(nil)
+		checkAddrHeader(t, message, HeaderTo, "ToMailAddress", 0, 0, "", "")
 	})
 }
 
@@ -1176,8 +1176,8 @@ func TestMsg_AddToFormat(t *testing.T) {
 	})
 }
 
-func TestMsg_AddToAddr(t *testing.T) {
-	t.Run("AddToAddr with valid addresses", func(t *testing.T) {
+func TestMsg_AddToMailAddress(t *testing.T) {
+	t.Run("AddToMailAddress with valid addresses", func(t *testing.T) {
 		message := NewMsg()
 		if message == nil {
 			t.Fatal("message is nil")
@@ -1190,19 +1190,19 @@ func TestMsg_AddToAddr(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to parse test address: %s", err)
 		}
-		message.AddToAddr(addr)
+		message.AddToMailAddress(addr)
 
 		addr, err = mail.ParseAddress("michael.tester@example.com")
 		if err != nil {
 			t.Fatalf("failed to parse test address: %s", err)
 		}
-		message.AddToAddr(addr)
+		message.AddToMailAddress(addr)
 
-		checkAddrHeader(t, message, HeaderTo, "AddToAddr", 0, 3, "toni.tester@example.com", "")
-		checkAddrHeader(t, message, HeaderTo, "AddToAddr", 1, 3, "tina.tester@example.com", "")
-		checkAddrHeader(t, message, HeaderTo, "AddToAddr", 2, 3, "michael.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderTo, "AddToMailAddress", 0, 3, "toni.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderTo, "AddToMailAddress", 1, 3, "tina.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderTo, "AddToMailAddress", 2, 3, "michael.tester@example.com", "")
 	})
-	t.Run("AddToAddr with nil", func(t *testing.T) {
+	t.Run("AddToMailAddress with nil", func(t *testing.T) {
 		message := NewMsg()
 		if message == nil {
 			t.Fatal("message is nil")
@@ -1210,28 +1210,28 @@ func TestMsg_AddToAddr(t *testing.T) {
 		if err := message.To("toni.tester@example.com"); err != nil {
 			t.Fatalf("failed to set To: %s", err)
 		}
-		message.AddToAddr(nil)
-		checkAddrHeader(t, message, HeaderTo, "AddToAddr", 0, 1, "toni.tester@example.com", "")
+		message.AddToMailAddress(nil)
+		checkAddrHeader(t, message, HeaderTo, "AddToMailAddress", 0, 1, "toni.tester@example.com", "")
 	})
-	t.Run("AddToAddr with nil as initial address", func(t *testing.T) {
+	t.Run("AddToMailAddress with nil as initial address", func(t *testing.T) {
 		message := NewMsg()
 		if message == nil {
 			t.Fatal("message is nil")
 		}
-		message.ToAddr(nil)
+		message.ToMailAddress(nil)
 
 		addr, err := mail.ParseAddress("toni.tester@example.com")
 		if err != nil {
 			t.Fatalf("failed to parse test address: %s", err)
 		}
-		message.AddToAddr(addr)
+		message.AddToMailAddress(addr)
 		addr, err = mail.ParseAddress("Tina Tester <tina.tester@example.com>")
 		if err != nil {
 			t.Fatalf("failed to parse test address: %s", err)
 		}
-		message.AddToAddr(addr)
-		checkAddrHeader(t, message, HeaderTo, "AddToAddr", 0, 2, "toni.tester@example.com", "")
-		checkAddrHeader(t, message, HeaderTo, "AddToAddr", 1, 2, "tina.tester@example.com", "Tina Tester")
+		message.AddToMailAddress(addr)
+		checkAddrHeader(t, message, HeaderTo, "AddToMailAddress", 0, 2, "toni.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderTo, "AddToMailAddress", 1, 2, "tina.tester@example.com", "Tina Tester")
 	})
 }
 
@@ -1472,7 +1472,7 @@ func TestMsg_CcFromString(t *testing.T) {
 	})
 }
 
-func TestMsg_CcAddr(t *testing.T) {
+func TestMsg_CcMailAddress(t *testing.T) {
 	var addresses []*mail.Address
 	for _, address := range []string{"toni.tester@example.com", `"Tina Tester" <tina.tester@example.com>`,
 		"michael.tester@example.com"} {
@@ -1482,31 +1482,31 @@ func TestMsg_CcAddr(t *testing.T) {
 		}
 		addresses = append(addresses, addr)
 	}
-	t.Run("CcAddr with valid address", func(t *testing.T) {
+	t.Run("CcMailAddress with valid address", func(t *testing.T) {
 		message := NewMsg()
 		if message == nil {
 			t.Fatal("message is nil")
 		}
-		message.CcAddr(addresses[0])
-		checkAddrHeader(t, message, HeaderCc, "CcAddr", 0, 1, "toni.tester@example.com", "")
+		message.CcMailAddress(addresses[0])
+		checkAddrHeader(t, message, HeaderCc, "CcMailAddress", 0, 1, "toni.tester@example.com", "")
 	})
-	t.Run("CcAddr with multiple valid addresses", func(t *testing.T) {
+	t.Run("CcMailAddress with multiple valid addresses", func(t *testing.T) {
 		message := NewMsg()
 		if message == nil {
 			t.Fatal("message is nil")
 		}
-		message.CcAddr(addresses...)
-		checkAddrHeader(t, message, HeaderCc, "CcAddr", 0, 3, "toni.tester@example.com", "")
-		checkAddrHeader(t, message, HeaderCc, "CcAddr", 1, 3, "tina.tester@example.com", "Tina Tester")
-		checkAddrHeader(t, message, HeaderCc, "CcAddr", 2, 3, "michael.tester@example.com", "")
+		message.CcMailAddress(addresses...)
+		checkAddrHeader(t, message, HeaderCc, "CcMailAddress", 0, 3, "toni.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderCc, "CcMailAddress", 1, 3, "tina.tester@example.com", "Tina Tester")
+		checkAddrHeader(t, message, HeaderCc, "CcMailAddress", 2, 3, "michael.tester@example.com", "")
 	})
-	t.Run("CcAddr with nil", func(t *testing.T) {
+	t.Run("CcMailAddress with nil", func(t *testing.T) {
 		message := NewMsg()
 		if message == nil {
 			t.Fatal("message is nil")
 		}
-		message.CcAddr(nil)
-		checkAddrHeader(t, message, HeaderCc, "CcAddr", 0, 0, "", "")
+		message.CcMailAddress(nil)
+		checkAddrHeader(t, message, HeaderCc, "CcMailAddress", 0, 0, "", "")
 	})
 }
 

--- a/msg_test.go
+++ b/msg_test.go
@@ -1696,6 +1696,65 @@ func TestMsg_AddBcc(t *testing.T) {
 	})
 }
 
+func TestMsg_AddBccMailAddress(t *testing.T) {
+	t.Run("AddBccMailAddress with valid addresses", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		if err := message.Bcc("toni.tester@example.com"); err != nil {
+			t.Fatalf("failed to set Bcc: %s", err)
+		}
+
+		addr, err := mail.ParseAddress("tina.tester@example.com")
+		if err != nil {
+			t.Fatalf("failed to parse test address: %s", err)
+		}
+		message.AddBccMailAddress(addr)
+
+		addr, err = mail.ParseAddress("michael.tester@example.com")
+		if err != nil {
+			t.Fatalf("failed to parse test address: %s", err)
+		}
+		message.AddBccMailAddress(addr)
+
+		checkAddrHeader(t, message, HeaderBcc, "AddBccMailAddress", 0, 3, "toni.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderBcc, "AddBccMailAddress", 1, 3, "tina.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderBcc, "AddBccMailAddress", 2, 3, "michael.tester@example.com", "")
+	})
+	t.Run("AddBccMailAddress with nil", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		if err := message.Bcc("toni.tester@example.com"); err != nil {
+			t.Fatalf("failed to set Bcc: %s", err)
+		}
+		message.AddBccMailAddress(nil)
+		checkAddrHeader(t, message, HeaderBcc, "AddBccMailAddress", 0, 1, "toni.tester@example.com", "")
+	})
+	t.Run("AddBccMailAddress with nil as initial address", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.BccMailAddress(nil)
+
+		addr, err := mail.ParseAddress("toni.tester@example.com")
+		if err != nil {
+			t.Fatalf("failed to parse test address: %s", err)
+		}
+		message.AddBccMailAddress(addr)
+		addr, err = mail.ParseAddress("Tina Tester <tina.tester@example.com>")
+		if err != nil {
+			t.Fatalf("failed to parse test address: %s", err)
+		}
+		message.AddBccMailAddress(addr)
+		checkAddrHeader(t, message, HeaderBcc, "AddBccMailAddress", 0, 2, "toni.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderBcc, "AddBccMailAddress", 1, 2, "tina.tester@example.com", "Tina Tester")
+	})
+}
+
 func TestMsg_AddBccFormat(t *testing.T) {
 	t.Run("AddBccFormat with valid addresses", func(t *testing.T) {
 		message := NewMsg()

--- a/msg_test.go
+++ b/msg_test.go
@@ -1569,6 +1569,44 @@ func TestMsg_Bcc(t *testing.T) {
 	})
 }
 
+func TestMsg_BccMailAddress(t *testing.T) {
+	var addresses []*mail.Address
+	for _, address := range []string{"toni.tester@example.com", `"Tina Tester" <tina.tester@example.com>`,
+		"michael.tester@example.com"} {
+		addr, err := mail.ParseAddress(address)
+		if err != nil {
+			t.Fatalf("failed to parse test address: %s", err)
+		}
+		addresses = append(addresses, addr)
+	}
+	t.Run("BccMailAddress with valid address", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.BccMailAddress(addresses[0])
+		checkAddrHeader(t, message, HeaderBcc, "BccMailAddress", 0, 1, "toni.tester@example.com", "")
+	})
+	t.Run("BccMailAddress with multiple valid addresses", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.BccMailAddress(addresses...)
+		checkAddrHeader(t, message, HeaderBcc, "BccMailAddress", 0, 3, "toni.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderBcc, "BccMailAddress", 1, 3, "tina.tester@example.com", "Tina Tester")
+		checkAddrHeader(t, message, HeaderBcc, "BccMailAddress", 2, 3, "michael.tester@example.com", "")
+	})
+	t.Run("BccMailAddress with nil", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.BccMailAddress(nil)
+		checkAddrHeader(t, message, HeaderBcc, "BccMailAddress", 0, 0, "", "")
+	})
+}
+
 func TestMsg_AddBcc(t *testing.T) {
 	t.Run("AddBcc with valid addresses", func(t *testing.T) {
 		message := NewMsg()

--- a/msg_test.go
+++ b/msg_test.go
@@ -1049,46 +1049,32 @@ func TestMsg_To(t *testing.T) {
 }
 
 func TestMsg_ToAddr(t *testing.T) {
-	t.Run("ToAddr with single address (mail only)", func(t *testing.T) {
+	var addresses []*mail.Address
+	for _, address := range []string{"toni.tester@example.com", `"Tina Tester" <tina.tester@example.com>`,
+		"michael.tester@example.com"} {
+		addr, err := mail.ParseAddress(address)
+		if err != nil {
+			t.Fatalf("failed to parse test address: %s", err)
+		}
+		addresses = append(addresses, addr)
+	}
+	t.Run("ToAddr with single address", func(t *testing.T) {
 		message := NewMsg()
 		if message == nil {
 			t.Fatal("message is nil")
 		}
-		addr := &mail.Address{Address: "toni.tester@example.com"}
-		message.ToAddr(addr)
+		message.ToAddr(addresses[0])
 		checkAddrHeader(t, message, HeaderTo, "ToAddr", 0, 1, "toni.tester@example.com", "")
 	})
-	t.Run("ToAddr with single address (full)", func(t *testing.T) {
+	t.Run("ToAddr with multiple addresses", func(t *testing.T) {
 		message := NewMsg()
 		if message == nil {
 			t.Fatal("message is nil")
-		}
-		addr := &mail.Address{Name: "Toni Tester", Address: "toni.tester@example.com"}
-		message.ToAddr(addr)
-		checkAddrHeader(t, message, HeaderTo, "ToAddr", 0, 1, "toni.tester@example.com", "Toni Tester")
-	})
-	t.Run("ToAddr with multiple addresses (mail only)", func(t *testing.T) {
-		message := NewMsg()
-		if message == nil {
-			t.Fatal("message is nil")
-		}
-		addresses := []*mail.Address{{Address: "toni.tester@example.com"}, {Address: "tina.tester@example.com"}}
-		message.ToAddr(addresses...)
-		checkAddrHeader(t, message, HeaderTo, "ToAddr", 0, 2, "toni.tester@example.com", "")
-		checkAddrHeader(t, message, HeaderTo, "ToAddr", 1, 2, "tina.tester@example.com", "")
-	})
-	t.Run("ToAddr with multiple addresses (full)", func(t *testing.T) {
-		message := NewMsg()
-		if message == nil {
-			t.Fatal("message is nil")
-		}
-		addresses := []*mail.Address{
-			{Address: "toni.tester@example.com", Name: "Toni Tester"},
-			{Address: "tina.tester@example.com", Name: "Tina Tester"},
 		}
 		message.ToAddr(addresses...)
-		checkAddrHeader(t, message, HeaderTo, "ToAddr", 0, 2, "toni.tester@example.com", "Toni Tester")
-		checkAddrHeader(t, message, HeaderTo, "ToAddr", 1, 2, "tina.tester@example.com", "Tina Tester")
+		checkAddrHeader(t, message, HeaderTo, "ToAddr", 0, 3, "toni.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderTo, "ToAddr", 1, 3, "tina.tester@example.com", "Tina Tester")
+		checkAddrHeader(t, message, HeaderTo, "ToAddr", 2, 3, "michael.tester@example.com", "")
 	})
 	t.Run("ToAddr with nil address", func(t *testing.T) {
 		message := NewMsg()
@@ -1453,6 +1439,44 @@ func TestMsg_CcFromString(t *testing.T) {
 		}
 		checkAddrHeader(t, message, HeaderCc, "CcFromString", 0, 2, "toni.tester@example.com", "")
 		checkAddrHeader(t, message, HeaderCc, "CcFromString", 1, 2, "tina.tester@example.com", "")
+	})
+}
+
+func TestMsg_CcAddr(t *testing.T) {
+	var addresses []*mail.Address
+	for _, address := range []string{"toni.tester@example.com", `"Tina Tester" <tina.tester@example.com>`,
+		"michael.tester@example.com"} {
+		addr, err := mail.ParseAddress(address)
+		if err != nil {
+			t.Fatalf("failed to parse test address: %s", err)
+		}
+		addresses = append(addresses, addr)
+	}
+	t.Run("CcAddr with valid address", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.CcAddr(addresses[0])
+		checkAddrHeader(t, message, HeaderCc, "CcAddr", 0, 1, "toni.tester@example.com", "")
+	})
+	t.Run("CcAddr with multiple valid addresses", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.CcAddr(addresses...)
+		checkAddrHeader(t, message, HeaderCc, "CcAddr", 0, 3, "toni.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderCc, "CcAddr", 1, 3, "tina.tester@example.com", "Tina Tester")
+		checkAddrHeader(t, message, HeaderCc, "CcAddr", 2, 3, "michael.tester@example.com", "")
+	})
+	t.Run("CcAddr with nil", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.CcAddr(nil)
+		checkAddrHeader(t, message, HeaderCc, "CcAddr", 0, 0, "", "")
 	})
 }
 

--- a/msg_test.go
+++ b/msg_test.go
@@ -1160,6 +1160,65 @@ func TestMsg_AddToFormat(t *testing.T) {
 	})
 }
 
+func TestMsg_AddToAddr(t *testing.T) {
+	t.Run("AddToAddr with valid addresses", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		if err := message.To("toni.tester@example.com"); err != nil {
+			t.Fatalf("failed to set To: %s", err)
+		}
+
+		addr, err := mail.ParseAddress("tina.tester@example.com")
+		if err != nil {
+			t.Fatalf("failed to parse test address: %s", err)
+		}
+		message.AddToAddr(addr)
+
+		addr, err = mail.ParseAddress("michael.tester@example.com")
+		if err != nil {
+			t.Fatalf("failed to parse test address: %s", err)
+		}
+		message.AddToAddr(addr)
+
+		checkAddrHeader(t, message, HeaderTo, "AddToAddr", 0, 3, "toni.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderTo, "AddToAddr", 1, 3, "tina.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderTo, "AddToAddr", 2, 3, "michael.tester@example.com", "")
+	})
+	t.Run("AddToAddr with nil", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		if err := message.To("toni.tester@example.com"); err != nil {
+			t.Fatalf("failed to set To: %s", err)
+		}
+		message.AddToAddr(nil)
+		checkAddrHeader(t, message, HeaderTo, "AddToAddr", 0, 1, "toni.tester@example.com", "")
+	})
+	t.Run("AddToAddr with nil as initial address", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.ToAddr(nil)
+
+		addr, err := mail.ParseAddress("toni.tester@example.com")
+		if err != nil {
+			t.Fatalf("failed to parse test address: %s", err)
+		}
+		message.AddToAddr(addr)
+		addr, err = mail.ParseAddress("Tina Tester <tina.tester@example.com>")
+		if err != nil {
+			t.Fatalf("failed to parse test address: %s", err)
+		}
+		message.AddToAddr(addr)
+		checkAddrHeader(t, message, HeaderTo, "AddToAddr", 0, 2, "toni.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderTo, "AddToAddr", 1, 2, "tina.tester@example.com", "Tina Tester")
+	})
+}
+
 func TestMsg_ToIgnoreInvalid(t *testing.T) {
 	t.Run("ToIgnoreInvalid with valid address", func(t *testing.T) {
 		message := NewMsg()

--- a/msg_test.go
+++ b/msg_test.go
@@ -1383,6 +1383,65 @@ func TestMsg_AddCc(t *testing.T) {
 	})
 }
 
+func TestMsg_AddCcMailAddress(t *testing.T) {
+	t.Run("AddCcMailAddress with valid addresses", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		if err := message.Cc("toni.tester@example.com"); err != nil {
+			t.Fatalf("failed to set Cc: %s", err)
+		}
+
+		addr, err := mail.ParseAddress("tina.tester@example.com")
+		if err != nil {
+			t.Fatalf("failed to parse test address: %s", err)
+		}
+		message.AddCcMailAddress(addr)
+
+		addr, err = mail.ParseAddress("michael.tester@example.com")
+		if err != nil {
+			t.Fatalf("failed to parse test address: %s", err)
+		}
+		message.AddCcMailAddress(addr)
+
+		checkAddrHeader(t, message, HeaderCc, "AddCcMailAddress", 0, 3, "toni.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderCc, "AddCcMailAddress", 1, 3, "tina.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderCc, "AddCcMailAddress", 2, 3, "michael.tester@example.com", "")
+	})
+	t.Run("AddCcMailAddress with nil", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		if err := message.Cc("toni.tester@example.com"); err != nil {
+			t.Fatalf("failed to set Cc: %s", err)
+		}
+		message.AddCcMailAddress(nil)
+		checkAddrHeader(t, message, HeaderCc, "AddCcMailAddress", 0, 1, "toni.tester@example.com", "")
+	})
+	t.Run("AddCcMailAddress with nil as initial address", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.CcMailAddress(nil)
+
+		addr, err := mail.ParseAddress("toni.tester@example.com")
+		if err != nil {
+			t.Fatalf("failed to parse test address: %s", err)
+		}
+		message.AddCcMailAddress(addr)
+		addr, err = mail.ParseAddress("Tina Tester <tina.tester@example.com>")
+		if err != nil {
+			t.Fatalf("failed to parse test address: %s", err)
+		}
+		message.AddCcMailAddress(addr)
+		checkAddrHeader(t, message, HeaderCc, "AddCcMailAddress", 0, 2, "toni.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderCc, "AddCcMailAddress", 1, 2, "tina.tester@example.com", "Tina Tester")
+	})
+}
+
 func TestMsg_AddCcFormat(t *testing.T) {
 	t.Run("AddCcFormat with valid addresses", func(t *testing.T) {
 		message := NewMsg()

--- a/msgwriter.go
+++ b/msgwriter.go
@@ -122,6 +122,9 @@ func (mw *msgWriter) writeMsg(msg *Msg) {
 		if addresses, ok := msg.addrHeader[to]; ok {
 			var val []string
 			for _, addr := range addresses {
+				if addr == nil {
+					continue
+				}
 				val = append(val, addr.String())
 			}
 			msg.headerCount += mw.writeHeader(Header(to), val...)


### PR DESCRIPTION
This PR adds support for directly providing `*mail.Address` instances by providing a `SetAddrHeaderFromMailAddress` method. It also provides methods for directly providing `mail.Address` instances for all the various address types (From, To, CC, BCC, etc.). Additionally it adds a `IsAddrHeader` method, which checks if the provided string is an address header.

This PR closes #467 