### PR TITLE
Add deadlock test for client connections

### DIFF
--- a/client.go
+++ b/client.go
@@ -1068,7 +1068,7 @@ func (c *Client) DialToSMTPClientWithContext(ctxDial context.Context) (*smtp.Cli
 	}
 	client.ErrorHandlerRegistry = c.ErrorHandlerRegistry
 
-	err = client.UpdateDeadline(0)
+	err = client.UpdateDeadline(c.connTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -2057,7 +2057,7 @@ func TestClient_DialWithContext(t *testing.T) {
 		dialTimeout := time.Millisecond * 300
 
 		done := make(chan error, 1)
-		go func() {
+		go func(ctxParent context.Context) {
 			client, err := NewClient(DefaultHost, WithPort(sslServerPort), WithTLSPolicy(NoTLS),
 				WithTimeout(dialTimeout))
 			if err != nil {
@@ -2065,10 +2065,9 @@ func TestClient_DialWithContext(t *testing.T) {
 				return
 			}
 
-			ctxDial, cancelDial := context.WithCancel(t.Context())
-			t.Cleanup(cancelDial)
-			done <- client.DialWithContext(ctxDial)
-		}()
+			dialCtx := context.WithoutCancel(ctxParent)
+			done <- client.DialWithContext(dialCtx)
+		}(ctx)
 
 		select {
 		case err := <-done:

--- a/client_test.go
+++ b/client_test.go
@@ -2036,6 +2036,49 @@ func TestClient_DialWithContext(t *testing.T) {
 			t.Fatalf("failed to close client: %s", err)
 		}
 	})
+	t.Run("dialing a TLS server with no TLS runs into deadlock", func(t *testing.T) {
+		ctxSSL, cancelSSL := context.WithCancel(ctx)
+		defer cancelSSL()
+		PortAdder.Add(1)
+		sslServerPort := int(TestServerPortBase + PortAdder.Load())
+		sslFeatureSet := "250-AUTH PLAIN\r\n250-8BITMIME\r\n250-DSN\r\n250 SMTPUTF8"
+		go func() {
+			if err := simpleSMTPServer(ctxSSL, t, &serverProps{
+				SSLListener: true,
+				FeatureSet:  sslFeatureSet,
+				ListenPort:  sslServerPort,
+			}); err != nil {
+				t.Errorf("failed to start test server: %s", err)
+				return
+			}
+		}()
+		time.Sleep(time.Millisecond * 30)
+		testDeadlock := time.Second * 2
+		dialTimeout := time.Millisecond * 300
+
+		done := make(chan error, 1)
+		go func() {
+			client, err := NewClient(DefaultHost, WithPort(sslServerPort), WithTLSPolicy(NoTLS),
+				WithTimeout(dialTimeout))
+			if err != nil {
+				done <- err
+				return
+			}
+
+			ctxDial, cancelDial := context.WithCancel(t.Context())
+			t.Cleanup(cancelDial)
+			done <- client.DialWithContext(ctxDial)
+		}()
+
+		select {
+		case err := <-done:
+			if err == nil || !strings.Contains(err.Error(), "i/o timeout") {
+				t.Fatalf("expected client fail with i/o timeout, but got: %s", err)
+			}
+		case <-time.After(testDeadlock):
+			t.Fatalf("potential deadlock detected, expected client to fail after %s", dialTimeout.String())
+		}
+	})
 }
 
 func TestClient_Reset(t *testing.T) {


### PR DESCRIPTION
- Adds a test for connections to a TLS server without TLS that would hang indefinetly (as addition to #521)
- Fixes a zero deadline after connection as accidentally introduced in #521  