### PR TITLE
feat: add option to skip SMTPUTF8 in "MAIL FROM" commands

### DIFF
--- a/client.go
+++ b/client.go
@@ -178,6 +178,10 @@ type (
 		// sendMutex is used to synchronize access to shared resources during the dial and send methods.
 		sendMutex sync.Mutex
 
+		// skipUTF8 indicates that the Client should skip the "SMTPUTF8" in a "MAIL FROM" even if the server
+		// claims to support it
+		skipUTF8 bool
+
 		// smtpAuth is the authentication type that is used to authenticate the user with SMTP server. It
 		// satisfies the smtp.Auth interface.
 		//
@@ -739,6 +743,20 @@ func WithLogAuthData() Option {
 	}
 }
 
+// WithoutSMTPUTF8 forces the SMTP client to skip the SMTPUTF8 extension in the "MAIL FROM" command, even if
+// the server supports it.
+//
+// This option is useful for servers that advertise support for SMTPUTF8 but do not actually implement it.
+//
+// Returns:
+//   - An Option function that configures the Client to skip SMTPUTF8 in the "MAIL FROM" command.
+func WithoutSMTPUTF8() Option {
+	return func(c *Client) error {
+		c.skipUTF8 = true
+		return nil
+	}
+}
+
 // TLSPolicy returns the TLSPolicy that is currently set on the Client as a string.
 //
 // This method retrieves the current TLSPolicy configured for the Client and returns it as a string representation.
