### PR TITLE
feat(client): Add WithoutRset option to skip RSET after delivery

### DIFF
--- a/client.go
+++ b/client.go
@@ -166,6 +166,12 @@ type (
 		// other than AUTH.
 		noNoop bool
 
+		// noRset indicates that the Client should skip the "RSET" at the end of the mail delivery
+		//
+		// This is useful for servers for custom MTAs that have not implemented the "RSET" SMTP
+		// command and would issue an "unknown command" error after successful delivery
+		noRset bool
+
 		// pass represents a password or a secret token used for the SMTP authentication.
 		pass string
 
@@ -707,6 +713,21 @@ func WithoutNoop() Option {
 	}
 }
 
+// WithoutRset indicates that the Client should not send a "RSET" command after successful mail
+// delivery.
+//
+// This option is useful for servers have not implemented the "RSET" SMTP command and would return
+// an "unknown command" error after successful delivery.
+//
+// Returns:
+//   - An Option function that configures the Client to skip the "RSET" command.
+func WithoutRset() Option {
+	return func(c *Client) error {
+		c.noRset = true
+		return nil
+	}
+}
+
 // WithDialContextFunc sets the provided DialContextFunc as the DialContext for connecting to the SMTP server.
 //
 // This function overrides the default DialContext function used by the Client when establishing a connection
@@ -1179,6 +1200,9 @@ func (c *Client) Reset() error {
 // Returns:
 //   - An error if the connection check fails or if sending the RSET command fails; otherwise, returns nil.
 func (c *Client) ResetWithSMTPClient(client *smtp.Client) error {
+	if c.noRset {
+		return nil
+	}
 	if err := c.checkConn(client); err != nil {
 		return err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -654,7 +654,17 @@ func TestNewClient(t *testing.T) {
 				"WithoutNoop", WithoutNoop(),
 				func(c *Client) error {
 					if !c.noNoop {
-						return fmt.Errorf("failed to disable Noop. Want noNoop: %t, got: %t", false, c.noNoop)
+						return fmt.Errorf("failed to disable Noop. Want noNoop: %t, got: %t", true, c.noNoop)
+					}
+					return nil
+				},
+				false, nil,
+			},
+			{
+				"WithoutRset", WithoutRset(),
+				func(c *Client) error {
+					if !c.noRset {
+						return fmt.Errorf("failed to disable Rset. Want noRset: %t, got: %t", true, c.noNoop)
 					}
 					return nil
 				},

--- a/client_test.go
+++ b/client_test.go
@@ -3454,6 +3454,50 @@ func TestClient_sendSingleMsg(t *testing.T) {
 			t.Errorf("expected ErrSMTPReset, got %s", sendErr.Reason)
 		}
 	})
+	t.Run("RSET is failing but we skip it with noRset", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		PortAdder.Add(1)
+		serverPort := int(TestServerPortBase + PortAdder.Load())
+		featureSet := "250-8BITMIME\r\n250-DSN\r\n250 SMTPUTF8"
+		go func() {
+			if err := simpleSMTPServer(ctx, t, &serverProps{
+				FailOnReset: true,
+				FeatureSet:  featureSet,
+				ListenPort:  serverPort,
+			}); err != nil {
+				t.Errorf("failed to start test server: %s", err)
+				return
+			}
+		}()
+		time.Sleep(time.Millisecond * 30)
+
+		message := testMessage(t)
+
+		ctxDial, cancelDial := context.WithTimeout(ctx, time.Millisecond*500)
+		t.Cleanup(cancelDial)
+
+		client, err := NewClient(DefaultHost, WithPort(serverPort), WithTLSPolicy(NoTLS),
+			WithoutRset())
+		if err != nil {
+			t.Fatalf("failed to create new client: %s", err)
+		}
+		if err = client.DialWithContext(ctxDial); err != nil {
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				t.Skip("failed to connect to the test server due to timeout")
+			}
+			t.Fatalf("failed to connect to test server: %s", err)
+		}
+		t.Cleanup(func() {
+			if err := client.Close(); err != nil {
+				t.Errorf("failed to close client: %s", err)
+			}
+		})
+		if err = client.sendSingleMsg(client.smtpClient, message); err != nil {
+			t.Errorf("client should not have failed, but got: %s", err)
+		}
+	})
 	t.Run("connect and send email but with mix of valid and invalid rcpts", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()


### PR DESCRIPTION
This PR adds a `WithoutRset()` client option, to tell the Client to not send a SMTP `RSET` after a successful delivery. This option is useful for servers have not implemented the "RSET" SMTP command and would return an "unknown command" error after successful delivery.

Addresses #551 