### PR TITLE
fix: preserve EHLO error when both EHLO and HELO fail

### DIFF
--- a/smtp/smtp.go
+++ b/smtp/smtp.go
@@ -152,11 +152,11 @@ func (c *Client) Close() error {
 func (c *Client) hello() error {
 	if !c.didHello {
 		c.didHello = true
-		ehloErr := c.ehlo()
-		if ehloErr != nil {
-			heloErr := c.helo()
-			if heloErr != nil {
-				c.helloError = fmt.Errorf("EHLO failed: %w, HELO also failed: %v", ehloErr, heloErr)
+		err := c.ehlo()
+		if err != nil {
+			if heloErr := c.helo(); heloErr != nil {
+				c.helloError = fmt.Errorf("smtp: EHLO/HELO exchange failed. EHLO response: %w, HELO response: %s",
+					err, heloErr)
 			}
 		}
 	}

--- a/smtp/smtp.go
+++ b/smtp/smtp.go
@@ -152,9 +152,12 @@ func (c *Client) Close() error {
 func (c *Client) hello() error {
 	if !c.didHello {
 		c.didHello = true
-		err := c.ehlo()
-		if err != nil {
-			c.helloError = c.helo()
+		ehloErr := c.ehlo()
+		if ehloErr != nil {
+			heloErr := c.helo()
+			if heloErr != nil {
+				c.helloError = fmt.Errorf("EHLO failed: %w, HELO also failed: %v", ehloErr, heloErr)
+			}
 		}
 	}
 	return c.helloError

--- a/smtp/smtp.go
+++ b/smtp/smtp.go
@@ -155,7 +155,7 @@ func (c *Client) hello() error {
 		err := c.ehlo()
 		if err != nil {
 			if heloErr := c.helo(); heloErr != nil {
-				c.helloError = fmt.Errorf("smtp: EHLO/HELO exchange failed. EHLO response: %w, HELO response: %s",
+				c.helloError = fmt.Errorf("smtp: EHLO/HELO exchange failed. EHLO response: %w, HELO response: %w",
 					err, heloErr)
 			}
 		}


### PR DESCRIPTION
Fixes #511

## Problem

In `smtp.Client.hello()`, when `ehlo()` fails the client falls back to `helo()`. If `helo()` also fails, only the HELO error is stored:

```go
err := c.ehlo()
if err != nil {
    c.helloError = c.helo()  // EHLO error lost!
}
```

The original EHLO error — which often contains the server's actual rejection reason — is silently discarded. Users see a generic or misleading HELO error, making it difficult to diagnose configuration issues.

## Fix

When both EHLO and HELO fail, combine both errors into a single message with the EHLO error wrapped for `errors.Is`/`errors.As` compatibility:

```go
ehloErr := c.ehlo()
if ehloErr != nil {
    heloErr := c.helo()
    if heloErr != nil {
        c.helloError = fmt.Errorf("EHLO failed: %w, HELO also failed: %v", ehloErr, heloErr)
    }
}
```

When only EHLO fails but HELO succeeds, no error is returned (unchanged behavior).

## Testing

All existing smtp tests pass.