@@ -1082,6 +1100,7 @@ func (c *Client) DialToSMTPClientWithContext(ctxDial context.Context) (*smtp.Cli
 	if c.logAuthData {
 		client.SetLogAuthData()
 	}
+	client.SkipSMTPUTF8(c.skipUTF8)
 	if err = client.Hello(c.helo); err != nil {
 		return nil, err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -725,6 +725,17 @@ func TestNewClient(t *testing.T) {
 				},
 				false, nil,
 			},
+			{
+				"WithoutSMTPUTF8", WithoutSMTPUTF8(),
+				func(c *Client) error {
+					if !c.skipUTF8 {
+						return fmt.Errorf("failed to disable SMTPUTF8. Want skipSMTPUTF8: %t, got: %t", true,
+							c.skipUTF8)
+					}
+					return nil
+				},
+				false, nil,
+			},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {

--- a/smtp/smtp.go
+++ b/smtp/smtp.go
@@ -100,6 +100,10 @@ type Client struct {
 	// the resource at a time.
 	mutex sync.RWMutex
 
+	// skipUTF8 indicates whether the Client should skip SMTPUTF8 in "MAIL FROM" commands, even if the
+	// server advertises support for SMTPUTF8.
+	skipUTF8 bool
+
 	// tls indicates whether the Client is using TLS
 	tls bool
 
@@ -190,6 +194,14 @@ func (c *Client) Hello(localName string) error {
 // EHLO request, excluding code and features.
 func (c *Client) HelloResponse() string {
 	return c.helloResponse
+}
+
+// SkipSMTPUTF8 sets the Client's SkipSMTPUTF8 flag. If set to true, the Client will not
+// send SMTPUTF8 in "MAIL FROM" commands, even if the server advertises support for SMTPUTF8.
+func (c *Client) SkipSMTPUTF8(val bool) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.skipUTF8 = val
 }
 
 // cmd is a convenience function that sends a command and returns the response
@@ -388,7 +400,7 @@ func (c *Client) Mail(from string) error {
 		if _, ok := c.ext["8BITMIME"]; ok {
 			cmdStr += " BODY=8BITMIME"
 		}
-		if _, ok := c.ext["SMTPUTF8"]; ok {
+		if _, ok := c.ext["SMTPUTF8"]; ok && !c.skipUTF8 {
 			cmdStr += " SMTPUTF8"
 		}
 		_, ok := c.ext["DSN"]

--- a/smtp/smtp_test.go
+++ b/smtp/smtp_test.go
@@ -2606,6 +2606,83 @@ func TestClient_Mail(t *testing.T) {
 			t.Errorf("expected mail from command to be %q, but sent %q", expected, resp[7])
 		}
 	})
+	t.Run("server announces SMTPUTF8 but MAIL FROM does not implement it fails", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		PortAdder.Add(1)
+		serverPort := int(TestServerPortBase + PortAdder.Load())
+		featureSet := "250-8BITMIME\r\n250-SMTPUTF8\r\n250 STARTTLS"
+		echoBuffer := bytes.NewBuffer(nil)
+		props := &serverProps{
+			EchoBuffer:     echoBuffer,
+			FeatureSet:     featureSet,
+			ListenPort:     serverPort,
+			FailOnSMTPUTF8: true,
+		}
+		go func() {
+			if err := simpleSMTPServer(ctx, t, props); err != nil {
+				t.Errorf("failed to start test server: %s", err)
+				return
+			}
+		}()
+		time.Sleep(time.Millisecond * 30)
+
+		client, err := Dial(fmt.Sprintf("%s:%d", TestServerAddr, serverPort))
+		if err != nil {
+			t.Fatalf("failed to dial to test server: %s", err)
+		}
+		t.Cleanup(func() {
+			if err = client.Close(); err != nil {
+				t.Errorf("failed to close client: %s", err)
+			}
+		})
+		fromAddr, err := netmail.ParseAddress("valid-from@domain.tld")
+		if err != nil {
+			t.Fatalf("failed to parse from address: %s", err)
+		}
+		if err = client.Mail(fromAddr.String()); err == nil {
+			t.Error("expected MAIL FROM to fail due to non-support of SMTPUTF8")
+		}
+	})
+	t.Run("server announces SMTPUTF8 but MAIL FROM does not implement succeeds due to skip", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		PortAdder.Add(1)
+		serverPort := int(TestServerPortBase + PortAdder.Load())
+		featureSet := "250-8BITMIME\r\n250-SMTPUTF8\r\n250 STARTTLS"
+		echoBuffer := bytes.NewBuffer(nil)
+		props := &serverProps{
+			EchoBuffer:     echoBuffer,
+			FeatureSet:     featureSet,
+			ListenPort:     serverPort,
+			FailOnSMTPUTF8: true,
+		}
+		go func() {
+			if err := simpleSMTPServer(ctx, t, props); err != nil {
+				t.Errorf("failed to start test server: %s", err)
+				return
+			}
+		}()
+		time.Sleep(time.Millisecond * 30)
+
+		client, err := Dial(fmt.Sprintf("%s:%d", TestServerAddr, serverPort))
+		if err != nil {
+			t.Fatalf("failed to dial to test server: %s", err)
+		}
+		t.Cleanup(func() {
+			if err = client.Close(); err != nil {
+				t.Errorf("failed to close client: %s", err)
+			}
+		})
+		fromAddr, err := netmail.ParseAddress("valid-from@domain.tld")
+		if err != nil {
+			t.Fatalf("failed to parse from address: %s", err)
+		}
+		client.SkipSMTPUTF8(true)
+		if err = client.Mail(fromAddr.String()); err != nil {
+			t.Errorf("failed to set mail from address: %s", err)
+		}
+	})
 }
 
 func TestClient_Rcpt(t *testing.T) {
@@ -3906,6 +3983,7 @@ type serverProps struct {
 	FailOnReset           bool
 	FailOnRcptTo          bool
 	FailOnSTARTTLS        bool
+	FailOnSMTPUTF8        bool
 	FailTemp              bool
 	SimulateShortResponse bool
 	FeatureSet            string
@@ -4060,6 +4138,10 @@ func handleTestServerConnection(connection net.Conn, t *testing.T, props *server
 		case strings.HasPrefix(data, "MAIL FROM:"):
 			if props.FailOnMailFrom {
 				writeLine("500 5.5.2 Error: fail on MAIL FROM")
+				break
+			}
+			if strings.Contains(data, "SMTPUTF8") && props.FailOnSMTPUTF8 {
+				writeLine("502 5.3.3 Command not implemented")
 				break
 			}
 			from := strings.TrimPrefix(data, "MAIL FROM:")


### PR DESCRIPTION
- Added `WithoutSMTPUTF8` function to configure the client to skip the `SMTPUTF8` extension.
- Introduced `skipUTF8` flag in the `Client` struct to control `SMTPUTF8` behavior.
- Updated `MAIL FROM` command generation to respect the `skipUTF8` flag.
- Provided `SkipSMTPUTF8` method to toggle `SMTPUTF8` skipping.

Fixes #545 