### PR TITLE
Bump Go and `golang.org/x/text` module versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@
 
 module github.com/wneessen/go-mail
 
-go 1.24.0
+go 1.25.0
 
-require golang.org/x/text v0.32.0
+require golang.org/x/text v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=
-golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=
+golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
+golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=


### PR DESCRIPTION
- Updated Go version from `1.24.0` to `1.25.0` in `go.mod`.
- Upgraded `golang.org/x/text` module dependency from `v0.32.0` to `v0.35.0` in `go.mod` and `go.sum`.