### PR TITLE
feat: add AddGenHeaderPreformatted for multiple preformatted headers

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,5 +5,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: GitHub Community Discussions
-    url: https://github.com/wneessen/go-mail/discussions
+    url: https://github.com/thib-d/go-mail/discussions
     about: If your question is not a feature or a bug, please go to the discussion panel and retrieve if your question already exists before submitting.

--- a/README.md
+++ b/README.md
@@ -6,20 +6,20 @@ SPDX-License-Identifier: MIT
 
 # go-mail - Easy to use, yet comprehensive library for sending mails with Go
 
-[![GoDoc](https://godoc.org/github.com/wneessen/go-mail?status.svg)](https://pkg.go.dev/github.com/wneessen/go-mail)
+[![GoDoc](https://godoc.org/github.com/thib-d/go-mail?status.svg)](https://pkg.go.dev/github.com/thib-d/go-mail)
 [![codecov](https://codecov.io/gh/wneessen/go-mail/branch/main/graph/badge.svg?token=37KWJV03MR)](https://codecov.io/gh/wneessen/go-mail) 
-[![Go Report Card](https://goreportcard.com/badge/github.com/wneessen/go-mail)](https://goreportcard.com/report/github.com/wneessen/go-mail) 
+[![Go Report Card](https://goreportcard.com/badge/github.com/thib-d/go-mail)](https://goreportcard.com/report/github.com/thib-d/go-mail) 
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge-flat.svg)](https://github.com/avelino/awesome-go)
 [![#go-mail on Discord](https://img.shields.io/badge/Discord-%23go%E2%80%93mail-blue.svg)](https://discord.gg/ysQXkaccXk) 
-[![REUSE status](https://api.reuse.software/badge/github.com/wneessen/go-mail)](https://api.reuse.software/info/github.com/wneessen/go-mail)
+[![REUSE status](https://api.reuse.software/badge/github.com/thib-d/go-mail)](https://api.reuse.software/info/github.com/thib-d/go-mail)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8701/badge)](https://www.bestpractices.dev/projects/8701)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/wneessen/go-mail/badge)](https://securityscorecards.dev/viewer/?uri=github.com/wneessen/go-mail)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/thib-d/go-mail/badge)](https://securityscorecards.dev/viewer/?uri=github.com/thib-d/go-mail)
 <a href="https://ko-fi.com/D1D24V9IX"><img src="https://uploads-ssl.webflow.com/5c14e387dab576fe667689cf/5cbed8a4ae2b88347c06c923_BuyMeACoffee_blue.png" height="20" alt="buy ma a coffee"></a>
 
 <p style="text-align: center"><img src="./assets/gopher2.svg" width="250" alt="go-mail logo"/></p>
 
 The main idea of this library was to provide a simple interface for sending mails to
-my [JS-Mailer](https://github.com/wneessen/js-mailer) project. It quickly evolved into a full-fledged mail library.
+my [JS-Mailer](https://github.com/thib-d/js-mailer) project. It quickly evolved into a full-fledged mail library.
 
 go-mail follows idiomatic Go style and best practice. It has a small dependency footprint by mainly relying on the
 Go Standard Library and the Go extended packages. It combines a lot of functionality from the standard library to 
@@ -57,7 +57,7 @@ Here are some highlights of go-mail's featureset:
 * [X] Middleware support for 3rd-party libraries to alter mail messages
 * [X] Support sending mails via a local sendmail command
 * [X] Support for requestng MDNs (RFC 8098) and DSNs (RFC 1891)
-* [X] DKIM signature support via [go-mail-middlware](https://github.com/wneessen/go-mail-middleware)
+* [X] DKIM signature support via [go-mail-middlware](https://github.com/thib-d/go-mail-middleware)
 * [X] Message object satisfies `io.WriterTo` and `io.Reader` interfaces
 * [X] Support for Go's `html/template` and `text/template` (as message body, alternative part or attachment/emebed)
 * [X] Output to file support which allows storing mail messages as e. g. `.eml` files to disk to open them in a MUA
@@ -96,7 +96,7 @@ fulfill. Yet, since version v0.2.8 we've added support for middleware on the `Ms
 alter a given mail message to their needs without relying on `go-mail` to support their specific need.
 
 To get our users started with message middleware, we've created a collection of useful middlewares. It can be 
-found in a seperate repository: [go-mail-middlware](https://github.com/wneessen/go-mail-middleware).
+found in a seperate repository: [go-mail-middlware](https://github.com/thib-d/go-mail-middleware).
 
 ## Merch
 Thanks to our wonderful friends at [HelloTux](https://www.hellotux.com) we can offer great go-mail merchandising. All merch articles are embroidery 
@@ -111,11 +111,11 @@ We provide example code in both our GoDocs as well as on our official Website (s
 check out our [Getting started](https://go-mail.dev/getting-started/introduction/) guide.
 
 ## Authors/Contributors
-go-mail was initially created and developed by [Winni Neessen](https://github.com/wneessen/), but over time a lot of amazing people 
+go-mail was initially created and developed by [Winni Neessen](https://github.com/thib-d/), but over time a lot of amazing people 
 contributed ot the project. Big thanks to all of them for improving the go-mail project (be it writing code, testing
 code, reviewing code, writing documenation or helping to translate the website):
 
-<a href="https://github.com/wneessen/go-mail/graphs/contributors">
+<a href="https://github.com/thib-d/go-mail/graphs/contributors">
   <img alt="image of contributors" src="https://contrib.rocks/image?repo=wneessen/go-mail" />
 </a>
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -5,7 +5,7 @@
 version = 1
 SPDX-PackageName = "go-mail"
 SPDX-PackageSupplier = "The go-mail Authors"
-SPDX-PackageDownloadLocation = "https://github.com/wneessen/go-mail"
+SPDX-PackageDownloadLocation = "https://github.com/thib-d/go-mail"
 
 [[annotations]]
 path = ["testdata/**"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: MIT
 
 To report (possible) security issues in go-mail, please either send a mail to 
 [security@go-mail.dev](mailto:security@go-mail.dev) or use Github's 
-[private reporting feature](https://github.com/wneessen/go-mail/security/advisories/new).
+[private reporting feature](https://github.com/thib-d/go-mail/security/advisories/new).
 Reports are always welcome. Even if you are not 100% certain that a specific issue you found
 counts as a security issue, we'd love to hear the details, so we can figure out together if
 the issue in question needds to be addressed.

--- a/client.go
+++ b/client.go
@@ -15,8 +15,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/wneessen/go-mail/log"
-	"github.com/wneessen/go-mail/smtp"
+	"github.com/thib-d/go-mail/log"
+	"github.com/thib-d/go-mail/smtp"
 )
 
 const (

--- a/client_test.go
+++ b/client_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wneessen/go-mail/log"
-	"github.com/wneessen/go-mail/smtp"
+	"github.com/thib-d/go-mail/log"
+	"github.com/thib-d/go-mail/smtp"
 )
 
 const (
@@ -2217,7 +2217,7 @@ func TestClient_DialAndSendWithContext(t *testing.T) {
 			t.Fatalf("failed to dial and send: %s", err)
 		}
 	})
-	// https://github.com/wneessen/go-mail/commit/4641da450f5e3b3726e01b1cf03c88361cf49c8f
+	// https://github.com/thib-d/go-mail/commit/4641da450f5e3b3726e01b1cf03c88361cf49c8f
 	t.Run("DialAndSendWithContext with nil messages", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -2337,7 +2337,7 @@ func TestClient_DialAndSendWithContext(t *testing.T) {
 			t.Errorf("client was supposed to fail on dial")
 		}
 	})
-	// https://github.com/wneessen/go-mail/issues/380
+	// https://github.com/thib-d/go-mail/issues/380
 	t.Run("concurrent sending via DialAndSendWithContext", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -2377,7 +2377,7 @@ func TestClient_DialAndSendWithContext(t *testing.T) {
 		}
 		wg.Wait()
 	})
-	// https://github.com/wneessen/go-mail/issues/385
+	// https://github.com/thib-d/go-mail/issues/385
 	t.Run("concurrent sending via DialAndSendWithContext on receiver func", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -2630,7 +2630,7 @@ func TestClient_auth(t *testing.T) {
 			t.Fatalf("client should have failed to connect")
 		}
 	})
-	// https://github.com/wneessen/go-mail/issues/428
+	// https://github.com/thib-d/go-mail/issues/428
 	t.Run("auth with custom auth type should succeed", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -2665,7 +2665,7 @@ func TestClient_auth(t *testing.T) {
 			t.Errorf("failed to send message: %s", err)
 		}
 	})
-	// https://github.com/wneessen/go-mail/issues/428
+	// https://github.com/thib-d/go-mail/issues/428
 	t.Run("auth with custom auth type should fail", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -2696,7 +2696,7 @@ func TestClient_auth(t *testing.T) {
 			t.Fatalf("client should have failed to connect")
 		}
 	})
-	// https://github.com/wneessen/go-mail/issues/428
+	// https://github.com/thib-d/go-mail/issues/428
 	t.Run("auth with custom auth type overridden by SetCustomAuth", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -2811,7 +2811,7 @@ func TestClient_Send(t *testing.T) {
 			t.Errorf("failed to send email: %s", err)
 		}
 	})
-	// https://github.com/wneessen/go-mail/commit/4641da450f5e3b3726e01b1cf03c88361cf49c8f
+	// https://github.com/thib-d/go-mail/commit/4641da450f5e3b3726e01b1cf03c88361cf49c8f
 	t.Run("connect and try to send email but message is nil", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/doc_test.go
+++ b/doc_test.go
@@ -11,7 +11,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/wneessen/go-mail"
+	"github.com/thib-d/go-mail"
 )
 
 // Code example for the NewClient method

--- a/eml_test.go
+++ b/eml_test.go
@@ -42,8 +42,8 @@ So, "Hello".`
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text without encoding
-User-Agent: go-mail v0.4.0 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.0 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.0 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.0 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -65,8 +65,8 @@ This is a signature`
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text without encoding
-User-Agent: go-mail v0.4.0 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.0 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.0 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.0 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -88,8 +88,8 @@ This is a signature`
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text without encoding
-User-Agent: go-mail v0.4.0 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.0 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.0 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.0 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -111,8 +111,8 @@ This is a signature`
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text without encoding
-User-Agent: go-mail v0.4.0 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.0 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.0 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.0 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -134,8 +134,8 @@ This is a signature`
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text without encoding
-User-Agent: go-mail v0.4.0 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.0 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.0 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.0 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -148,8 +148,8 @@ This plain text body should not be parsed as Base64.
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text without encoding
-User-Agent: go-mail v0.4.0 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.0 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.0 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.0 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -162,8 +162,8 @@ This plain text body should not be parsed as Base64.
 MIME-Version = 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text without encoding
-User-Agent = go-mail v0.4.0 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.0 // https://github.com/wneessen/go-mail
+User-Agent = go-mail v0.4.0 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.0 // https://github.com/thib-d/go-mail
 From = "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -185,8 +185,8 @@ This is a signature`
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text without encoding
-User-Agent: go-mail v0.4.0 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.0 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.0 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.0 // https://github.com/thib-d/go-mail
 From: Toni Tester" go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -208,8 +208,8 @@ This is a signature`
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text without encoding
-User-Agent: go-mail v0.4.0 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.0 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.0 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.0 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: go-mail+test.go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -231,8 +231,8 @@ This is a signature`
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text without encoding
-User-Agent: go-mail v0.4.0 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.0 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.0 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.0 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -253,8 +253,8 @@ This is a signature`
 	exampleMailPlainNoEncNoDate = `MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text without encoding
-User-Agent: go-mail v0.4.0 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.0 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.0 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.0 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -276,8 +276,8 @@ This is a signature`
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text quoted-printable
-User-Agent: go-mail v0.4.0 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.0 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.0 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.0 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -299,8 +299,8 @@ This is a signature`
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text quoted-printable
-User-Agent: go-mail v0.4.0 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.0 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.0 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.0 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -322,8 +322,8 @@ This is a signature`
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text base64
-User-Agent: go-mail v0.4.0 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.0 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.0 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.0 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -338,8 +338,8 @@ ClRoaXMgaXMgYSBzaWduYXR1cmU=`
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text base64 with attachment
-User-Agent: go-mail v0.4.1 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.1 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.1 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.1 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -369,8 +369,8 @@ Y2VzCiAgICAgaW4KICBpdAouCgpBcyB3ZWxsIGFzIGFuIGVtb2ppOiDwn5mCCg==
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text base64 with attachment
-User-Agent: go-mail v0.4.1 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.1 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.1 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.1 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -398,8 +398,8 @@ Y2VzCiAgICAgaW4KICBpdAouCgpBcyB3ZWxsIGFzIGFuIGVtb2ppOiDwn5mCCg==
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text base64 with attachment
-User-Agent: go-mail v0.4.1 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.1 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.1 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.1 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -429,8 +429,8 @@ Y2VzCiAgICAgaW4KICBpdAouCgpBcyB3ZWxsIGFzIGFuIGVtb2ppOiDwn5mCCg==
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text base64 with attachment
-User-Agent: go-mail v0.4.1 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.1 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.1 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.1 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -460,8 +460,8 @@ Y2VzCiAgICAgaW4KICBpdAouCgpBcyB3ZWxsIGFzIGFuIGVtb2ppOiDwn5mCCg==
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text base64 with attachment
-User-Agent: go-mail v0.4.1 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.1 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.1 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.1 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -491,8 +491,8 @@ Y2VzCiAgICAgaW4KICBpdAouCgpBcyB3ZWxsIGFzIGFuIGVtb2ppOiDwn5mCCg==
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text base64 with attachment
-User-Agent: go-mail v0.4.1 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.1 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.1 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.1 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -521,8 +521,8 @@ Y2VzCiAgICAgaW4KICBpdAouCgpBcyB3ZWxsIGFzIGFuIGVtb2ppOiDwn5mCCg==
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text base64 with attachment
-User-Agent: go-mail v0.4.1 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.1 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.1 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.1 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -552,8 +552,8 @@ Y2VzCiAgICAgaW4KICBpdAouCgpBcyB3ZWxsIGFzIGFuIGVtb2ppOiDwn5mCCg==
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text base64 with embed
-User-Agent: go-mail v0.4.1 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.1 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.1 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.1 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -579,8 +579,8 @@ UAAAAABJRU5ErkJggg==
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text base64 with embed
-User-Agent: go-mail v0.4.1 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.1 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.1 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.1 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -605,8 +605,8 @@ UAAAAABJRU5ErkJggg==
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text base64 with attachment, embed and alternative part
-User-Agent: go-mail v0.4.1 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.1 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.1 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.1 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -732,8 +732,8 @@ GAAAABFJREFUCJljnMoAA0wMNGcCAEQrAKk9oHKhAAAAAElFTkSuQmCC
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // 7bit with base64 attachment
-User-Agent: go-mail v0.4.1 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.1 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.1 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.1 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -765,8 +765,8 @@ VGhpcyBpcyBhIHRlc3QgaW4gQmFzZTY0
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // 7bit with base64 attachment
-User-Agent: go-mail v0.4.1 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.1 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.1 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.1 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -798,8 +798,8 @@ VGh@@@@§§§§hIHRlc3QgaW4gQmFzZTY0
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // 8bit with base64 attachment
-User-Agent: go-mail v0.4.1 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.1 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.1 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.1 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -831,8 +831,8 @@ VGhpcyBpcyBhIHRlc3QgaW4gQmFzZTY0
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail with inline embed
-User-Agent: go-mail v0.4.1 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.1 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.1 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.1 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Content-Type: multipart/related; boundary="abc123"
@@ -862,8 +862,8 @@ UAAAAABJRU5ErkJggg==
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail with inline embed
-User-Agent: go-mail v0.4.1 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.1 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.1 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.1 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Content-Type: multipart/related; boundary="abc123"
@@ -889,13 +889,13 @@ Content-Disposition: broken; filename="test.png"
 iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2NgYGD4DwABBAEAwS2O
 UAAAAABJRU5ErkJggg==
 --abc123--`
-	// https://github.com/wneessen/go-mail/issues/457
+	// https://github.com/thib-d/go-mail/issues/457
 	exampleMailPlainB64WithAttachmentAndMetadata = `Date: Wed, 01 Nov 2023 00:00:00 +0000
 MIME-Version: 1.0
 Message-ID: <1305604950.683004066175.AAAAAAAAaaaaaaaaB@go-mail.dev>
 Subject: Example mail // plain text base64 with attachment
-User-Agent: go-mail v0.4.1 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.4.1 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.4.1 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.4.1 // https://github.com/thib-d/go-mail
 From: "Toni Tester" <go-mail@go-mail.dev>
 To: <go-mail+test@go-mail.dev>
 Cc: <go-mail+cc@go-mail.dev>
@@ -1170,7 +1170,7 @@ func TestEMLToMsgFromReader(t *testing.T) {
 			})
 		}
 	})
-	// https://github.com/wneessen/go-mail/issues/457
+	// https://github.com/thib-d/go-mail/issues/457
 	t.Run("EMLToMsgFromReader via EMLToMsgFromString with attachment and metadata", func(t *testing.T) {
 		message, err := EMLToMsgFromString(exampleMailPlainB64WithAttachmentAndMetadata)
 		if err != nil {
@@ -1219,7 +1219,7 @@ func TestEMLToMsgFromFile(t *testing.T) {
 			t.Errorf("EMLToMsgFromFile with invalid EML message should fail")
 		}
 	})
-	// https://github.com/wneessen/go-mail/issues/446
+	// https://github.com/thib-d/go-mail/issues/446
 	t.Run("EMLToMsgFromFile and writing it back to buffer succeeds", func(t *testing.T) {
 		parsed, err := EMLToMsgFromFile("testdata/invoice.eml")
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,11 @@
 //
 // SPDX-License-Identifier: MIT
 
-module github.com/wneessen/go-mail
+module github.com/thib-d/go-mail
 
 go 1.24.0
 
-require golang.org/x/text v0.31.0
+require (
+	github.com/wneessen/go-mail v0.7.2
+	golang.org/x/text v0.32.0
+)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ module github.com/thib-d/go-mail
 go 1.24.0
 
 require (
-	github.com/wneessen/go-mail v0.7.2
+	github.com/thib-d/go-mail v0.7.2
 	golang.org/x/text v0.32.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
-golang.org/x/text v0.31.0 h1:aC8ghyu4JhP8VojJ2lEHBnochRno1sgL6nEi9WGFGMM=
-golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=
+github.com/wneessen/go-mail v0.7.2 h1:xxPnhZ6IZLSgxShebmZ6DPKh1b6OJcoHfzy7UjOkzS8=
+github.com/wneessen/go-mail v0.7.2/go.mod h1:+TkW6QP3EVkgTEqHtVmnAE/1MRhmzb8Y9/W3pweuS+k=
+golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=
+golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/wneessen/go-mail v0.7.2 h1:xxPnhZ6IZLSgxShebmZ6DPKh1b6OJcoHfzy7UjOkzS8=
-github.com/wneessen/go-mail v0.7.2/go.mod h1:+TkW6QP3EVkgTEqHtVmnAE/1MRhmzb8Y9/W3pweuS+k=
+github.com/thib-d/go-mail v0.7.2 h1:xxPnhZ6IZLSgxShebmZ6DPKh1b6OJcoHfzy7UjOkzS8=
+github.com/thib-d/go-mail v0.7.2/go.mod h1:+TkW6QP3EVkgTEqHtVmnAE/1MRhmzb8Y9/W3pweuS+k=
 golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=
 golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=

--- a/msg.go
+++ b/msg.go
@@ -3032,7 +3032,7 @@ func (m *Msg) checkUserAgent() {
 	_, uaok := m.genHeader[HeaderUserAgent]
 	_, xmok := m.genHeader[HeaderXMailer]
 	if !uaok && !xmok {
-		m.SetUserAgent(fmt.Sprintf("go-mail v%s // https://github.com/wneessen/go-mail",
+		m.SetUserAgent(fmt.Sprintf("go-mail v%s // https://github.com/thib-d/go-mail",
 			VERSION))
 	}
 }

--- a/msg.go
+++ b/msg.go
@@ -513,6 +513,40 @@ func (m *Msg) SetGenHeader(header Header, values ...string) {
 	m.genHeader[header] = values
 }
 
+// AddGenHeaderPreformatted adds a generic header field to the Msg with a preformatted value.
+// Unlike SetGenHeaderPreformatted, this method appends to existing headers instead of
+// replacing them. This is useful when you need multiple headers with the same key,
+// such as multiple DKIM-Signature headers for key rotation.
+//
+// Parameters:
+//   - header: The Header type representing the header field name (e.g., HeaderDKIMSig)
+//   - value: The preformatted header value string (will not be canonicalized)
+//
+// Example:
+//
+//	m := mail.NewMsg()
+//	m.AddGenHeaderPreformatted(mail.HeaderDKIMSig, "v=1; a=rsa-sha256; d=example.com; s=selector1; ...")
+//	m.AddGenHeaderPreformatted(mail.HeaderDKIMSig, "v=1; a=rsa-sha256; d=example.com; s=selector2; ...")
+//	// Message now has two DKIM-Signature headers
+func (m *Msg) AddGenHeaderPreformatted(header Header, value string) {
+	if m.genHeader == nil {
+		m.genHeader = make(map[Header][]string)
+	}
+	m.genHeader[header] = append(m.genHeader[header], value)
+}
+
+// Note: The existing SetGenHeaderPreformatted function looks like this:
+//
+// func (m *Msg) SetGenHeaderPreformatted(header Header, value string) {
+//     if m.genHeader == nil {
+//         m.genHeader = make(map[Header][]string)
+//     }
+//     m.genHeader[header] = []string{value}  // <-- This REPLACES
+// }
+//
+// The difference is that AddGenHeaderPreformatted uses append() to ADD to existing values
+// while SetGenHeaderPreformatted replaces all existing values with a single new value.
+
 // SetHeaderPreformatted sets a generic header field of the Msg, which content is already preformatted.
 //
 // Deprecated: This method only exists for compatibility reasons. Please use

--- a/msg_test.go
+++ b/msg_test.go
@@ -8266,3 +8266,160 @@ func FuzzMsg_From(f *testing.F) {
 		m.Reset()
 	})
 }
+
+// TestMsg_AddGenHeaderPreformatted tests the AddGenHeaderPreformatted method
+func TestMsg_AddGenHeaderPreformatted(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers []struct {
+			key   Header
+			value string
+		}
+		wantCount map[Header]int
+	}{
+		{
+			name: "single header",
+			headers: []struct {
+				key   Header
+				value string
+			}{
+				{HeaderXMailer, "test-mailer"},
+			},
+			wantCount: map[Header]int{
+				HeaderXMailer: 1,
+			},
+		},
+		{
+			name: "multiple different headers",
+			headers: []struct {
+				key   Header
+				value string
+			}{
+				{HeaderXMailer, "test-mailer"},
+				{HeaderXPriority, "1"},
+			},
+			wantCount: map[Header]int{
+				HeaderXMailer:   1,
+				HeaderXPriority: 1,
+			},
+		},
+		{
+			name: "multiple same headers",
+			headers: []struct {
+				key   Header
+				value string
+			}{
+				{Header("X-Custom"), "value1"},
+				{Header("X-Custom"), "value2"},
+			},
+			wantCount: map[Header]int{
+				Header("X-Custom"): 2,
+			},
+		},
+		{
+			name: "three same headers",
+			headers: []struct {
+				key   Header
+				value string
+			}{
+				{Header("X-Custom"), "value1"},
+				{Header("X-Custom"), "value2"},
+				{Header("X-Custom"), "value3"},
+			},
+			wantCount: map[Header]int{
+				Header("X-Custom"): 3,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewMsg()
+
+			// Add all headers
+			for _, h := range tt.headers {
+				m.AddGenHeaderPreformatted(h.key, h.value)
+			}
+
+			// Verify counts
+			for header, expectedCount := range tt.wantCount {
+				if got := len(m.genHeader[header]); got != expectedCount {
+					t.Errorf("AddGenHeaderPreformatted() header %s count = %d, want %d",
+						header, got, expectedCount)
+				}
+			}
+		})
+	}
+}
+
+// TestMsg_AddGenHeaderPreformatted_PreservesValues tests that values are preserved correctly
+func TestMsg_AddGenHeaderPreformatted_PreservesValues(t *testing.T) {
+	m := NewMsg()
+	customHeader := Header("X-Custom")
+
+	value1 := "first-value"
+	value2 := "second-value"
+
+	m.AddGenHeaderPreformatted(customHeader, value1)
+	m.AddGenHeaderPreformatted(customHeader, value2)
+
+	values := m.genHeader[customHeader]
+
+	if len(values) != 2 {
+		t.Fatalf("Expected 2 values, got %d", len(values))
+	}
+
+	if values[0] != value1 {
+		t.Errorf("First value = %q, want %q", values[0], value1)
+	}
+
+	if values[1] != value2 {
+		t.Errorf("Second value = %q, want %q", values[1], value2)
+	}
+}
+
+// TestMsg_AddGenHeaderPreformatted_MultipleAdds tests that multiple Add calls accumulate values
+func TestMsg_AddGenHeaderPreformatted_MultipleAdds(t *testing.T) {
+	m := NewMsg()
+	customHeader := Header("X-Custom")
+
+	// Add headers one by one
+	m.AddGenHeaderPreformatted(customHeader, "first")
+	if len(m.genHeader[customHeader]) != 1 {
+		t.Fatalf("After first Add: expected 1 value, got %d", len(m.genHeader[customHeader]))
+	}
+
+	m.AddGenHeaderPreformatted(customHeader, "second")
+	if len(m.genHeader[customHeader]) != 2 {
+		t.Fatalf("After second Add: expected 2 values, got %d", len(m.genHeader[customHeader]))
+	}
+
+	m.AddGenHeaderPreformatted(customHeader, "third")
+	if len(m.genHeader[customHeader]) != 3 {
+		t.Fatalf("After third Add: expected 3 values, got %d", len(m.genHeader[customHeader]))
+	}
+
+	// Verify all values are present
+	expected := []string{"first", "second", "third"}
+	for i, exp := range expected {
+		if m.genHeader[customHeader][i] != exp {
+			t.Errorf("Value at index %d = %q, want %q", i, m.genHeader[customHeader][i], exp)
+		}
+	}
+}
+
+// TestMsg_AddGenHeaderPreformatted_NilMap tests that the method handles nil map correctly
+func TestMsg_AddGenHeaderPreformatted_NilMap(t *testing.T) {
+	m := &Msg{} // Create without NewMsg to have nil genHeader
+
+	// Should not panic
+	m.AddGenHeaderPreformatted(HeaderXMailer, "test")
+
+	if m.genHeader == nil {
+		t.Error("genHeader should be initialized")
+	}
+
+	if len(m.genHeader[HeaderXMailer]) != 1 {
+		t.Errorf("Expected 1 header, got %d", len(m.genHeader[HeaderXMailer]))
+	}
+}

--- a/msg_test.go
+++ b/msg_test.go
@@ -594,13 +594,13 @@ func TestMsg_SetHeaderPreformatted(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				//goland:noinspection GoDeprecation
 				message.SetHeaderPreformatted(tt.header, "test")
-				value, ok := message.preformHeader[tt.header]
+				values, ok := message.preformHeader[tt.header]
 				if !ok {
 					t.Fatalf("failed to set header, genHeader field for %s is not set", tt.header)
 				}
-				if value != "test" {
-					t.Errorf("failed to set header, genHeader value for %s is %s, want: %s", tt.header,
-						value, "test")
+				if len(values) != 1 || values[0] != "test" {
+					t.Errorf("failed to set header, preformHeader value for %s is %v, want: %s", tt.header,
+						values, "test")
 				}
 			})
 		}
@@ -616,13 +616,13 @@ func TestMsg_SetGenHeaderPreformatted(t *testing.T) {
 		for _, tt := range genHeaderTests {
 			t.Run(tt.name, func(t *testing.T) {
 				message.SetGenHeaderPreformatted(tt.header, "test")
-				value, ok := message.preformHeader[tt.header]
+				values, ok := message.preformHeader[tt.header]
 				if !ok {
-					t.Fatalf("failed to set header, genHeader field for %s is not set", tt.header)
+					t.Fatalf("failed to set header, preformHeader field for %s is not set", tt.header)
 				}
-				if value != "test" {
-					t.Errorf("failed to set header, genHeader value for %s is %s, want: %s", tt.header,
-						value, "test")
+				if len(values) != 1 || values[0] != "test" {
+					t.Errorf("failed to set header, preformHeader value for %s is %v, want: %s", tt.header,
+						values, "test")
 				}
 			})
 		}
@@ -634,13 +634,13 @@ func TestMsg_SetGenHeaderPreformatted(t *testing.T) {
 		}
 		message.preformHeader = nil
 		message.SetGenHeaderPreformatted(HeaderSubject, "test")
-		value, ok := message.preformHeader[HeaderSubject]
+		values, ok := message.preformHeader[HeaderSubject]
 		if !ok {
-			t.Fatalf("failed to set header, genHeader field for %s is not set", HeaderSubject)
+			t.Fatalf("failed to set header, preformHeader field for %s is not set", HeaderSubject)
 		}
-		if value != "test" {
-			t.Errorf("failed to set header, genHeader value for %s is %s, want: %s", HeaderSubject,
-				value, "test")
+		if len(values) != 1 || values[0] != "test" {
+			t.Errorf("failed to set header, preformHeader value for %s is %v, want: %s", HeaderSubject,
+				values, "test")
 		}
 	})
 }
@@ -8343,7 +8343,7 @@ func TestMsg_AddGenHeaderPreformatted(t *testing.T) {
 
 			// Verify counts
 			for header, expectedCount := range tt.wantCount {
-				if got := len(m.genHeader[header]); got != expectedCount {
+				if got := len(m.preformHeader[header]); got != expectedCount {
 					t.Errorf("AddGenHeaderPreformatted() header %s count = %d, want %d",
 						header, got, expectedCount)
 				}
@@ -8363,7 +8363,7 @@ func TestMsg_AddGenHeaderPreformatted_PreservesValues(t *testing.T) {
 	m.AddGenHeaderPreformatted(customHeader, value1)
 	m.AddGenHeaderPreformatted(customHeader, value2)
 
-	values := m.genHeader[customHeader]
+	values := m.preformHeader[customHeader]
 
 	if len(values) != 2 {
 		t.Fatalf("Expected 2 values, got %d", len(values))
@@ -8385,41 +8385,41 @@ func TestMsg_AddGenHeaderPreformatted_MultipleAdds(t *testing.T) {
 
 	// Add headers one by one
 	m.AddGenHeaderPreformatted(customHeader, "first")
-	if len(m.genHeader[customHeader]) != 1 {
-		t.Fatalf("After first Add: expected 1 value, got %d", len(m.genHeader[customHeader]))
+	if len(m.preformHeader[customHeader]) != 1 {
+		t.Fatalf("After first Add: expected 1 value, got %d", len(m.preformHeader[customHeader]))
 	}
 
 	m.AddGenHeaderPreformatted(customHeader, "second")
-	if len(m.genHeader[customHeader]) != 2 {
-		t.Fatalf("After second Add: expected 2 values, got %d", len(m.genHeader[customHeader]))
+	if len(m.preformHeader[customHeader]) != 2 {
+		t.Fatalf("After second Add: expected 2 values, got %d", len(m.preformHeader[customHeader]))
 	}
 
 	m.AddGenHeaderPreformatted(customHeader, "third")
-	if len(m.genHeader[customHeader]) != 3 {
-		t.Fatalf("After third Add: expected 3 values, got %d", len(m.genHeader[customHeader]))
+	if len(m.preformHeader[customHeader]) != 3 {
+		t.Fatalf("After third Add: expected 3 values, got %d", len(m.preformHeader[customHeader]))
 	}
 
 	// Verify all values are present
 	expected := []string{"first", "second", "third"}
 	for i, exp := range expected {
-		if m.genHeader[customHeader][i] != exp {
-			t.Errorf("Value at index %d = %q, want %q", i, m.genHeader[customHeader][i], exp)
+		if m.preformHeader[customHeader][i] != exp {
+			t.Errorf("Value at index %d = %q, want %q", i, m.preformHeader[customHeader][i], exp)
 		}
 	}
 }
 
 // TestMsg_AddGenHeaderPreformatted_NilMap tests that the method handles nil map correctly
 func TestMsg_AddGenHeaderPreformatted_NilMap(t *testing.T) {
-	m := &Msg{} // Create without NewMsg to have nil genHeader
+	m := &Msg{} // Create without NewMsg to have nil preformHeader
 
 	// Should not panic
 	m.AddGenHeaderPreformatted(HeaderXMailer, "test")
 
-	if m.genHeader == nil {
-		t.Error("genHeader should be initialized")
+	if m.preformHeader == nil {
+		t.Error("preformHeader should be initialized")
 	}
 
-	if len(m.genHeader[HeaderXMailer]) != 1 {
-		t.Errorf("Expected 1 header, got %d", len(m.genHeader[HeaderXMailer]))
+	if len(m.preformHeader[HeaderXMailer]) != 1 {
+		t.Errorf("Expected 1 header, got %d", len(m.preformHeader[HeaderXMailer]))
 	}
 }

--- a/msg_test.go
+++ b/msg_test.go
@@ -1992,7 +1992,7 @@ func TestMsg_ReplyToFormat(t *testing.T) {
 			t.Errorf("ReplyToFormat should fail with invalid address")
 		}
 	})
-	// https://github.com/wneessen/go-mail/issues/440
+	// https://github.com/thib-d/go-mail/issues/440
 	t.Run("ReplyToFormat with special characters must not double encode", func(t *testing.T) {
 		message := NewMsg()
 		if message == nil {
@@ -2249,7 +2249,7 @@ func TestMsg_SetUserAgent(t *testing.T) {
 		if message == nil {
 			t.Fatal("message is nil")
 		}
-		want := fmt.Sprintf("go-mail v%s // https://github.com/wneessen/go-mail", VERSION)
+		want := fmt.Sprintf("go-mail v%s // https://github.com/thib-d/go-mail", VERSION)
 		message.checkUserAgent()
 		checkGenHeader(t, message, HeaderUserAgent, "SetUserAgent", 0, 1, want)
 		checkGenHeader(t, message, HeaderXMailer, "SetUserAgent", 0, 1, want)
@@ -5372,7 +5372,7 @@ func TestMsg_AttachReader(t *testing.T) {
 	})
 	// Tests the Msg.AttachReader methods with consecutive calls to Msg.WriteTo to make sure
 	// the attachments are not lost.
-	// https://github.com/wneessen/go-mail/issues/110
+	// https://github.com/thib-d/go-mail/issues/110
 	t.Run("AttachReader with consecutive writes", func(t *testing.T) {
 		teststring := "This is a test string"
 		message := testMessage(t)
@@ -5467,7 +5467,7 @@ func TestMsg_AttachReadSeeker(t *testing.T) {
 	})
 	// Tests the Msg.AttachReadSeeker methods with consecutive calls to Msg.WriteTo to make sure
 	// the attachments are not lost.
-	// https://github.com/wneessen/go-mail/issues/110
+	// https://github.com/thib-d/go-mail/issues/110
 	t.Run("AttachReadSeeker with consecutive writes", func(t *testing.T) {
 		teststring := []byte("This is a test string")
 		message := testMessage(t)
@@ -5906,7 +5906,7 @@ func TestMsg_EmbedReader(t *testing.T) {
 	})
 	// Tests the Msg.EmbedReader methods with consecutive calls to Msg.WriteTo to make sure
 	// the attachments are not lost.
-	// https://github.com/wneessen/go-mail/issues/110
+	// https://github.com/thib-d/go-mail/issues/110
 	t.Run("EmbedReader with consecutive writes", func(t *testing.T) {
 		teststring := "This is a test string"
 		message := testMessage(t)
@@ -6001,7 +6001,7 @@ func TestMsg_EmbedReadSeeker(t *testing.T) {
 	})
 	// Tests the Msg.EmbedReadSeeker methods with consecutive calls to Msg.WriteTo to make sure
 	// the attachments are not lost.
-	// https://github.com/wneessen/go-mail/issues/110
+	// https://github.com/thib-d/go-mail/issues/110
 	t.Run("EmbedReadSeeker with consecutive writes", func(t *testing.T) {
 		teststring := []byte("This is a test string")
 		message := testMessage(t)
@@ -7686,9 +7686,9 @@ func TestMsg_checkUserAgent(t *testing.T) {
 		message := testMessage(t)
 		message.checkUserAgent()
 		checkGenHeader(t, message, HeaderUserAgent, "checkUserAgent", 0, 1,
-			fmt.Sprintf("go-mail v%s // https://github.com/wneessen/go-mail", VERSION))
+			fmt.Sprintf("go-mail v%s // https://github.com/thib-d/go-mail", VERSION))
 		checkGenHeader(t, message, HeaderXMailer, "checkUserAgent", 0, 1,
-			fmt.Sprintf("go-mail v%s // https://github.com/wneessen/go-mail", VERSION))
+			fmt.Sprintf("go-mail v%s // https://github.com/thib-d/go-mail", VERSION))
 	})
 	t.Run("noDefaultUserAgent should return empty string", func(t *testing.T) {
 		message := testMessage(t)

--- a/msgwriter.go
+++ b/msgwriter.go
@@ -236,10 +236,13 @@ func (mw *msgWriter) writeGenHeader(msg *Msg) {
 // Parameters:
 //   - msg: The Msg object containing the preformatted headers to be written.
 func (mw *msgWriter) writePreformattedGenHeader(msg *Msg) {
-	for key, val := range msg.preformHeader {
-		line := fmt.Sprintf("%s: %s%s", key, val, SingleNewLine)
-		mw.writeString(line)
-		msg.headerCount += strings.Count(line, SingleNewLine)
+	for key, values := range msg.preformHeader {
+		for _, val := range values {
+			fmt.Printf("Writing preformatted header: %s: %s\n", key, val)
+			line := fmt.Sprintf("%s: %s%s", key, val, SingleNewLine)
+			mw.writeString(line)
+			msg.headerCount += strings.Count(line, SingleNewLine)
+		}
 	}
 }
 

--- a/smime.go
+++ b/smime.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/wneessen/go-mail/internal/pkcs7"
+	"github.com/thib-d/go-mail/internal/pkcs7"
 )
 
 var (

--- a/smtp/example_test.go
+++ b/smtp/example_test.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/wneessen/go-mail/smtp"
+	"github.com/thib-d/go-mail/smtp"
 )
 
 func Example() {

--- a/smtp/smtp.go
+++ b/smtp/smtp.go
@@ -33,7 +33,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/wneessen/go-mail/log"
+	"github.com/thib-d/go-mail/log"
 )
 
 var (

--- a/smtp/smtp_test.go
+++ b/smtp/smtp_test.go
@@ -39,7 +39,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wneessen/go-mail/log"
+	"github.com/thib-d/go-mail/log"
 )
 
 const (

--- a/testdata/invoice.eml
+++ b/testdata/invoice.eml
@@ -2,8 +2,8 @@ Date: Mon, 03 Mar 2025 10:18:52 +0100
 MIME-Version: 1.0
 Message-ID: <fTLb20IMVl4XQJkbTpFOUg@dev-vm>
 Subject: Order Confirmation and Invoice
-User-Agent: go-mail v0.6.2 // https://github.com/wneessen/go-mail
-X-Mailer: go-mail v0.6.2 // https://github.com/wneessen/go-mail
+User-Agent: go-mail v0.6.2 // https://github.com/thib-d/go-mail
+X-Mailer: go-mail v0.6.2 // https://github.com/thib-d/go-mail
 From: "Snake-Oil Inc." <go-mail@neessen.dev>
 To: <winni@go-mail.dev>
 Content-Type: multipart/mixed;


### PR DESCRIPTION
This adds AddGenHeaderPreformatted() which appends to existing headers instead of replacing them. Useful for adding multiple headers with the same key (e.g., multiple signatures).

Fixes #508