### PR TITLE
Allow multiple Addresses in ReplyTo Header and add GetReplyTo()

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -625,9 +625,13 @@ func (m *Msg) SetAddrHeaderFromMailAddress(header AddrHeader, values ...*mail.Ad
 	}
 
 	switch header {
-	case HeaderEnvelopeFrom, HeaderFrom, HeaderReplyTo:
+	case HeaderEnvelopeFrom, HeaderFrom:
 		if len(addresses) > 0 {
 			m.addrHeader[header] = []*mail.Address{addresses[0]}
+		}
+	case HeaderReplyTo:
+		if len(addresses) > 0 {
+			m.addrHeader[header] = addresses
 		}
 	default:
 		m.addrHeader[header] = addresses
@@ -1168,7 +1172,7 @@ func (m *Msg) ReplyTo(addr string) error {
 	return m.SetAddrHeader(HeaderReplyTo, addr)
 }
 
-// ReplyToMailAddress sets one or more "BCC" (blind carbon copy) addresses in the mail body for the Msg.
+// ReplyToMailAddress sets one or more "Reply-To" addresses for the Msg, specifying where replies should be sent.
 //
 // The "Reply-To" address can be different from the "From" address, allowing the sender to specify an alternate
 // address for responses.
@@ -1178,8 +1182,8 @@ func (m *Msg) ReplyTo(addr string) error {
 //
 // References:
 //   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
-func (m *Msg) ReplyToMailAddress(addr *mail.Address) {
-	m.SetAddrHeaderFromMailAddress(HeaderReplyTo, addr)
+func (m *Msg) ReplyToMailAddress(addrs ...*mail.Address) {
+	m.SetAddrHeaderFromMailAddress(HeaderReplyTo, addrs...)
 }
 
 // ReplyToFormat sets the "Reply-To" address for the Msg using the provided name and email address, specifying
@@ -1701,6 +1705,20 @@ func (m *Msg) GetBccString() []string {
 //   - A slice of strings containing the values of the specified generic header.
 func (m *Msg) GetGenHeader(header Header) []string {
 	return m.genHeader[header]
+}
+
+// GetReplyTo returns the content of the "ReplyTo" address header of the Msg.
+//
+// This method retrieves the list of email addresses set in the "ReplyTo" header of the message.
+// It returns a slice of pointers to `mail.Address` objects representing the return path(s) of the email.
+//
+// Returns:
+//   - A slice of `*mail.Address` containing the "ReplyTo" header addresses.
+//
+// References:
+//   - https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.3
+func (m *Msg) GetReplyTo() []*mail.Address {
+	return m.GetAddrHeader(HeaderReplyTo)
 }
 
 // GetParts returns the message parts of the Msg.

--- a/msg_test.go
+++ b/msg_test.go
@@ -1960,6 +1960,17 @@ func TestMsg_ReplyToMailAddress(t *testing.T) {
 		message.ReplyToMailAddress(addresses[1])
 		checkAddrHeader(t, message, HeaderReplyTo, "ReplyToMailAddress", 0, 1, "tina.tester@example.com", "Tina Tester")
 	})
+	t.Run("ReplyToMailAddress with multiple valid addresses", func(t *testing.T) {
+		message := NewMsg()
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		message.ReplyToMailAddress(addresses...)
+		replyTo := message.GetReplyTo()
+		if !reflect.DeepEqual(replyTo, addresses) {
+			t.Errorf("expected: %v  go: %v", addresses, replyTo)
+		}
+	})
 	t.Run("ReplyToMailAddress with nil", func(t *testing.T) {
 		message := NewMsg()
 		if message == nil {

--- a/msg_test.go
+++ b/msg_test.go
@@ -1967,9 +1967,12 @@ func TestMsg_ReplyToMailAddress(t *testing.T) {
 		}
 		message.ReplyToMailAddress(addresses...)
 		replyTo := message.GetReplyTo()
-		if !reflect.DeepEqual(replyTo, addresses) {
-			t.Errorf("expected: %v  go: %v", addresses, replyTo)
+		if len(replyTo) != 3 {
+			t.Fatalf("expected GetReplyTo to return %d addresses, got: %d", len(addresses), len(replyTo))
 		}
+		checkAddrHeader(t, message, HeaderReplyTo, "ReplyToMailAddress", 0, 3, "toni.tester@example.com", "")
+		checkAddrHeader(t, message, HeaderReplyTo, "ReplyToMailAddress", 1, 3, "tina.tester@example.com", "Tina Tester")
+		checkAddrHeader(t, message, HeaderReplyTo, "ReplyToMailAddress", 2, 3, "michael.tester@example.com", "")
 	})
 	t.Run("ReplyToMailAddress with nil", func(t *testing.T) {
 		message := NewMsg()


### PR DESCRIPTION
RFC5322 permits multiple recipients in a Reply-To header:

> In either case, an optional reply-to field MAY also be included, which
> contains the field name "Reply-To" and a comma-separated list of one
> or more addresses.

Also fix a small error where the documentation for ReplyToMailAddress
was describing the functionality of the equivalent BCC function.

Link: https://www.rfc-editor.org/rfc/rfc5322#section-3.6.2
