### PR TITLE
fix: prevent nil pointer panic in writeBody when partWriter is nil

### DIFF
--- a/msg_test.go
+++ b/msg_test.go
@@ -6912,6 +6912,26 @@ func TestMsg_WriteTo(t *testing.T) {
 	})
 }
 
+func TestMsg_WriteTo_FailingWriter(t *testing.T) {
+	t.Run("WriteTo with failing writer does not panic", func(t *testing.T) {
+		message := NewMsg()
+		if err := message.From(TestSenderValid); err != nil {
+			t.Fatalf("failed to set from address: %s", err)
+		}
+		if err := message.To(TestRcptValid); err != nil {
+			t.Fatalf("failed to set to address: %s", err)
+		}
+		message.Subject("Test panic fix")
+		message.SetBodyString(TypeTextPlain, "plain text")
+		message.AddAlternativeString(TypeTextHTML, "<p>html</p>")
+
+		_, err := message.WriteTo(failReadWriteSeekCloser{})
+		if err == nil {
+			t.Error("expected error when writing to a failing writer, got nil")
+		}
+	})
+}
+
 func TestMsg_WriteToFile(t *testing.T) {
 	t.Run("WriteToFile with normal mail parts", func(t *testing.T) {
 		tempfile, err := os.CreateTemp("", "testmail.*.eml")

--- a/msgwriter.go
+++ b/msgwriter.go
@@ -525,6 +525,9 @@ func (mw *msgWriter) writeBody(writeFunc func(io.Writer) (int64, error), encodin
 	if mw.depth > 0 {
 		writer = mw.partWriter
 	}
+	if writer == nil {
+		return
+	}
 	writeBuffer := bytes.Buffer{}
 	lineBreaker := base64LineBreaker{}
 	lineBreaker.out = &writeBuffer

--- a/msgwriter_test.go
+++ b/msgwriter_test.go
@@ -763,6 +763,18 @@ func TestMsgWriter_writeBody(t *testing.T) {
 			t.Errorf("expected error: bodyWriter function: intentional write failure, got: %s", msgwriter.err)
 		}
 	})
+	t.Run("writeBody with nil partWriter does not panic", func(t *testing.T) {
+		mw := &msgWriter{
+			charset: CharsetUTF8,
+			encoder: getEncoder(EncodingQP),
+			depth:   1,
+		}
+		mw.partWriter = nil
+		writeFunc := func(w io.Writer) (int64, error) {
+			return 0, nil
+		}
+		mw.writeBody(writeFunc, EncodingQP)
+	})
 }
 
 func TestMsgWriter_sanitizeFilename(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes #542
`Msg.WriteTo` panics with a nil pointer dereference when the underlying `io.Writer` returns an error during a multipart message write.
## Root cause
In `writeBody`, when `mw.depth > 0`, the local `writer` variable is set to `mw.partWriter`. If a preceding call to `newPart` → `CreatePart` failed (because the underlying writer returned an error), `mw.partWriter` is `nil` and the error is stored in `mw.err`. Since `writeBody` does not check for a nil `writer` before calling `io.Copy`, it panics.
## Fix
Added a nil guard for `writer` in `writeBody` that returns early when the writer could not be resolved. This allows `WriteTo` to return the error already captured in `mw.err` instead of panicking.
## Tests added
- **`TestMsgWriter_writeBody/writeBody_with_nil_partWriter_does_not_panic`** — unit test that directly exercises `writeBody` with a nil `partWriter` at `depth > 0`.
- **`TestMsg_WriteTo_FailingWriter`** — end-to-end test that calls `Msg.WriteTo` with a multipart message and a writer that always fails, verifying it returns an error instead of panicking.
All existing tests continue to pass.
