### PR TITLE
Fix vulnerability in mail address passing to the smtp client

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -11,4 +11,4 @@ package mail
 
 // VERSION indicates the current version of the package. It is also attached to the default user
 // agent string.
-const VERSION = "0.7.0"
+const VERSION = "0.7.1"

--- a/msg.go
+++ b/msg.go
@@ -1495,10 +1495,12 @@ func (m *Msg) GetSender(useFullAddr bool) (string, error) {
 			return "", ErrNoFromAddress
 		}
 	}
-	if useFullAddr {
-		return from[0].String(), nil
+
+	addr := from[0]
+	if !useFullAddr {
+		addr.Name = ""
 	}
-	return from[0].Address, nil
+	return addr.String(), nil
 }
 
 // GetRecipients returns a list of the currently set "TO", "CC", and "BCC" addresses for the Msg.

--- a/msg.go
+++ b/msg.go
@@ -1522,7 +1522,8 @@ func (m *Msg) GetRecipients() ([]string, error) {
 			continue
 		}
 		for _, r := range addresses {
-			rcpts = append(rcpts, r.Address)
+			r.Name = ""
+			rcpts = append(rcpts, r.String())
 		}
 	}
 	if len(rcpts) <= 0 {

--- a/msg_test.go
+++ b/msg_test.go
@@ -2687,6 +2687,43 @@ func TestMsg_GetRecipients(t *testing.T) {
 				`<"toni.tester@example.com> ORCPT=admin@admin.com"@example.com>`, rcpts[0])
 		}
 	})
