### PR TITLE
fix(random): drop the unreachable '-' character from cr

### DIFF
--- a/random.go
+++ b/random.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Range of characters for the secure string generation
-const cr = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-"
+const cr = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._"
 
 // Bitmask sizes for the string generators (based on 93 chars total)
 //


### PR DESCRIPTION
\`cr\` in [random.go:16](https://github.com/wneessen/go-mail/blob/main/random.go#L16) is declared as a 65-character set, but \`randomStringSecure\` derives each index from a 6-bit mask:

\`\`\`go
letterIdxBits = 6
letterIdxMask = 1<<letterIdxBits - 1  // 63
\`\`\`

So \`char & letterIdxMask\` is always in [0, 63] and the last character (\`-\` at index 64) is never reachable. The \`if i < charRangeLength\` guard ahead of the WriteByte was never triggered for that reason. The function comment and its sole caller [\`SetMessageID\`](https://github.com/wneessen/go-mail/blob/main/msg.go#L1235) both already document 64 possible characters:

\`\`\`go
// We have 64 possible characters, which for a 22 character string, provides approx. 132 bits of entropy.
randString, _ := randomStringSecure(22)
\`\`\`

Dropping the trailing dash makes the constant match the bitmask the function actually uses. No behavior change for callers (the dash was never produced anyway).

The alternative would be to widen the mask to 7 bits and rely on the existing rejection check, but that doubles the loop's expected read-rate and the trade-off doesn't seem worth keeping one extra symbol in message IDs.