### PR TITLE
Update README compatibility policy for Go versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,14 @@ documentation website at [go-mail.dev](https://go-mail.dev)
 
 ## Compatibility
 
-Go is growing fast and providing great features with every new release. While we'd love to adopt the latest Go features
-into our code, we realize that not everybody using this package can run the latest Go versions. Therefore we try to
-implement alternative solutions for Go versions that do not support these features. Yet, the work needed to maintain
-the separate versions is not to be underestimated. For that reason, we might retire that code at some point. 
-We guarantee that go-mail will always support the last four releases of Go. With two Go releases per year, this gives
-the user a timeframe of two years to update to the next or even the latest version of Go.
+Go evolves quickly and introduces valuable improvements with each release. To balance adopting new features with 
+ensuring stability for our users, we align our support with the official Go release policy. In practice, go-mail 
+will always support the same set of Go versions that the Go team actively maintains - the most recent release 
+along with its two predecessors.
+
+Since Go provides two releases per year, this translates into roughly one year of guaranteed compatibility for 
+any given Go version. We encourage users to stay current with supported Go versions to benefit from security 
+updates, performance improvements, and new language features.
 
 ## Support
 We have a support and general discussion channel on Discord. Find us at: [#go-mail](https://discord.gg/dbfQyC4s) alternatively find us

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@
 
 module github.com/wneessen/go-mail
 
-go 1.20
+go 1.23.0
 
 require golang.org/x/text v0.22.0


### PR DESCRIPTION
- Revised compatibility section to align with the official Go release policy.
- Clarified support for the most recent Go release and its two predecessors.
- Updated messaging to encourage users to stay current for security, performance, and feature benefits.
- Bumped `go.mod` to required 1.23.0 as minimum version