+	t.Run("GetRecipients with quoted local-part in to,cc and bcc (issue #495)", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		addr := `"toni.tester@example.com> ORCPT=admin@admin.com"@example.com`
+		if err := message.To(addr); err != nil {
+			t.Fatalf("failed to set to address: %s", err)
+		}
+		addr = `"tina.tester@example.com> ORCPT=admin@admin.com"@example.com`
+		if err := message.Cc(addr); err != nil {
+			t.Fatalf("failed to set to address: %s", err)
+		}
+		addr = `"troy.tester@example.com> ORCPT=admin@admin.com"@example.com`
+		if err := message.Bcc(addr); err != nil {
+			t.Fatalf("failed to set to address: %s", err)
+		}
+		rcpts, err := message.GetRecipients()
+		if err != nil {
+			t.Errorf("failed to get recipients: %s", err)
+		}
+		if len(rcpts) != 3 {
+			t.Fatalf("expected 3 recipient, got: %d", len(rcpts))
+		}
+		if !strings.EqualFold(rcpts[0], `<"toni.tester@example.com> ORCPT=admin@admin.com"@example.com>`) {
+			t.Errorf("expected recipient not returned. Want: %s, got: %s",
+				`<"toni.tester@example.com> ORCPT=admin@admin.com"@example.com>`, rcpts[0])
+		}
+		if !strings.EqualFold(rcpts[1], `<"tina.tester@example.com> ORCPT=admin@admin.com"@example.com>`) {
+			t.Errorf("expected recipient not returned. Want: %s, got: %s",
+				`<"tina.tester@example.com> ORCPT=admin@admin.com"@example.com>`, rcpts[1])
+		}
+		if !strings.EqualFold(rcpts[2], `<"troy.tester@example.com> ORCPT=admin@admin.com"@example.com>`) {
+			t.Errorf("expected recipient not returned. Want: %s, got: %s",
+				`<"troy.tester@example.com> ORCPT=admin@admin.com"@example.com>`, rcpts[2])
+		}
+	})
 	t.Run("GetRecipients with only cc", func(t *testing.T) {
 		message := NewMsg()
 		if message == nil {

--- a/msg_test.go
+++ b/msg_test.go
@@ -2661,9 +2661,30 @@ func TestMsg_GetRecipients(t *testing.T) {
 		if len(rcpts) != 1 {
 			t.Fatalf("expected 1 recipient, got: %d", len(rcpts))
 		}
-		if !strings.EqualFold(rcpts[0], "toni.tester@example.com") {
+		if !strings.EqualFold(rcpts[0], "<toni.tester@example.com>") {
 			t.Errorf("expected recipient not returned. Want: %s, got: %s",
-				"toni.tester@example.com", rcpts[0])
+				"<toni.tester@example.com>", rcpts[0])
+		}
+	})
+	t.Run("GetRecipients with quoted local-part (issue #495)", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		addr := `"toni.tester@example.com> ORCPT=admin@admin.com"@example.com`
+		if err := message.To(addr); err != nil {
+			t.Fatalf("failed to set to address: %s", err)
+		}
+		rcpts, err := message.GetRecipients()
+		if err != nil {
+			t.Errorf("failed to get recipients: %s", err)
+		}
+		if len(rcpts) != 1 {
+			t.Fatalf("expected 1 recipient, got: %d", len(rcpts))
+		}
+		if !strings.EqualFold(rcpts[0], `<"toni.tester@example.com> ORCPT=admin@admin.com"@example.com>`) {
+			t.Errorf("expected recipient not returned. Want: %s, got: %s",
+				`<"toni.tester@example.com> ORCPT=admin@admin.com"@example.com>`, rcpts[0])
 		}
 	})
 	t.Run("GetRecipients with only cc", func(t *testing.T) {
@@ -2681,9 +2702,9 @@ func TestMsg_GetRecipients(t *testing.T) {
 		if len(rcpts) != 1 {
 			t.Fatalf("expected 1 recipient, got: %d", len(rcpts))
 		}
-		if !strings.EqualFold(rcpts[0], "toni.tester@example.com") {
+		if !strings.EqualFold(rcpts[0], "<toni.tester@example.com>") {
 			t.Errorf("expected recipient not returned. Want: %s, got: %s",
-				"toni.tester@example.com", rcpts[0])
+				"<toni.tester@example.com>", rcpts[0])
 		}
 	})
 	t.Run("GetRecipients with only bcc", func(t *testing.T) {
@@ -2701,9 +2722,9 @@ func TestMsg_GetRecipients(t *testing.T) {
 		if len(rcpts) != 1 {
 			t.Fatalf("expected 1 recipient, got: %d", len(rcpts))
 		}
-		if !strings.EqualFold(rcpts[0], "toni.tester@example.com") {
+		if !strings.EqualFold(rcpts[0], "<toni.tester@example.com>") {
 			t.Errorf("expected recipient not returned. Want: %s, got: %s",
-				"toni.tester@example.com", rcpts[0])
+				"<toni.tester@example.com>", rcpts[0])
 		}
 	})
 	t.Run("GetRecipients with to and cc", func(t *testing.T) {
@@ -2724,13 +2745,13 @@ func TestMsg_GetRecipients(t *testing.T) {
 		if len(rcpts) != 2 {
 			t.Fatalf("expected 2 recipient, got: %d", len(rcpts))
 		}
-		if !strings.EqualFold(rcpts[0], "toni.tester@example.com") {
+		if !strings.EqualFold(rcpts[0], "<toni.tester@example.com>") {
 			t.Errorf("expected recipient not returned. Want: %s, got: %s",
-				"toni.tester@example.com", rcpts[0])
+				"<toni.tester@example.com>", rcpts[0])
 		}
-		if !strings.EqualFold(rcpts[1], "tina.tester@example.com") {
+		if !strings.EqualFold(rcpts[1], "<tina.tester@example.com>") {
 			t.Errorf("expected recipient not returned. Want: %s, got: %s",
-				"tina.tester@example.com", rcpts[1])
+				"<tina.tester@example.com>", rcpts[1])
 		}
 	})
 	t.Run("GetRecipients with to and bcc", func(t *testing.T) {
@@ -2751,13 +2772,13 @@ func TestMsg_GetRecipients(t *testing.T) {
 		if len(rcpts) != 2 {
 			t.Fatalf("expected 2 recipient, got: %d", len(rcpts))
 		}
-		if !strings.EqualFold(rcpts[0], "toni.tester@example.com") {
+		if !strings.EqualFold(rcpts[0], "<toni.tester@example.com>") {
 			t.Errorf("expected recipient not returned. Want: %s, got: %s",
-				"toni.tester@example.com", rcpts[0])
+				"<toni.tester@example.com>", rcpts[0])
 		}
-		if !strings.EqualFold(rcpts[1], "tina.tester@example.com") {
+		if !strings.EqualFold(rcpts[1], "<tina.tester@example.com>") {
 			t.Errorf("expected recipient not returned. Want: %s, got: %s",
-				"tina.tester@example.com", rcpts[1])
+				"<tina.tester@example.com>", rcpts[1])
 		}
 	})
 	t.Run("GetRecipients with cc and bcc", func(t *testing.T) {
@@ -2778,13 +2799,13 @@ func TestMsg_GetRecipients(t *testing.T) {
 		if len(rcpts) != 2 {
 			t.Fatalf("expected 2 recipient, got: %d", len(rcpts))
 		}
-		if !strings.EqualFold(rcpts[0], "toni.tester@example.com") {
+		if !strings.EqualFold(rcpts[0], "<toni.tester@example.com>") {
 			t.Errorf("expected recipient not returned. Want: %s, got: %s",
-				"toni.tester@example.com", rcpts[0])
+				"<toni.tester@example.com>", rcpts[0])
 		}
-		if !strings.EqualFold(rcpts[1], "tina.tester@example.com") {
+		if !strings.EqualFold(rcpts[1], "<tina.tester@example.com>") {
 			t.Errorf("expected recipient not returned. Want: %s, got: %s",
-				"tina.tester@example.com", rcpts[1])
+				"<tina.tester@example.com>", rcpts[1])
 		}
 	})
 	t.Run("GetRecipients with to, cc and bcc", func(t *testing.T) {
@@ -2808,17 +2829,17 @@ func TestMsg_GetRecipients(t *testing.T) {
 		if len(rcpts) != 3 {
 			t.Fatalf("expected 3 recipient, got: %d", len(rcpts))
 		}
-		if !strings.EqualFold(rcpts[0], "toni.tester@example.com") {
+		if !strings.EqualFold(rcpts[0], "<toni.tester@example.com>") {
 			t.Errorf("expected recipient not returned. Want: %s, got: %s",
-				"toni.tester@example.com", rcpts[0])
+				"<toni.tester@example.com>", rcpts[0])
 		}
-		if !strings.EqualFold(rcpts[1], "tina.tester@example.com") {
+		if !strings.EqualFold(rcpts[1], "<tina.tester@example.com>") {
 			t.Errorf("expected recipient not returned. Want: %s, got: %s",
-				"tina.tester@example.com", rcpts[1])
+				"<tina.tester@example.com>", rcpts[1])
 		}
-		if !strings.EqualFold(rcpts[2], "tom.tester@example.com") {
+		if !strings.EqualFold(rcpts[2], "<tom.tester@example.com>") {
 			t.Errorf("expected recipient not returned. Want: %s, got: %s",
-				"tina.tester@example.com", rcpts[2])
+				"<tina.tester@example.com>", rcpts[2])
 		}
 	})
 	t.Run("GetRecipients with no recipients", func(t *testing.T) {

--- a/msg_test.go
+++ b/msg_test.go
@@ -2539,8 +2539,8 @@ func TestMsg_GetSender(t *testing.T) {
 		if err != nil {
 			t.Errorf("failed to get sender: %s", err)
 		}
-		if !strings.EqualFold(sender, "toni.tester@example.com") {
-			t.Errorf("expected sender not returned. Want: %s, got: %s", "toni.tester@example.com", sender)
+		if !strings.EqualFold(sender, "<toni.tester@example.com>") {
+			t.Errorf("expected sender not returned. Want: %s, got: %s", "<toni.tester@example.com>", sender)
 		}
 	})
 	t.Run("GetSender with envelope from only (full address)", func(t *testing.T) {
@@ -2571,8 +2571,8 @@ func TestMsg_GetSender(t *testing.T) {
 		if err != nil {
 			t.Errorf("failed to get sender: %s", err)
 		}
-		if !strings.EqualFold(sender, "toni.tester@example.com") {
-			t.Errorf("expected sender not returned. Want: %s, got: %s", "toni.tester@example.com", sender)
+		if !strings.EqualFold(sender, "<toni.tester@example.com>") {
+			t.Errorf("expected sender not returned. Want: %s, got: %s", "<toni.tester@example.com>", sender)
 		}
 	})
 	t.Run("GetSender with from only (full address)", func(t *testing.T) {
@@ -2606,8 +2606,8 @@ func TestMsg_GetSender(t *testing.T) {
 		if err != nil {
 			t.Errorf("failed to get sender: %s", err)
 		}
-		if !strings.EqualFold(sender, "toni.tester@example.com") {
-			t.Errorf("expected sender not returned. Want: %s, got: %s", "toni.tester@example.com", sender)
+		if !strings.EqualFold(sender, "<toni.tester@example.com>") {
+			t.Errorf("expected sender not returned. Want: %s, got: %s", "<toni.tester@example.com>", sender)
 		}
 	})
 	t.Run("GetSender with envelope from and from (full address)", func(t *testing.T) {

--- a/smtp/smtp.go
+++ b/smtp/smtp.go
@@ -368,7 +368,7 @@ func (c *Client) Mail(from string) error {
 	if err := c.hello(); err != nil {
 		return err
 	}
-	cmdStr := "MAIL FROM:<%s>"
+	cmdStr := "MAIL FROM:%s"
 
 	c.mutex.RLock()
 	if c.ext != nil {

--- a/smtp/smtp.go
+++ b/smtp/smtp.go
@@ -402,10 +402,10 @@ func (c *Client) Rcpt(to string) error {
 	c.mutex.RUnlock()
 
 	if ok && c.dsnrntype != "" {
-		_, _, err := c.cmd(25, "RCPT TO:<%s> NOTIFY=%s", to, c.dsnrntype)
+		_, _, err := c.cmd(25, "RCPT TO:%s NOTIFY=%s", to, c.dsnrntype)
 		return err
 	}
-	_, _, err := c.cmd(25, "RCPT TO:<%s>", to)
+	_, _, err := c.cmd(25, "RCPT TO:%s", to)
 	return err
 }
 

--- a/smtp/smtp_test.go
+++ b/smtp/smtp_test.go
@@ -2262,7 +2262,11 @@ func TestClient_Mail(t *testing.T) {
 				t.Errorf("failed to close client: %s", err)
 			}
 		})
-		if err = client.Mail("valid-from@domain.tld"); err != nil {
+		fromAddr, err := netmail.ParseAddress("valid-from@domain.tld")
+		if err != nil {
+			t.Fatalf("failed to parse from address: %s", err)
+		}
+		if err = client.Mail(fromAddr.String()); err != nil {
 			t.Errorf("failed to set mail from address: %s", err)
 		}
 	})
@@ -2359,7 +2363,11 @@ func TestClient_Mail(t *testing.T) {
 				t.Errorf("failed to close client: %s", err)
 			}
 		})
-		if err = client.Mail("valid-from@domain.tld"); err != nil {
+		fromAddr, err := netmail.ParseAddress("valid-from@domain.tld")
+		if err != nil {
+			t.Fatalf("failed to parse from address: %s", err)
+		}
+		if err = client.Mail(fromAddr.String()); err != nil {
 			t.Errorf("failed to set mail from address: %s", err)
 		}
 		expected := "MAIL FROM:<valid-from@domain.tld> BODY=8BITMIME"
@@ -2399,7 +2407,11 @@ func TestClient_Mail(t *testing.T) {
 				t.Errorf("failed to close client: %s", err)
 			}
 		})
-		if err = client.Mail("valid-from@domain.tld"); err != nil {
+		fromAddr, err := netmail.ParseAddress("valid-from@domain.tld")
+		if err != nil {
+			t.Fatalf("failed to parse from address: %s", err)
+		}
+		if err = client.Mail(fromAddr.String()); err != nil {
 			t.Errorf("failed to set mail from address: %s", err)
 		}
 		expected := "MAIL FROM:<valid-from@domain.tld> SMTPUTF8"
@@ -2439,7 +2451,11 @@ func TestClient_Mail(t *testing.T) {
 				t.Errorf("failed to close client: %s", err)
 			}
 		})
-		if err = client.Mail("valid-from+📧@domain.tld"); err != nil {
+		fromAddr, err := netmail.ParseAddress("valid-from+📧@domain.tld")
+		if err != nil {
+			t.Fatalf("failed to parse from address: %s", err)
+		}
+		if err = client.Mail(fromAddr.String()); err != nil {
 			t.Errorf("failed to set mail from address: %s", err)
 		}
 		expected := "MAIL FROM:<valid-from+📧@domain.tld> SMTPUTF8"
@@ -2480,7 +2496,11 @@ func TestClient_Mail(t *testing.T) {
 			}
 		})
 		client.dsnmrtype = "FULL"
-		if err = client.Mail("valid-from@domain.tld"); err != nil {
+		fromAddr, err := netmail.ParseAddress("valid-from@domain.tld")
+		if err != nil {
+			t.Fatalf("failed to parse from address: %s", err)
+		}
+		if err = client.Mail(fromAddr.String()); err != nil {
 			t.Errorf("failed to set mail from address: %s", err)
 		}
 		expected := "MAIL FROM:<valid-from@domain.tld> RET=FULL"
@@ -2521,7 +2541,11 @@ func TestClient_Mail(t *testing.T) {
 			}
 		})
 		client.dsnmrtype = "FULL"
-		if err = client.Mail("valid-from@domain.tld"); err != nil {
+		fromAddr, err := netmail.ParseAddress("valid-from@domain.tld")
+		if err != nil {
+			t.Fatalf("failed to parse from address: %s", err)
+		}
+		if err = client.Mail(fromAddr.String()); err != nil {
 			t.Errorf("failed to set mail from address: %s", err)
 		}
 		expected := "MAIL FROM:<valid-from@domain.tld> BODY=8BITMIME SMTPUTF8 RET=FULL"
@@ -3015,12 +3039,16 @@ func TestSendMail(t *testing.T) {
 			config.RootCAs = testConfig.RootCAs
 			config.Certificates = testConfig.Certificates
 		}
+		fromAddr, err := netmail.ParseAddress("valid-from@domain.tld")
+		if err != nil {
+			t.Fatalf("failed to parse from address: %s", err)
+		}
 		auth := LoginAuth("username", "password", TestServerAddr, false)
 		toAddr, err := netmail.ParseAddress("valid-to@domain.tld")
 		if err != nil {
 			t.Fatalf("failed to parse recipient address: %s", err)
 		}
-		if err := SendMail(addr, auth, "valid-from@domain.tld", []string{toAddr.String()},
+		if err := SendMail(addr, auth, fromAddr.String(), []string{toAddr.String()},
 			[]byte("test message")); err != nil {
 			t.Fatalf("failed to send mail: %s", err)
 		}
@@ -3103,12 +3131,16 @@ Subject: Hooray for Go
 Line 1
 .Leading dot line .
 Goodbye.`)
+		fromAddr, err := netmail.ParseAddress("valid-from@domain.tld")
+		if err != nil {
+			t.Fatalf("failed to parse from address: %s", err)
+		}
 		toAddr, err := netmail.ParseAddress("valid-to@domain.tld")
 		if err != nil {
 			t.Fatalf("failed to parse recipient address: %s", err)
 		}
 		auth := LoginAuth("username", "password", TestServerAddr, false)
-		if err := SendMail(addr, auth, "valid-from@domain.tld", []string{toAddr.String()}, message); err != nil {
+		if err = SendMail(addr, auth, fromAddr.String(), []string{toAddr.String()}, message); err != nil {
 			t.Fatalf("failed to send mail: %s", err)
 		}
 		props.BufferMutex.RLock()


### PR DESCRIPTION
This PR fixes a vulnerability in the mail address handling when the address is passed to the SMTP client. 

Due to incorrect handling of the `mail.Address` when a sender or recipient address is passed to the `MAIL FROM` or `RCPT TO` commands of the SMTP client, this could lead to possible wrong address routing or even to ESMTP parameter smuggling.

Instead of making use of the `String()` method of `mail.Address`, which takes care of proper escaping and quotation of mail address, we used the `Address` value of the `mail.Address` which is the raw value. This meant, if a mail address like this was set: `"toni.tester@example.com> ORCPT=admin@admin.com"@example.com`, instead of the correctly quoted/escaped address, the SMTP would get the raw value passed which would translate into something like this being passed to the SMTP server: `RCPT TO:<toni.tester@example.com> ORCPT=admin@admin.com@example.com>`. Since ORCTP is a valid command for the SMTP server, the mail would be routed to the wrong address. Potentially even other SMTP commands could be smuggled in using this method.

This vulnerability was reported by @xclow3n in #495. Thank you very much for the report!