### PR TITLE
Add native DKIM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Here are some highlights of go-mail's featureset:
 * [X] Middleware support for 3rd-party libraries to alter mail messages
 * [X] Support sending mails via a local sendmail command
 * [X] Support for requestng MDNs (RFC 8098) and DSNs (RFC 1891)
-* [X] DKIM signature support via [go-mail-middlware](https://github.com/wneessen/go-mail-middleware)
+* [X] DKIM signature support
 * [X] Message object satisfies `io.WriterTo` and `io.Reader` interfaces
 * [X] Support for Go's `html/template` and `text/template` (as message body, alternative part or attachment/emebed)
 * [X] Output to file support which allows storing mail messages as e. g. `.eml` files to disk to open them in a MUA

--- a/client.go
+++ b/client.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/wneessen/go-mail/internal/dkim"
 	"github.com/wneessen/go-mail/log"
 	"github.com/wneessen/go-mail/smtp"
 )
@@ -129,7 +130,7 @@ type (
 		dialContextFunc DialContextFunc
 
 		// dkim is the DKIM configuration for the Client.
-		dkim *DKIMConfig
+		dkim *dkim.Signer
 
 		// dsnRcptNotifyType represents the different types of notifications for DSN (Delivery Status Notifications)
 		// receipts.
@@ -821,15 +822,15 @@ func WithoutSMTPUTF8() Option {
 //
 // Returns:
 //   - An Option function that configures the Client to always sign messages using DKIM.
-func WithAlwaysDKIMSign(config *DKIMConfig) Option {
+func WithAlwaysDKIMSign(signer *dkim.Signer) Option {
 	return func(c *Client) error {
-		if config == nil {
+		if signer == nil {
 			return errors.New("DKIM config must not be nil")
 		}
-		if err := config.ValidateConfig(); err != nil {
+		if err := signer.ValidateConfig(); err != nil {
 			return err
 		}
-		c.dkim = config
+		c.dkim = signer
 		return nil
 	}
 }
@@ -1101,17 +1102,17 @@ func (c *Client) SetLogAuthData(logAuth bool) {
 //
 // Returns:
 //   - An error if the provided DKIMConfig is invalid or nil.
-func (c *Client) SetAlwaysDKIMSign(config *DKIMConfig) error {
-	if config == nil {
+func (c *Client) SetAlwaysDKIMSign(signer *dkim.Signer) error {
+	if signer == nil {
 		return errors.New("DKIM config must not be nil")
 	}
-	if err := config.ValidateConfig(); err != nil {
+	if err := signer.ValidateConfig(); err != nil {
 		return fmt.Errorf("invalid DKIM config: %w", err)
 	}
 
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	c.dkim = config
+	c.dkim = signer
 	return nil
 }
 

--- a/client.go
+++ b/client.go
@@ -128,6 +128,9 @@ type (
 		// dialContextFunc is the DialContextFunc that is used by the Client to connect to the SMTP server.
 		dialContextFunc DialContextFunc
 
+		// dkim is the DKIM configuration for the Client.
+		dkim *DKIMConfig
+
 		// dsnRcptNotifyType represents the different types of notifications for DSN (Delivery Status Notifications)
 		// receipts.
 		dsnRcptNotifyType []string
@@ -804,6 +807,33 @@ func WithoutSMTPUTF8() Option {
 	}
 }
 
+// WithAlwaysDKIMSign instructs the Client to sign every Msg that is sent with it using DKIM.
+//
+// This option is useful if you are planning to send multiple Msgs via the same client and don't
+// want to reconfigure DKIM for each Msg.
+//
+// Note: This will always take precedence over any DKIM configuration set on the Msg itself, if
+// used on the Client. If the Msg is not sent via the Client, the Msg's DKIM configuration will
+// be used instead.
+//
+// Parameters:
+//   - config: The DKIMConfig holding all the required options needed to DKIM sign a mail.
+//
+// Returns:
+//   - An Option function that configures the Client to always sign messages using DKIM.
+func WithAlwaysDKIMSign(config *DKIMConfig) Option {
+	return func(c *Client) error {
+		if config == nil {
+			return errors.New("DKIM config must not be nil")
+		}
+		if err := config.ValidateConfig(); err != nil {
+			return err
+		}
+		c.dkim = config
+		return nil
+	}
+}
+
 // TLSPolicy returns the TLSPolicy that is currently set on the Client as a string.
 //
 // This method retrieves the current TLSPolicy configured for the Client and returns it as a string representation.
@@ -1055,6 +1085,34 @@ func (c *Client) SetSMTPAuthCustom(smtpAuth smtp.Auth) {
 //   - logAuth: Set wether or not to log SMTP authentication data for the Client.
 func (c *Client) SetLogAuthData(logAuth bool) {
 	c.logAuthData = logAuth
+}
+
+// SetAlwaysDKIMSign sets or overrides the Client to sign every Msg that is sent with it using DKIM.
+//
+// This option is useful if you are planning to send multiple Msgs via the same client and don't
+// want to reconfigure DKIM for each Msg.
+//
+// Note: This will always take precedence over any DKIM configuration set on the Msg itself, if
+// used on the Client. If the Msg is not sent via the Client, the Msg's DKIM configuration will
+// be used instead.
+//
+// Parameters:
+//   - config: The DKIMConfig holding all the required options needed to DKIM sign a mail.
+//
+// Returns:
+//   - An error if the provided DKIMConfig is invalid or nil.
+func (c *Client) SetAlwaysDKIMSign(config *DKIMConfig) error {
+	if config == nil {
+		return errors.New("DKIM config must not be nil")
+	}
+	if err := config.ValidateConfig(); err != nil {
+		return fmt.Errorf("invalid DKIM config: %w", err)
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.dkim = config
+	return nil
 }
 
 // DialWithContext establishes a connection to the server using the provided context.Context.
@@ -1609,6 +1667,12 @@ func (c *Client) sendSingleMsg(client *smtp.Client, message *Msg) error {
 			affectedMsg: message, errcode: errorCode(err),
 			enhancedStatusCode: enhancedStatusCode(err, escSupport),
 		}
+	}
+
+	// the Client is instructed to always DKIM sign the Msg, this will override the
+	// Msg's own DKIM configuration if set
+	if c.dkim != nil {
+		message.dkim = c.dkim
 	}
 	_, err = message.WriteTo(writer)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -1104,10 +1104,10 @@ func (c *Client) SetLogAuthData(logAuth bool) {
 //   - An error if the provided DKIMConfig is invalid or nil.
 func (c *Client) SetAlwaysDKIMSign(signer *dkim.Signer) error {
 	if signer == nil {
-		return errors.New("DKIM config must not be nil")
+		return errors.New("DKIM signer must not be nil")
 	}
 	if err := signer.ValidateConfig(); err != nil {
-		return fmt.Errorf("invalid DKIM config: %w", err)
+		return fmt.Errorf("invalid DKIM signer: %w", err)
 	}
 
 	c.mutex.Lock()

--- a/client_test.go
+++ b/client_test.go
@@ -8,8 +8,11 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/ecdsa"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
@@ -169,6 +172,11 @@ func TestNewClient(t *testing.T) {
 		hostname := "mail.example.com"
 		netDailer := net.Dialer{}
 		tlsDailer := tls.Dialer{NetDialer: &netDailer, Config: &tls.Config{}}
+		privKey, err := PrivKeyFromPEM(testKeyRSA)
+		if err != nil {
+			t.Fatalf("failed to read private key from PEM: %s", err)
+		}
+		signer := DKIMSigner{Domain: testDomain, Selector: testSelector, Signer: privKey}
 		tests := []struct {
 			name       string
 			option     Option
@@ -757,6 +765,17 @@ func TestNewClient(t *testing.T) {
 				},
 				false, nil,
 			},
+			{
+				"WithAlwaysDKIMSign", WithAlwaysDKIMSign(&signer),
+				func(c *Client) error {
+					if c.dkim.Domain != testDomain {
+						return fmt.Errorf("failed to set DKIM signer. Want DKIM sign domain: %s, got: %s",
+							testDomain, c.dkim.Domain)
+					}
+					return nil
+				},
+				false, nil,
+			},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
@@ -823,6 +842,34 @@ func TestNewClient(t *testing.T) {
 		if !strings.EqualFold(client.host, "/tmp/mail.sock") {
 			t.Errorf("expected host to be set to unix socket path, expected: %s, got: %s", "/tmp/mail.sock",
 				client.host)
+		}
+	})
+	t.Run("NewClient WithAlwaysDKIMSign with nil signer", func(t *testing.T) {
+		_, err := NewClient(DefaultHost, WithAlwaysDKIMSign(nil))
+		if err == nil {
+			t.Error("expected error when creating client with nil DKIM signer, got nil")
+		}
+	})
+	t.Run("NewClient WithAlwaysDKIMSign with nil key", func(t *testing.T) {
+		signer := DKIMSigner{Domain: testDomain, Selector: testSelector, Signer: nil}
+		_, err := NewClient(DefaultHost, WithAlwaysDKIMSign(&signer))
+		if err == nil {
+			t.Error("expected error when creating client with nil crypto.Signer, got nil")
+		}
+	})
+	t.Run("NewClient WithAlwaysDKIMSign with ecDSA key", func(t *testing.T) {
+		block, _ := pem.Decode(testKeyECDSAPKCS8)
+		if block == nil {
+			t.Fatalf("no vaild PEM data found")
+		}
+		privKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			t.Fatalf("failed to parse ecDSA key: %s", err)
+		}
+		signer := DKIMSigner{Domain: testDomain, Selector: testSelector, Signer: privKey.(*ecdsa.PrivateKey)}
+		_, err = NewClient(DefaultHost, WithAlwaysDKIMSign(&signer))
+		if err == nil {
+			t.Error("expected error when creating client with ecDSA DKIM signer, got nil")
 		}
 	})
 }
@@ -1612,6 +1659,49 @@ func TestClient_SetLogAuthData(t *testing.T) {
 		client.SetLogAuthData(false)
 		if client.logAuthData {
 			t.Errorf("failed to set logAuthData, want: false, got: %t", client.logAuthData)
+		}
+	})
+}
+
+func TestClient_SetAlwaysDKIMSign(t *testing.T) {
+	privKey, err := PrivKeyFromPEM(testKeyRSA)
+	if err != nil {
+		t.Fatalf("failed to parse test key: %s", err)
+	}
+	signer := NewDKIMSigner(testDomain, testSelector, privKey)
+
+	t.Run("SetAlwaysDKIMSign with valid signer", func(t *testing.T) {
+		client, err := NewClient(DefaultHost)
+		if err != nil {
+			t.Fatalf("failed to create new client: %s", err)
+		}
+		if err := client.SetAlwaysDKIMSign(signer); err != nil {
+			t.Fatalf("failed to set DKIM signer: %s", err)
+		}
+		if client.dkim == nil {
+			t.Error("expected DKIM signer, got nil")
+		}
+		if client.dkim.Domain != testDomain {
+			t.Errorf("expected DKIM domain: %s, got: %s", testDomain, client.dkim.Domain)
+		}
+	})
+	t.Run("SetAlwaysDKIMSign with nil signer", func(t *testing.T) {
+		client, err := NewClient(DefaultHost)
+		if err != nil {
+			t.Fatalf("failed to create new client: %s", err)
+		}
+		if err := client.SetAlwaysDKIMSign(nil); err == nil {
+			t.Error("expected error when setting nil DKIM signer, got nil")
+		}
+	})
+	t.Run("SetAlwaysDKIMSign with nil crypto.Signer", func(t *testing.T) {
+		client, err := NewClient(DefaultHost)
+		if err != nil {
+			t.Fatalf("failed to create new client: %s", err)
+		}
+		invalidSigner := &DKIMSigner{Domain: testDomain, Selector: testSelector}
+		if err := client.SetAlwaysDKIMSign(invalidSigner); err == nil {
+			t.Error("expected error when setting invalid DKIM signer, got nil")
 		}
 	})
 }
@@ -3804,6 +3894,53 @@ func TestClient_sendSingleMsg(t *testing.T) {
 		}
 		if !strings.EqualFold(sendErr.enhancedStatusCode, "5.5.2") {
 			t.Errorf("expected enhanced status code 5.5.2, got %s", sendErr.enhancedStatusCode)
+		}
+	})
+	t.Run("DKIM signed message", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		PortAdder.Add(1)
+		serverPort := int(TestServerPortBase + PortAdder.Load())
+		featureSet := "250-ENHANCEDSTATUSCODES\r\n250-8BITMIME\r\n250-DSN\r\n250 SMTPUTF8"
+		go func() {
+			if err := simpleSMTPServer(ctx, t, &serverProps{
+				FeatureSet: featureSet,
+				ListenPort: serverPort,
+			}); err != nil {
+				t.Errorf("failed to start test server: %s", err)
+				return
+			}
+		}()
+		time.Sleep(time.Millisecond * 30)
+
+		privKey, err := PrivKeyFromPEM(testKeyRSA)
+		if err != nil {
+			t.Fatalf("failed to generate DKIM key: %s", err)
+		}
+		signer := NewDKIMSigner(testDomain, testSelector, privKey)
+		message := testMessage(t)
+
+		ctxDial, cancelDial := context.WithTimeout(ctx, time.Millisecond*500)
+		t.Cleanup(cancelDial)
+
+		client, err := NewClient(DefaultHost, WithPort(serverPort), WithTLSPolicy(NoTLS), WithAlwaysDKIMSign(signer))
+		if err != nil {
+			t.Fatalf("failed to create new client: %s", err)
+		}
+		if err = client.DialWithContext(ctxDial); err != nil {
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				t.Skip("failed to connect to the test server due to timeout")
+			}
+			t.Fatalf("failed to connect to test server: %s", err)
+		}
+		t.Cleanup(func() {
+			if err := client.Close(); err != nil {
+				t.Errorf("failed to close client: %s", err)
+			}
+		})
+		if err = client.sendSingleMsg(client.smtpClient, message); err != nil {
+			t.Errorf("failed to deliver mail: %s", err)
 		}
 	})
 }

--- a/dkim.go
+++ b/dkim.go
@@ -26,21 +26,7 @@ const (
 	CanonicalizationRelaxed Canonicalization = dkim.CanonicalizationRelaxed
 )
 
-// SignWithDKIM enables DKIM signing for this Msg. The signature is produced
-// over the final rendered bytes during WriteTo (after S/MIME and middlewares).
-/*
-func (m *Msg) SignWithDKIM(config *dkim.Signer) error {
-	if config == nil {
-		return errors.New("dkim: config must not be nil")
-	}
-	if err := config.ValidateConfig(); err != nil {
-		return err
-	}
-	m.dkim = config
-	return nil
-}
-*/
-
+// NewDKIMSigner creates a new DKIMSigner with the given domain, selector, and private key
 func NewDKIMSigner(domain, selector string, privKey crypto.Signer) *DKIMSigner {
 	return dkim.NewSigner(domain, selector, privKey)
 }

--- a/dkim.go
+++ b/dkim.go
@@ -45,11 +45,10 @@ func WithDKIM(config *DKIMConfig) MsgOption {
 	return func(m *Msg) { m.dkim = config }
 }
 
-func (m *Msg) hasDKIM() bool { return m.dkim != nil }
-
-// loadRSASigner decodes a PEM-encoded RSA private key into a crypto.Signer.
-// It accepts both PKCS#1 ("RSA PRIVATE KEY") and PKCS#8 ("PRIVATE KEY") blocks.
-func loadSigner(pemBytes []byte) (crypto.Signer, error) {
+// SignerFromPEM decodes a PEM-encoded RSA or Ed25519 private key block into a
+// crypto.Signer. It accepts both PKCS#1 ("RSA PRIVATE KEY") and PKCS#8 ("PRIVATE KEY")
+// byte slices
+func SignerFromPEM(pemBytes []byte) (crypto.Signer, error) {
 	block, _ := pem.Decode(pemBytes)
 	if block == nil {
 		return nil, errors.New("no valid PEM data found")
@@ -76,3 +75,6 @@ func loadSigner(pemBytes []byte) (crypto.Signer, error) {
 		return nil, fmt.Errorf("unsupported PEM block type %q", block.Type)
 	}
 }
+
+// hasDKIM returns true if the Msg has a DKIM config.
+func (m *Msg) hasDKIM() bool { return m.dkim != nil }

--- a/dkim.go
+++ b/dkim.go
@@ -16,20 +16,20 @@ import (
 	"github.com/wneessen/go-mail/internal/dkim"
 )
 
-// DKIMConfig represents the DKIM configuration
-type DKIMConfig = dkim.DKIM
+// DKIMSigner represents the DKIM configuration
+type DKIMSigner = dkim.Signer
 
-// Re-export the enums users need to set canonicalization.
-type DKIMCanonicalization = dkim.Canonicalization
+type Canonicalization = dkim.Canonicalization
 
 const (
-	DKIMCanonSimple  = dkim.CanonicalizationSimple
-	DKIMCanonRelaxed = dkim.CanonicalizationRelaxed
+	CanonicalizationSimple  Canonicalization = dkim.CanonicalizationSimple
+	CanonicalizationRelaxed Canonicalization = dkim.CanonicalizationRelaxed
 )
 
 // SignWithDKIM enables DKIM signing for this Msg. The signature is produced
 // over the final rendered bytes during WriteTo (after S/MIME and middlewares).
-func (m *Msg) SignWithDKIM(config *DKIMConfig) error {
+/*
+func (m *Msg) SignWithDKIM(config *dkim.Signer) error {
 	if config == nil {
 		return errors.New("dkim: config must not be nil")
 	}
@@ -39,16 +39,16 @@ func (m *Msg) SignWithDKIM(config *DKIMConfig) error {
 	m.dkim = config
 	return nil
 }
+*/
 
-// WithDKIM is the NewMsg option form; validation is deferred to WriteTo.
-func WithDKIM(config *DKIMConfig) MsgOption {
-	return func(m *Msg) { m.dkim = config }
+func NewDKIMSigner(domain, selector string, privKey crypto.Signer) *DKIMSigner {
+	return dkim.NewSigner(domain, selector, privKey)
 }
 
-// SignerFromPEM decodes a PEM-encoded RSA or Ed25519 private key block into a
+// PrivKeyFromPEM decodes a PEM-encoded RSA or Ed25519 private key block into a
 // crypto.Signer. It accepts both PKCS#1 ("RSA PRIVATE KEY") and PKCS#8 ("PRIVATE KEY")
 // byte slices
-func SignerFromPEM(pemBytes []byte) (crypto.Signer, error) {
+func PrivKeyFromPEM(pemBytes []byte) (crypto.Signer, error) {
 	block, _ := pem.Decode(pemBytes)
 	if block == nil {
 		return nil, errors.New("no valid PEM data found")
@@ -77,4 +77,6 @@ func SignerFromPEM(pemBytes []byte) (crypto.Signer, error) {
 }
 
 // hasDKIM returns true if the Msg has a DKIM config.
-func (m *Msg) hasDKIM() bool { return m.dkim != nil }
+func (m *Msg) hasDKIM() bool {
+	return m.dkim != nil
+}

--- a/dkim.go
+++ b/dkim.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: The go-mail Authors
+//
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+
+	"github.com/wneessen/go-mail/internal/dkim"
+)
+
+// DKIMConfig represents the DKIM configuration
+type DKIMConfig = dkim.DKIM
+
+// Re-export the enums users need to set canonicalization.
+type DKIMCanonicalization = dkim.Canonicalization
+
+const (
+	DKIMCanonSimple  = dkim.CanonicalizationSimple
+	DKIMCanonRelaxed = dkim.CanonicalizationRelaxed
+)
+
+// SignWithDKIM enables DKIM signing for this Msg. The signature is produced
+// over the final rendered bytes during WriteTo (after S/MIME and middlewares).
+func (m *Msg) SignWithDKIM(config *DKIMConfig) error {
+	if config == nil {
+		return errors.New("dkim: config must not be nil")
+	}
+	if err := config.ValidateConfig(); err != nil {
+		return err
+	}
+	m.dkim = config
+	return nil
+}
+
+// WithDKIM is the NewMsg option form; validation is deferred to WriteTo.
+func WithDKIM(config *DKIMConfig) MsgOption {
+	return func(m *Msg) { m.dkim = config }
+}
+
+func (m *Msg) hasDKIM() bool { return m.dkim != nil }
+
+// loadRSASigner decodes a PEM-encoded RSA private key into a crypto.Signer.
+// It accepts both PKCS#1 ("RSA PRIVATE KEY") and PKCS#8 ("PRIVATE KEY") blocks.
+func loadRSASigner(pemBytes []byte) (crypto.Signer, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, errors.New("no PEM data found")
+	}
+
+	switch block.Type {
+	case "RSA PRIVATE KEY": // PKCS#1
+		return x509.ParsePKCS1PrivateKey(block.Bytes)
+	case "PRIVATE KEY": // PKCS#8
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		rsaKey, ok := key.(*rsa.PrivateKey)
+		if !ok {
+			return nil, errors.New("PKCS#8 key is not an RSA key")
+		}
+		return rsaKey, nil
+	default:
+		return nil, fmt.Errorf("unsupported PEM block type %q", block.Type)
+	}
+}

--- a/dkim.go
+++ b/dkim.go
@@ -52,7 +52,7 @@ func (m *Msg) hasDKIM() bool { return m.dkim != nil }
 func loadSigner(pemBytes []byte) (crypto.Signer, error) {
 	block, _ := pem.Decode(pemBytes)
 	if block == nil {
-		return nil, errors.New("no PEM data found")
+		return nil, errors.New("no valid PEM data found")
 	}
 
 	switch block.Type {
@@ -64,11 +64,11 @@ func loadSigner(pemBytes []byte) (crypto.Signer, error) {
 			return nil, err
 		}
 
-		switch privKey := key.(type) {
+		switch key := key.(type) {
 		case *rsa.PrivateKey:
-			return privKey, nil
+			return key, nil
 		case ed25519.PrivateKey:
-			return privKey, nil
+			return key, nil
 		default:
 			return nil, fmt.Errorf("unsupported key type %T", key)
 		}

--- a/dkim.go
+++ b/dkim.go
@@ -6,6 +6,7 @@ package mail
 
 import (
 	"crypto"
+	"crypto/ed25519"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
@@ -48,25 +49,29 @@ func (m *Msg) hasDKIM() bool { return m.dkim != nil }
 
 // loadRSASigner decodes a PEM-encoded RSA private key into a crypto.Signer.
 // It accepts both PKCS#1 ("RSA PRIVATE KEY") and PKCS#8 ("PRIVATE KEY") blocks.
-func loadRSASigner(pemBytes []byte) (crypto.Signer, error) {
+func loadSigner(pemBytes []byte) (crypto.Signer, error) {
 	block, _ := pem.Decode(pemBytes)
 	if block == nil {
 		return nil, errors.New("no PEM data found")
 	}
 
 	switch block.Type {
-	case "RSA PRIVATE KEY": // PKCS#1
+	case "RSA PRIVATE KEY":
 		return x509.ParsePKCS1PrivateKey(block.Bytes)
-	case "PRIVATE KEY": // PKCS#8
+	case "PRIVATE KEY":
 		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 		if err != nil {
 			return nil, err
 		}
-		rsaKey, ok := key.(*rsa.PrivateKey)
-		if !ok {
-			return nil, errors.New("PKCS#8 key is not an RSA key")
+
+		switch privKey := key.(type) {
+		case *rsa.PrivateKey:
+			return privKey, nil
+		case ed25519.PrivateKey:
+			return privKey, nil
+		default:
+			return nil, fmt.Errorf("unsupported key type %T", key)
 		}
-		return rsaKey, nil
 	default:
 		return nil, fmt.Errorf("unsupported PEM block type %q", block.Type)
 	}

--- a/dkim.go
+++ b/dkim.go
@@ -16,24 +16,80 @@ import (
 	"github.com/wneessen/go-mail/internal/dkim"
 )
 
-// DKIMSigner represents the DKIM configuration
+// DKIMSigner represents the DKIM signing configuration.
+//
+// This type is an alias for dkim.Signer and holds the configuration used to apply DomainKeys
+// Identified Mail (DKIM) signatures to outgoing email messages, including the signing domain,
+// selector, private key, and canonicalization settings.
+//
+// References:
+//   - https://datatracker.ietf.org/doc/html/rfc6376
 type DKIMSigner = dkim.Signer
 
+// Canonicalization represents a DKIM canonicalization algorithm.
+//
+// This type is an alias for dkim.Canonicalization and identifies the method used to normalize the
+// header and body of a message before signing or verification. Canonicalization determines how
+// tolerant the signature is to modifications introduced in transit, such as whitespace changes.
+//
+// References:
+//   - https://datatracker.ietf.org/doc/html/rfc6376#section-3.4
 type Canonicalization = dkim.Canonicalization
 
+// CanonicalizationSimple and CanonicalizationRelaxed are the supported DKIM canonicalization modes.
+//
+// These constants enumerate the canonicalization algorithms defined by DKIM. The "simple" algorithm
+// tolerates almost no modification to the message, while the "relaxed" algorithm permits common,
+// insignificant changes such as whitespace normalization and header case folding.
+//
+// References:
+//   - https://datatracker.ietf.org/doc/html/rfc6376#section-3.4
 const (
 	CanonicalizationSimple  Canonicalization = dkim.CanonicalizationSimple
 	CanonicalizationRelaxed Canonicalization = dkim.CanonicalizationRelaxed
 )
 
-// NewDKIMSigner creates a new DKIMSigner with the given domain, selector, and private key
+// NewDKIMSigner creates a new DKIMSigner.
+//
+// This function constructs and returns a DKIMSigner configured to sign outgoing email messages
+// using DomainKeys Identified Mail (DKIM). It associates the signer with the provided domain and
+// selector, which together locate the public key in DNS, and uses the supplied private key to
+// generate cryptographic signatures over message headers and body.
+//
+// Parameters:
+//   - domain: The signing domain published in DNS (the "d=" tag).
+//   - selector: The selector used to locate the public key in DNS (the "s=" tag).
+//   - privKey: The private key used to produce the DKIM signature.
+//
+// Returns:
+//   - A pointer to a configured DKIMSigner ready to sign messages.
+//
+// References:
+//   - https://datatracker.ietf.org/doc/html/rfc6376
 func NewDKIMSigner(domain, selector string, privKey crypto.Signer) *DKIMSigner {
 	return dkim.NewSigner(domain, selector, privKey)
 }
 
-// PrivKeyFromPEM decodes a PEM-encoded RSA or Ed25519 private key block into a
-// crypto.Signer. It accepts both PKCS#1 ("RSA PRIVATE KEY") and PKCS#8 ("PRIVATE KEY")
-// byte slices
+// PrivKeyFromPEM decodes a PEM-encoded private key into a crypto.Signer.
+//
+// This function parses a PEM-encoded RSA or Ed25519 private key block and returns it as a
+// crypto.Signer. It accepts both PKCS#1 ("RSA PRIVATE KEY") and PKCS#8 ("PRIVATE KEY") encodings,
+// decoding the PEM data, dispatching on the block type, and validating that the contained key is a
+// supported type. The returned crypto.Signer can be passed directly to NewDKIMSigner to construct
+// a DKIMSigner. It returns an error if no valid PEM data is found, if parsing fails, or if the key
+// type is unsupported.
+//
+// Parameters:
+//   - pemBytes: The PEM-encoded private key data, in either PKCS#1 or PKCS#8 format.
+//
+// Returns:
+//   - A crypto.Signer wrapping the decoded private key, suitable for use with NewDKIMSigner.
+//   - An error if the PEM data is invalid, cannot be parsed, or contains an unsupported key type.
+//
+// References:
+//   - https://datatracker.ietf.org/doc/html/rfc8017
+//   - https://datatracker.ietf.org/doc/html/rfc5208
+//   - https://datatracker.ietf.org/doc/html/rfc8032
 func PrivKeyFromPEM(pemBytes []byte) (crypto.Signer, error) {
 	block, _ := pem.Decode(pemBytes)
 	if block == nil {
@@ -60,9 +116,4 @@ func PrivKeyFromPEM(pemBytes []byte) (crypto.Signer, error) {
 	default:
 		return nil, fmt.Errorf("unsupported PEM block type %q", block.Type)
 	}
-}
-
-// hasDKIM returns true if the Msg has a DKIM config.
-func (m *Msg) hasDKIM() bool {
-	return m.dkim != nil
 }

--- a/dkim_test.go
+++ b/dkim_test.go
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: The go-mail Authors
+//
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"testing"
+)
+
+func TestDKIM(t *testing.T) {}

--- a/dkim_test.go
+++ b/dkim_test.go
@@ -8,4 +8,132 @@ import (
 	"testing"
 )
 
-func TestDKIM(t *testing.T) {}
+const (
+	testDomain   = "example.com"
+	testSelector = "2026a"
+)
+
+var (
+	testKeyEd25519 = []byte(`-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIPEZCuuDQ2PIH1RDbMl92DIb8Vsqz2j7B26aHomVq1pU
+-----END PRIVATE KEY-----`)
+
+	testKeyRSA = []byte(`-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCqUtV4PV2kTmkW
+ti9PxJ0atHVu7Jf5zMNMHNy+prWCqSqDlz8Tz6weRiuP7+a7vGliCQHr02etzz0r
+lPJ+tTXw/18/B49+1BWu3ves2d7N67IIziRIOXkxdSjcfgDqzXrUmtnhMp8nVn1V
+YPavr2J1OSuA5sBz3C5GFddurFeR5a3C1BEsqEU0BJtbwX2dreNWGvznK2WgP+nR
+1K78uoAsVsviUEqaYvo8Ipvq7+oP2JQqjj7AKZ6JNaOSl9vc0MY89bveSW7NksyJ
+W2YNAuGxhkbPzjYu/8UwPv7vS/zTZjzZ55d5MDVwafqVWNOqxmqLPKO4D2x6HaQ6
+WVnmkcq7AgMBAAECggEABT0IoFWW1Vbgbliw1NH+h+kZRtqGlSHu+1ploR5GnCAO
+jHJoPDQd0ZF62sbxqy8VUkGqVNP1hFSvJU9/q0S1Ciu0QHTqXyOFUxGzWNqB5YZM
+8H+n59Bb6CnvRFsxeY/LB+NC8Vy7xxtiggl+gzT0uqArif29yCWmfo5Tv4bx4vFL
+bv04dm5JIcWpsmBuXVQcjRI1axmwbBATvMagQ/iwEB5OHxG0Z5Xf/c6ivEDeVkVX
++CIDyMmj2wcqz0Ao98x1IOUtN1c6HTD1FaeLJHFg2l2aj6RBwcTFWfEpjHIQz3Ul
+oe7FJxwi9RefoX/KNGmv46zc0Jssx3ZuPg0KjH00eQKBgQDLu9osJc+MfLw2vKlF
+nwb+V8gf7cYZqw6fFLhbpugKe/Y/8lbvgmBUp19wEcGeD770MtY8NWVqEzqSOYkg
+JQF9sxjOIotqad0ZAwYohVM9hHIcaMCgDfRPFYrrz5s6mSE/PIAr1bnAFO0LLChj
+pcCHPi+dNzvpkPEODBCBui8PAwKBgQDWBMa6w9GXu7l2i64clU6EWgPrymKXxBq2
+2m218r3B5ZJiKet+hHF3wC2w6kv0TAGdi3fj6FizVRqofQrlMgIydT2YvOjTByaJ
+nXYupGvE6KLGQGgfIf1Tv0k+8cv04AlJLI2xnijPc+A2vDpnJU0B5tzcfS2ctsSa
+7dFY/AgL6QKBgH/0Eyn29Ur+bBbUllsrbXEAIKgs5WXpkN1IXiDxynoLMLUotoDm
+GSoRlFcGT9u9d+hWpUZbIr5kJT0A9aZCl5UijkmoWHcU1c+Hnq6ETastK528DH55
+RR8GIKHJWWyMD91vWfAt4uNIQTfrG9K5nxlRbQYIUpB2f26bFSLkk/mRAoGAZtI4
+n/YANkPMYLXO2pCo/lE43QmIwJ1IsFzUpLuQix0+bMbzCv+afAvqZ7rI7v+tLwGY
+gfhY1R+oBRa+K0sRXyiQhVcNDIW88BSkeNgpppqVyWWcIIj16kxWZlVIxcb07yDm
+mlUAClsDd4iLDo8PJkDCD3Rce5QbdMuY7oV3YDECgYA/nf2B5Qo2im4w9GiCMYIr
+E6IylAS2062WYGJVnSNrcfWn8uO9Z2VSNCwTpsvdTxugpe5e8kLHr2BbLypUyyau
+wJzNCYNbFNw2GX2AE4G9bjGigkRfzOzG465xsZ178EgqW05MFtdNSSSUyvNMdJtb
+hcSTp1LpV7OWf4eUXzgnZQ==
+-----END PRIVATE KEY-----`)
+
+	testKeyRSAPKCS1 = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQDrR8LgINQIN+jUkt0+OYFlDqf4hT10x9jRUMMg/NrcG/h5mP9B
+7KU2TGUIt3ItetSB/ltfaIsOeEtns2eAGVzz77cQodWC9qWkYbuou9xQNbL2jNFF
+aFA30p5E8iupp9dndm2nJXws5EjCp/JEYRGeYW7kgAWFNvDFnTng7M1lXQIDAQAB
+AoGAW2F90OsvLxn39kgsYfSXyxZMKvwlCGxuS63ge7l5j6/Va/T+fy5YZKR7QU1u
+rTddvjd6aa4DBFW4g8hsVJaFQQKVRngIK5pMCk6wrBVW1glCAKeQ1ie2bZt0LvYs
+9HLnthpaZxU/eaFpgwUvmZVPgV1uLRe4MxeotHi9cW27PUECQQD6eOHmCHnd6pmx
+MBj5/xL86x3Ldyf/axyUC7SUIotIzsbkrmd6PSjFENFAKvTU/oOdleVpyAAgw92e
+Ykey+NAlAkEA8HkMOUUk6RpCPTe3M76XMaje9Hf3yinyIZG3BjILue402rfaJ0m6
+eRmGcsuRO5CIezz2GL3dHCvwfU3kOMw+2QJBAMH0a5FSzPPgX+VKhnzIXa7GbksJ
+WUq7aeTmb44qdcsKfA/HUc/hnjmDvVXALdjlwYt88KqKOjclFO850aWwcJUCQA0M
+RGGHIu2TAy0XLNWd7c4//3j8WXGavQydP3USmhhImI2VlDy1f2y6udTYvtSgjwdA
+04mcI7c3myDxbQS38GECQQDnZMASDyQE+/CK8plckVrGGcy+X/8EGta+HeK0ZH3E
+UDKil5X2rYZq+ADN7yEYh9f9i9da/ngzkaog1TvcLqpJ
+-----END RSA PRIVATE KEY-----`)
+
+	testKeyECDSA = []byte(`-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEINPqdWSVBy9EvOpJX4UY9jt4fGEsmluDZMpPIipdmLRloAoGCCqGSM49
+AwEHoUQDQgAEcCgO5Z7nsPCejY8fNCBN7LGIA6QXxqERjQ5oC0aqp4UPpi/Le4zf
+nVcSsVa47l739jl+jqC2yQYVjTvst/+Dyg==
+-----END EC PRIVATE KEY-----`)
+
+	testKeyECDSAPKCS8 = []byte(`-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg1ajprHhlC1/J4YXs
+t1fwAS19v+kHh+UDcz/8ltM8XpChRANCAASoHEYSvB4X9KWX8eQ0spf+OLkIJg5v
+4LXlgz/dkVsxbMM9zM9usBTi3WCTMggJvZemZQTW2MVV677Q4QynRqSG
+-----END PRIVATE KEY-----`)
+)
+
+func TestNewDKIMSigner(t *testing.T) {
+	tests := []struct {
+		name    string
+		keyData []byte
+	}{
+		{"Signer with RSA key", testKeyRSA},
+		{"Signer with Ed25519 key", testKeyEd25519},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			privKey, err := PrivKeyFromPEM(test.keyData)
+			if err != nil {
+				t.Fatalf("failed to read private key from PEM: %s", err)
+			}
+			signer := NewDKIMSigner(testDomain, testSelector, privKey)
+			if signer == nil {
+				t.Fatal("signer is nil")
+			}
+		})
+	}
+}
+
+func TestPrivKeyFromPEM(t *testing.T) {
+	t.Run("RSA key succeeds", func(t *testing.T) {
+		_, err := PrivKeyFromPEM(testKeyRSA)
+		if err != nil {
+			t.Fatalf("failed to read private key from PEM: %s", err)
+		}
+	})
+	t.Run("RSA key succeeds (PKCS#1)", func(t *testing.T) {
+		_, err := PrivKeyFromPEM(testKeyRSAPKCS1)
+		if err != nil {
+			t.Fatalf("failed to read private key from PEM: %s", err)
+		}
+	})
+	t.Run("Ed25519 key succeeds", func(t *testing.T) {
+		_, err := PrivKeyFromPEM(testKeyEd25519)
+		if err != nil {
+			t.Fatalf("failed to read private key from PEM: %s", err)
+		}
+	})
+	t.Run("ecDSA key is not supported", func(t *testing.T) {
+		_, err := PrivKeyFromPEM(testKeyECDSA)
+		if err == nil {
+			t.Fatal("expected ecDSA to fail as unsupported")
+		}
+	})
+	t.Run("ecDSA key is not supported (PKCS#8)", func(t *testing.T) {
+		_, err := PrivKeyFromPEM(testKeyECDSAPKCS8)
+		if err == nil {
+			t.Fatal("expected ecDSA to fail as unsupported")
+		}
+	})
+	t.Run("nil byte key fails", func(t *testing.T) {
+		_, err := PrivKeyFromPEM(nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
         devShells.default = pkgs.mkShell {
           buildInputs = [
             go-overlay.packages.${system}.govendor
+            nixpkgs.legacyPackages.${system}.dkimpy
             nixpkgs.legacyPackages.${system}.gofumpt
             nixpkgs.legacyPackages.${system}.golangci-lint
             nixpkgs.legacyPackages.${system}.reuse

--- a/internal/dkim/dkim.go
+++ b/internal/dkim/dkim.go
@@ -15,6 +15,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 )
@@ -54,8 +55,8 @@ var (
 		"Content-Type", "MIME-Version"}
 )
 
-// Config holds all DKIM signing parameters.
-type Config struct {
+// DKIM holds all DKIM signing parameters.
+type DKIM struct {
 	Domain    string
 	Selector  string
 	Signer    crypto.Signer
@@ -71,21 +72,23 @@ type Config struct {
 	AUID          string
 	BodyLength    int64
 
+	Encoder io.WriteCloser
+
 	// Now is injectable for deterministic tests, we default to time.Now
 	Now func() time.Time
 }
 
 // Validate validates the DKIM configuration for required settings
-func (c *Config) Validate() error {
+func (d *DKIM) ValidateConfig() error {
 	switch {
-	case c.Domain == "":
+	case d.Domain == "":
 		return ErrDKIMNoDomain
-	case c.Selector == "":
+	case d.Selector == "":
 		return ErrDKIMNoSelector
-	case c.Signer == nil:
+	case d.Signer == nil:
 		return ErrDKIMNoSigner
 	}
-	for _, h := range c.effectiveHeaders() {
+	for _, h := range d.effectiveHeaders() {
 		if strings.EqualFold(h, "from") {
 			return nil
 		}
@@ -95,47 +98,47 @@ func (c *Config) Validate() error {
 
 // effectiveHeaders returns the list of headers to sign, defaulting to the standard set
 // if none are configured
-func (c *Config) effectiveHeaders() []string {
-	if len(c.SignedHeaders) == 0 {
+func (d *DKIM) effectiveHeaders() []string {
+	if len(d.SignedHeaders) == 0 {
 		return defaultHeader
 	}
-	return c.SignedHeaders
+	return d.SignedHeaders
 }
 
 // headerListForTag returns the list of headers to sign for a given tag, including any
 // oversign headers
-func (c *Config) headerListForTag() []string {
-	base := c.effectiveHeaders()
-	if len(c.Oversign) == 0 {
+func (d *DKIM) headerListForTag() []string {
+	base := d.effectiveHeaders()
+	if len(d.Oversign) == 0 {
 		return base
 	}
-	return append(append([]string{}, base...), c.Oversign...)
+	return append(append([]string{}, base...), d.Oversign...)
 }
 
 // now returns the current time, using the injected Now function if set, or
 // time.Now otherwise as default
-func (c *Config) now() time.Time {
-	if c.Now != nil {
-		return c.Now()
+func (d *DKIM) now() time.Time {
+	if d.Now != nil {
+		return d.Now()
 	}
 	return time.Now()
 }
 
 // Sign returns the DKIM-Signature header line for the given raw headers and body
-func Sign(config Config, rawHeaders, body []byte) (string, error) {
-	if err := config.Validate(); err != nil {
+func (d *DKIM) Sign(rawHeaders, body []byte) (string, error) {
+	if err := d.ValidateConfig(); err != nil {
 		return "", err
 	}
 
-	algo := config.Algorithm
+	algo := d.Algorithm
 	if algo == "" {
-		if _, ok := config.Signer.Public().(ed25519.PublicKey); ok {
+		if _, ok := d.Signer.Public().(ed25519.PublicKey); ok {
 			algo = SignatureAlgoED25519
 		} else {
 			algo = SignatureAlgoRSA
 		}
 	}
-	hc, bc := config.HeaderCanon, config.BodyCanon
+	hc, bc := d.HeaderCanon, d.BodyCanon
 	if hc == "" {
 		hc = CanonicalizationRelaxed
 	}
@@ -145,8 +148,8 @@ func Sign(config Config, rawHeaders, body []byte) (string, error) {
 
 	// Create the body hash (bh=)
 	cb := canonicalizeBody(body, bc)
-	if config.BodyLength > 0 && int64(len(cb)) > config.BodyLength {
-		cb = cb[:config.BodyLength]
+	if d.BodyLength > 0 && int64(len(cb)) > d.BodyLength {
+		cb = cb[:d.BodyLength]
 	}
 	bh := sha256.Sum256(cb)
 
@@ -154,47 +157,67 @@ func Sign(config Config, rawHeaders, body []byte) (string, error) {
 	tags := []string{
 		"v=1", "a=" + string(algo),
 		"c=" + string(hc) + "/" + string(bc),
-		"d=" + config.Domain, "s=" + config.Selector,
-		fmt.Sprintf("t=%d", config.now().Unix()),
-		"h=" + strings.Join(config.headerListForTag(), ":"),
+		"d=" + d.Domain, "s=" + d.Selector,
+		fmt.Sprintf("t=%d", d.now().Unix()),
+		"h=" + strings.Join(d.headerListForTag(), ":"),
 		"bh=" + base64.StdEncoding.EncodeToString(bh[:]),
 	}
-	if config.Expiration > 0 {
-		tags = append(tags, fmt.Sprintf("x=%d", config.now().Add(config.Expiration).Unix()))
+	if d.Expiration > 0 {
+		tags = append(tags, fmt.Sprintf("x=%d", d.now().Add(d.Expiration).Unix()))
 	}
-	if config.AUID != "" {
-		tags = append(tags, "i="+config.AUID)
+	if d.AUID != "" {
+		tags = append(tags, "i="+d.AUID)
 	}
-	if config.BodyLength > 0 {
-		tags = append(tags, fmt.Sprintf("l=%d", config.BodyLength))
+	if d.BodyLength > 0 {
+		tags = append(tags, fmt.Sprintf("l=%d", d.BodyLength))
 	}
 	tags = append(tags, "b=")
 	value := strings.Join(tags, "; ")
 
 	// Parse headers and assemble the input to signature (with empty b=)
 	store := parseHeaders(rawHeaders)
-	var in bytes.Buffer
-	for _, h := range config.headerListForTag() {
-		if line, ok := store.pop(h); ok {
+	in := bytes.NewBuffer(nil)
+	for _, header := range d.headerListForTag() {
+		if line, ok := store.pop(header); ok {
 			in.Write(canonicalizeHeader(line, hc))
 			in.WriteString("\r\n")
 		}
 	}
-	in.Write(canonicalizeHeader("DKIM-Signature:"+value, hc))
+
+	// Fold the tags ONCE with an empty b=. These exact bytes are reused for the
+	// wire, so the fold points can never diverge between what we sign and what
+	// we emit.
+	foldedTags := foldHeader(value) // value ends in "b="
+
+	switch hc {
+	case CanonicalizationSimple:
+		in.WriteString("DKIM-Signature: ")
+		in.WriteString(value) // unfolded, b= empty — matches the emitted line
+	case CanonicalizationRelaxed:
+		in.Write(canonicalizeHeader("DKIM-Signature:"+value, hc))
+	}
 
 	// Sign the message (Ed25519 signs the message, while RSA signs the SHA-256 digest)
-	var sig []byte
+	var signature []byte
 	var err error
-	if key, ok := config.Signer.(ed25519.PrivateKey); ok {
-		sig = ed25519.Sign(key, in.Bytes())
-	} else {
-		d := sha256.Sum256(in.Bytes())
-		sig, err = config.Signer.Sign(rand.Reader, d[:], crypto.SHA256)
+	switch key := d.Signer.(type) {
+	case ed25519.PrivateKey:
+		signature = ed25519.Sign(key, in.Bytes())
+	default:
+		digest := sha256.Sum256(in.Bytes())
+		signature, err = key.Sign(rand.Reader, digest[:], crypto.SHA256)
 	}
 	if err != nil {
 		return "", err
 	}
 
-	return "DKIM-Signature: " + foldHeader(value+base64.StdEncoding.EncodeToString(sig)) +
-		"\r\n", nil
+	sigB64 := base64.StdEncoding.EncodeToString(signature)
+	if hc == CanonicalizationSimple {
+		// Emit a single unfolded line: no byte-significant fold points for an
+		// MTA to rewrap. Must match the hash input, which also used the
+		// unfolded value.
+		return "DKIM-Signature: " + value + sigB64 + "\r\n", nil
+	}
+	// relaxed: folding is unfolded away by verifiers, so wrap for readability.
+	return "DKIM-Signature: " + appendFoldedBase64(foldedTags, sigB64) + "\r\n", nil
 }

--- a/internal/dkim/dkim.go
+++ b/internal/dkim/dkim.go
@@ -51,8 +51,10 @@ const (
 
 var (
 	// defaultHeader is the default set of headers to sign
-	defaultHeader = []string{"From", "To", "Subject", "Date", "Message-ID",
-		"Content-Type", "MIME-Version"}
+	defaultHeader = []string{
+		"From", "To", "Subject", "Date", "Message-ID",
+		"Content-Type", "MIME-Version",
+	}
 
 	// defaultCanonicalization is the default canonicalization algorithm to use
 	defaultCanonicalization = CanonicalizationRelaxed

--- a/internal/dkim/dkim.go
+++ b/internal/dkim/dkim.go
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: The go-mail Authors
+//
+// SPDX-License-Identifier: MIT
+
+// Package dkim implements
+// TODO: document this properly
+package dkim
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Canonicalization defines the DKIM canonicalization algorithm
+type Canonicalization string
+
+const (
+	// CanonicalizationSimple is the simple canonicalization algorithm
+	CanonicalizationSimple Canonicalization = "simple"
+
+	// CanonicalizationRelaxed is the relaxed canonicalization algorithm
+	CanonicalizationRelaxed Canonicalization = "relaxed"
+)
+
+// SignatureAlgo defines the DKIM signature algorithm
+type SignatureAlgo string
+
+const (
+	// SignatureAlgoRSA is the RSA SHA-256 signature algorithm
+	SignatureAlgoRSA SignatureAlgo = "rsa-sha256"
+
+	// SignatureAlgoED25519 is the ED25519 SHA-256 signature algorithm
+	SignatureAlgoED25519 SignatureAlgo = "ed25519-sha256"
+)
+
+var (
+	ErrDKIMNoDomain    = errors.New("a DKIM domain must be set")
+	ErrDKIMNoSelector  = errors.New("a DKIM selector must be set")
+	ErrDKIMNoSigner    = errors.New("a DKIM crypto signer must be provided")
+	ErrDKIMMissingFrom = errors.New("FROM is a required DKIM header")
+)
+
+var (
+	// defaultHeader is the default set of headers to sign
+	defaultHeader = []string{"From", "To", "Subject", "Date", "Message-ID",
+		"Content-Type", "MIME-Version"}
+)
+
+// Config holds all DKIM signing parameters.
+type Config struct {
+	Domain    string
+	Selector  string
+	Signer    crypto.Signer
+	Algorithm SignatureAlgo
+
+	// We default to CanonicalizationRelaxed for both header and body canonicalization
+	HeaderCanon Canonicalization
+	BodyCanon   Canonicalization
+
+	SignedHeaders []string
+	Oversign      []string
+	Expiration    time.Duration
+	AUID          string
+	BodyLength    int64
+
+	// Now is injectable for deterministic tests, we default to time.Now
+	Now func() time.Time
+}
+
+// Validate validates the DKIM configuration for required settings
+func (c *Config) Validate() error {
+	switch {
+	case c.Domain == "":
+		return ErrDKIMNoDomain
+	case c.Selector == "":
+		return ErrDKIMNoSelector
+	case c.Signer == nil:
+		return ErrDKIMNoSigner
+	}
+	for _, h := range c.effectiveHeaders() {
+		if strings.EqualFold(h, "from") {
+			return nil
+		}
+	}
+	return ErrDKIMMissingFrom
+}
+
+// effectiveHeaders returns the list of headers to sign, defaulting to the standard set
+// if none are configured
+func (c *Config) effectiveHeaders() []string {
+	if len(c.SignedHeaders) == 0 {
+		return defaultHeader
+	}
+	return c.SignedHeaders
+}
+
+// headerListForTag returns the list of headers to sign for a given tag, including any
+// oversign headers
+func (c *Config) headerListForTag() []string {
+	base := c.effectiveHeaders()
+	if len(c.Oversign) == 0 {
+		return base
+	}
+	return append(append([]string{}, base...), c.Oversign...)
+}
+
+// now returns the current time, using the injected Now function if set, or
+// time.Now otherwise as default
+func (c *Config) now() time.Time {
+	if c.Now != nil {
+		return c.Now()
+	}
+	return time.Now()
+}
+
+// Sign returns the DKIM-Signature header line for the given raw headers and body
+func Sign(config Config, rawHeaders, body []byte) (string, error) {
+	if err := config.Validate(); err != nil {
+		return "", err
+	}
+
+	algo := config.Algorithm
+	if algo == "" {
+		if _, ok := config.Signer.Public().(ed25519.PublicKey); ok {
+			algo = SignatureAlgoED25519
+		} else {
+			algo = SignatureAlgoRSA
+		}
+	}
+	hc, bc := config.HeaderCanon, config.BodyCanon
+	if hc == "" {
+		hc = CanonicalizationRelaxed
+	}
+	if bc == "" {
+		bc = CanonicalizationRelaxed
+	}
+
+	// Create the body hash (bh=)
+	cb := canonicalizeBody(body, bc)
+	if config.BodyLength > 0 && int64(len(cb)) > config.BodyLength {
+		cb = cb[:config.BodyLength]
+	}
+	bh := sha256.Sum256(cb)
+
+	// Assemble the header tags as signature placeholder (empty b=)
+	tags := []string{
+		"v=1", "a=" + string(algo),
+		"c=" + string(hc) + "/" + string(bc),
+		"d=" + config.Domain, "s=" + config.Selector,
+		fmt.Sprintf("t=%d", config.now().Unix()),
+		"h=" + strings.Join(config.headerListForTag(), ":"),
+		"bh=" + base64.StdEncoding.EncodeToString(bh[:]),
+	}
+	if config.Expiration > 0 {
+		tags = append(tags, fmt.Sprintf("x=%d", config.now().Add(config.Expiration).Unix()))
+	}
+	if config.AUID != "" {
+		tags = append(tags, "i="+config.AUID)
+	}
+	if config.BodyLength > 0 {
+		tags = append(tags, fmt.Sprintf("l=%d", config.BodyLength))
+	}
+	tags = append(tags, "b=")
+	value := strings.Join(tags, "; ")
+
+	// Parse headers and assemble the input to signature (with empty b=)
+	store := parseHeaders(rawHeaders)
+	var in bytes.Buffer
+	for _, h := range config.headerListForTag() {
+		if line, ok := store.pop(h); ok {
+			in.Write(canonicalizeHeader(line, hc))
+			in.WriteString("\r\n")
+		}
+	}
+	in.Write(canonicalizeHeader("DKIM-Signature:"+value, hc))
+
+	// Sign the message (Ed25519 signs the message, while RSA signs the SHA-256 digest)
+	var sig []byte
+	var err error
+	if key, ok := config.Signer.(ed25519.PrivateKey); ok {
+		sig = ed25519.Sign(key, in.Bytes())
+	} else {
+		d := sha256.Sum256(in.Bytes())
+		sig, err = config.Signer.Sign(rand.Reader, d[:], crypto.SHA256)
+	}
+	if err != nil {
+		return "", err
+	}
+
+	return "DKIM-Signature: " + foldHeader(value+base64.StdEncoding.EncodeToString(sig)) +
+		"\r\n", nil
+}

--- a/internal/dkim/dkim.go
+++ b/internal/dkim/dkim.go
@@ -2,8 +2,15 @@
 //
 // SPDX-License-Identifier: MIT
 
-// Package dkim implements
-// TODO: document this properly
+// Package dkim implements DKIM signing and verification according to RFC 6376. It provides
+// support for both simple and relaxed canonicalization algorithms as well as support for
+// RSA and ED25519 signature algorithms.
+//
+// This package only supports RSA-SHA256 and ED25519-SHA256 signature algorithms. RSA-SHA1
+// is not supported since it's deprecated and prohibited by RFC 8301.
+//
+// See: https://datatracker.ietf.org/doc/html/rfc6376
+// and: https://datatracker.ietf.org/doc/html/rfc8301#section-3.1
 package dkim
 
 import (
@@ -15,7 +22,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 )
@@ -43,9 +49,16 @@ const (
 )
 
 var (
-	ErrDKIMNoDomain    = errors.New("a DKIM domain must be set")
-	ErrDKIMNoSelector  = errors.New("a DKIM selector must be set")
-	ErrDKIMNoSigner    = errors.New("a DKIM crypto signer must be provided")
+	// ErrDKIMNoDomain is returned when no DKIM domain is set
+	ErrDKIMNoDomain = errors.New("a DKIM domain must be set")
+
+	// ErrDKIMNoSelector is returned when no DKIM selector is set
+	ErrDKIMNoSelector = errors.New("a DKIM selector must be set")
+
+	// ErrDKIMNoSigner is returned when no DKIM crypto signer is provided
+	ErrDKIMNoSigner = errors.New("a DKIM crypto signer must be provided")
+
+	// ErrDKIMMissingFrom is returned when the FROM header is missing
 	ErrDKIMMissingFrom = errors.New("FROM is a required DKIM header")
 )
 
@@ -62,7 +75,7 @@ type DKIM struct {
 	Signer    crypto.Signer
 	Algorithm SignatureAlgo
 
-	// We default to CanonicalizationRelaxed for both header and body canonicalization
+	// We default to CanonicalizationRelaxed for both header and body
 	HeaderCanon Canonicalization
 	BodyCanon   Canonicalization
 
@@ -71,8 +84,6 @@ type DKIM struct {
 	Expiration    time.Duration
 	AUID          string
 	BodyLength    int64
-
-	Encoder io.WriteCloser
 
 	// Now is injectable for deterministic tests, we default to time.Now
 	Now func() time.Time
@@ -197,14 +208,18 @@ func (d *DKIM) Sign(rawHeaders, body []byte) (string, error) {
 		in.Write(canonicalizeHeader("DKIM-Signature:"+value, hc))
 	}
 
-	// Sign the message (Ed25519 signs the message, while RSA signs the SHA-256 digest)
+	// Both algorithms sign the SHA-256 digest of the canonicalized headers
+	// Ed25519-SHA256 is PureEdDSA over that hash
+	//
+	// See: https://datatracker.ietf.org/doc/html/rfc6376#section-3.7
+	// and https://datatracker.ietf.org/doc/html/rfc8463#section-3
+	digest := sha256.Sum256(in.Bytes())
 	var signature []byte
 	var err error
 	switch key := d.Signer.(type) {
 	case ed25519.PrivateKey:
-		signature = ed25519.Sign(key, in.Bytes())
+		signature = ed25519.Sign(key, digest[:]) // PureEdDSA over the digest
 	default:
-		digest := sha256.Sum256(in.Bytes())
 		signature, err = key.Sign(rand.Reader, digest[:], crypto.SHA256)
 	}
 	if err != nil {

--- a/internal/dkim/dkim.go
+++ b/internal/dkim/dkim.go
@@ -18,6 +18,7 @@ import (
 	"crypto"
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
@@ -49,6 +50,12 @@ const (
 )
 
 var (
+	// defaultHeader is the default set of headers to sign
+	defaultHeader = []string{"From", "To", "Subject", "Date", "Message-ID",
+		"Content-Type", "MIME-Version"}
+)
+
+var (
 	// ErrDKIMNoDomain is returned when no DKIM domain is set
 	ErrDKIMNoDomain = errors.New("a DKIM domain must be set")
 
@@ -60,12 +67,10 @@ var (
 
 	// ErrDKIMMissingFrom is returned when the FROM header is missing
 	ErrDKIMMissingFrom = errors.New("FROM is a required DKIM header")
-)
 
-var (
-	// defaultHeader is the default set of headers to sign
-	defaultHeader = []string{"From", "To", "Subject", "Date", "Message-ID",
-		"Content-Type", "MIME-Version"}
+	// ErrDKIMUnsupportedSigner is returned when the DKIM signer type is
+	// unsupported
+	ErrDKIMUnsupportedSigner = errors.New("unsupported DKIM signer type")
 )
 
 // Signer represents a DKIM signer that holds all signing parameters
@@ -97,6 +102,10 @@ type Signer struct {
 	// Signer is the crypto.Signer used to sign the message.
 	Signer crypto.Signer
 
+	// NowFunc represents a function that is used to determine the signature's
+	// time field (t=). It can be overridden for deterministic tests.
+	NowFunc func() time.Time
+
 	// auid represents the DKIM Agent or User Identifier (auid)
 	// See: https://datatracker.ietf.org/doc/html/rfc6376#section-2.6
 	//
@@ -104,7 +113,7 @@ type Signer struct {
 	// whom the Signing Domain Identifier (SDID) has taken responsibility.
 	// The auid comprises a domain name and an optional <local-part>.  The
 	// domain name is the same as that used for the SDID or is a subdomain
-	// of it.  For DKIM processing, the domain name portion of the auid has
+	// of it. For DKIM processing, the domain name portion of the auid has
 	// only basic domain name semantics; any possible owner-specific
 	// semantics are outside the scope of DKIM.
 	//
@@ -139,16 +148,21 @@ type Signer struct {
 	// See: https://datatracker.ietf.org/doc/html/rfc6376#section-3.4
 	headerCanonicalization Canonicalization
 
-	algorithm       SignatureAlgo
-	bodyLength      int64
-	signedHeaders   []string
-	oversignHeaders []string
+	// algorithm defines the type of signature algorithm used for the DKIM signature
+	algorithm SignatureAlgo
 
-	// NowFunc represents a function that is used to determine the signature's
-	// time field (t=). It can be overridden for deterministic tests.
-	NowFunc func() time.Time
+	// bodyLength keeps track of the length of the message body
+	bodyLength int64
+
+	// signedHeaders holds the list of headers that are signed by the DKIM signature
+	signedHeaders []string
+
+	// oversignHeaders holds the list of headers that are oversigned by the DKIM signature
+	// for improved security of the signature
+	oversignHeaders []string
 }
 
+// NewSigner creates a new DKIM signer with the given domain, selector, and crypto.Signer
 func NewSigner(domain, selector string, signer crypto.Signer) *Signer {
 	dkimSigner := &Signer{
 		Domain:   domain,
@@ -158,27 +172,40 @@ func NewSigner(domain, selector string, signer crypto.Signer) *Signer {
 	return dkimSigner
 }
 
+// AUID sets the AUID (Authorized User ID) for the DKIM signature
+func (s *Signer) AUID(auid string) {
+	s.auid = auid
+}
+
+// BodyCanonicalization sets the canonicalization mode for the message body
 func (s *Signer) BodyCanonicalization(mode Canonicalization) {
 	s.bodyCanonicalization = mode
 }
 
+// ExpiresIn sets the expiration time for the DKIM signature
+func (s *Signer) ExpiresIn(expiration time.Duration) {
+	s.expiration = expiration
+}
+
+// HeaderCanonicalization sets the canonicalization mode for the message headers
 func (s *Signer) HeaderCanonicalization(mode Canonicalization) {
 	s.headerCanonicalization = mode
 }
 
-func (s *Signer) ExpireIn(expiration time.Duration) {
-	s.expiration = expiration
+// OversignHeaders sets the headers to be oversigned for the DKIM signature
+func (s *Signer) OversignHeaders(headers ...string) {
+	if len(headers) == 0 {
+		return
+	}
+	s.oversignHeaders = headers
 }
 
+// SignHeaders sets the headers to be signed for the DKIM signature
 func (s *Signer) SignHeaders(headers ...string) {
 	if len(headers) == 0 {
 		return
 	}
 	s.signedHeaders = headers
-}
-
-func (s *Signer) AUID(auid string) {
-	s.auid = auid
 }
 
 // Validate validates the DKIM configuration for required settings
@@ -191,6 +218,7 @@ func (s *Signer) ValidateConfig() error {
 	case s.Signer == nil:
 		return ErrDKIMNoSigner
 	}
+
 	for _, h := range s.effectiveHeaders() {
 		if strings.EqualFold(h, "from") {
 			return nil
@@ -233,17 +261,19 @@ func (s *Signer) Sign(rawHeaders, body []byte) (string, error) {
 		return "", err
 	}
 
-	algo := s.algorithm
-	if algo == "" {
-		if _, ok := s.Signer.Public().(ed25519.PublicKey); ok {
-			algo = SignatureAlgoED25519
-		} else {
-			algo = SignatureAlgoRSA
+	if s.algorithm == "" {
+		switch s.Signer.Public().(type) {
+		case ed25519.PublicKey:
+			s.algorithm = SignatureAlgoED25519
+		case *rsa.PublicKey:
+			s.algorithm = SignatureAlgoRSA
+		default:
+			return "", ErrDKIMUnsupportedSigner
 		}
 	}
-	hc, bc := s.headerCanonicalization, s.bodyCanonicalization
-	if hc == "" {
-		hc = CanonicalizationRelaxed
+	headerCanon, bc := s.headerCanonicalization, s.bodyCanonicalization
+	if headerCanon == "" {
+		headerCanon = CanonicalizationRelaxed
 	}
 	if bc == "" {
 		bc = CanonicalizationRelaxed
@@ -256,14 +286,16 @@ func (s *Signer) Sign(rawHeaders, body []byte) (string, error) {
 	}
 	bh := sha256.Sum256(cb)
 
-	// Assemble the header tags as signature placeholder (empty b=)
+	// Assemble the header tags as signature placeholder
 	tags := []string{
-		"v=1", "a=" + string(algo),
-		"c=" + string(hc) + "/" + string(bc),
-		"d=" + s.Domain, "s=" + s.Selector,
-		fmt.Sprintf("t=%d", s.now().Unix()),
-		"h=" + strings.Join(s.headerListForTag(), ":"),
-		"bh=" + base64.StdEncoding.EncodeToString(bh[:]),
+		"v=1", // Version is always 1
+		"c=" + string(headerCanon) + "/" + string(bc), // The canonicalization mode used for header/body
+		"d=" + s.Domain,                                  // The signing domain
+		"s=" + s.Selector,                                // The domain selector (<selector>._domainkey)
+		"a=" + string(s.algorithm),                       // The selected signing algorithm
+		fmt.Sprintf("t=%d", s.now().Unix()),              // The timestamp of the signature
+		"h=" + strings.Join(s.headerListForTag(), ":"),   // The headers to be signed (including oversigned headers)
+		"bh=" + base64.StdEncoding.EncodeToString(bh[:]), // The empty body hash
 	}
 	if s.expiration > 0 {
 		tags = append(tags, fmt.Sprintf("x=%d", s.now().Add(s.expiration).Unix()))
@@ -282,49 +314,50 @@ func (s *Signer) Sign(rawHeaders, body []byte) (string, error) {
 	in := bytes.NewBuffer(nil)
 	for _, header := range s.headerListForTag() {
 		if line, ok := store.pop(header); ok {
-			in.Write(canonicalizeHeader(line, hc))
+			in.Write(canonicalizeHeader(line, headerCanon))
 			in.WriteString("\r\n")
 		}
 	}
 
-	// Fold the tags ONCE with an empty b=. These exact bytes are reused for the
+	// Fold the tags once with an empty b=. These exact bytes are reused for the
 	// wire, so the fold points can never diverge between what we sign and what
 	// we emit.
-	foldedTags := foldHeader(value) // value ends in "b="
+	foldedTags := foldHeader(value)
 
-	switch hc {
+	switch headerCanon {
 	case CanonicalizationSimple:
 		in.WriteString("DKIM-Signature: ")
 		in.WriteString(value) // unfolded, b= empty — matches the emitted line
 	case CanonicalizationRelaxed:
-		in.Write(canonicalizeHeader("DKIM-Signature:"+value, hc))
+		in.Write(canonicalizeHeader("DKIM-Signature:"+value, headerCanon))
 	}
 
-	// Both algorithms sign the SHA-256 digest of the canonicalized headers
-	// Ed25519-SHA256 is PureEdDSA over that hash
+	// Both algorithms sign the SHA-256 hasher of the canonicalized headers
 	//
 	// See: https://datatracker.ietf.org/doc/html/rfc6376#section-3.7
 	// and https://datatracker.ietf.org/doc/html/rfc8463#section-3
-	digest := sha256.Sum256(in.Bytes())
 	var signature []byte
 	var err error
+	hasher := sha256.Sum256(in.Bytes())
 	switch key := s.Signer.(type) {
 	case ed25519.PrivateKey:
-		signature = ed25519.Sign(key, digest[:]) // PureEdDSA over the digest
+		signature = ed25519.Sign(key, hasher[:])
 	default:
-		signature, err = key.Sign(rand.Reader, digest[:], crypto.SHA256)
+		signature, err = key.Sign(rand.Reader, hasher[:], crypto.SHA256)
 	}
 	if err != nil {
 		return "", err
 	}
 
-	sigB64 := base64.StdEncoding.EncodeToString(signature)
-	if hc == CanonicalizationSimple {
-		// Emit a single unfolded line: no byte-significant fold points for an
-		// MTA to rewrap. Must match the hash input, which also used the
-		// unfolded value.
-		return "DKIM-Signature: " + value + sigB64 + "\r\n", nil
+	// Base64 encode the signature and fold it if allowed by the canonicalization mode
+	signatureB64 := base64.StdEncoding.EncodeToString(signature)
+	if headerCanon == CanonicalizationRelaxed {
+		// Relaxed canonicalization permits folding, which is our preferred output
+		// and the default
+		return "DKIM-Signature: " + appendFoldedBase64(foldedTags, signatureB64) + "\r\n", nil
 	}
-	// relaxed: folding is unfolded away by verifiers, so wrap for readability.
-	return "DKIM-Signature: " + appendFoldedBase64(foldedTags, sigB64) + "\r\n", nil
+
+	// For simple canonicalization, we emit the unfolded value directly to avoid
+	// issues with the signature validation
+	return "DKIM-Signature: " + value + signatureB64 + "\r\n", nil
 }

--- a/internal/dkim/dkim.go
+++ b/internal/dkim/dkim.go
@@ -53,6 +53,9 @@ var (
 	// defaultHeader is the default set of headers to sign
 	defaultHeader = []string{"From", "To", "Subject", "Date", "Message-ID",
 		"Content-Type", "MIME-Version"}
+
+	// defaultCanonicalization is the default canonicalization algorithm to use
+	defaultCanonicalization = CanonicalizationRelaxed
 )
 
 var (
@@ -155,7 +158,11 @@ type Signer struct {
 	// algorithm defines the type of signature algorithm used for the DKIM signature
 	algorithm SignatureAlgo
 
-	// bodyLength keeps track of the length of the message body
+	// bodyLength specifies the length of the message body that should be signed by DKIM.
+	// It is highly discouraged to set this value as it means that only a portion of the
+	// message body would be appropriately signed, including it allows malicious actors
+	// to send phishing emails, alter content or otherwise exploit emails and still pass
+	// DKIM
 	bodyLength int64
 
 	// signedHeaders holds the list of headers that are signed by the DKIM signature
@@ -183,16 +190,37 @@ func (s *Signer) AUID(auid string) {
 
 // BodyCanonicalization sets the canonicalization mode for the message body
 func (s *Signer) BodyCanonicalization(mode Canonicalization) {
+	if mode != CanonicalizationRelaxed && mode != CanonicalizationSimple {
+		mode = defaultCanonicalization
+	}
 	s.bodyCanonicalization = mode
+}
+
+// Bodylength sets the length of the message body to be signed by DKIM (via the l= tag)
+//
+// It is highly discouraged to set this value as it means that only a portion of the
+// message body would be appropriately signed, including it allows malicious actors
+// to send phishing emails, alter content or otherwise exploit emails and still pass
+// DKIM.
+//
+// Only use this option if you are sure what you are doing
+func (s *Signer) Bodylength(length int64) {
+	s.bodyLength = length
 }
 
 // ExpiresIn sets the expiration time for the DKIM signature
 func (s *Signer) ExpiresIn(expiration time.Duration) {
+	if expiration < 0 {
+		return
+	}
 	s.expiration = expiration
 }
 
 // HeaderCanonicalization sets the canonicalization mode for the message headers
 func (s *Signer) HeaderCanonicalization(mode Canonicalization) {
+	if mode != CanonicalizationRelaxed && mode != CanonicalizationSimple {
+		mode = defaultCanonicalization
+	}
 	s.headerCanonicalization = mode
 }
 
@@ -278,8 +306,6 @@ func (s *Signer) Sign(rawHeaders, body []byte) (string, error) {
 			s.algorithm = SignatureAlgoED25519
 		case *rsa.PublicKey:
 			s.algorithm = SignatureAlgoRSA
-		default:
-			return "", ErrDKIMUnsupportedSigner
 		}
 	}
 	headerCanon, bc := s.headerCanonicalization, s.bodyCanonicalization

--- a/internal/dkim/dkim.go
+++ b/internal/dkim/dkim.go
@@ -68,38 +68,130 @@ var (
 		"Content-Type", "MIME-Version"}
 )
 
-// DKIM holds all DKIM signing parameters.
-type DKIM struct {
-	Domain    string
-	Selector  string
-	Signer    crypto.Signer
-	Algorithm SignatureAlgo
+// Signer represents a DKIM signer that holds all signing parameters
+type Signer struct {
+	// Domain represents the DKIM Signing Domain Identifier (SDID). It is
+	// d single domain name that is the mandatory payload output of DKIM
+	// and that refers to the identity claiming some responsibility for
+	// the message by signing it.
+	//
+	// Domain MUST not be empty
+	//
+	// See: https://datatracker.ietf.org/doc/html/rfc6376#section-2.5
+	Domain string
 
-	// We default to CanonicalizationRelaxed for both header and body
-	HeaderCanon Canonicalization
-	BodyCanon   Canonicalization
+	// Selector represents the DKIM domain selectors
+	//
+	// To support multiple concurrent public keys per signing domain, the
+	// key namespace is subdivided using "selectors". For example,
+	// selectors might indicate the names of office locations (e.g.,
+	// "sanfrancisco", "coolumbeach", and "reykjavik"), the signing date
+	// (e.g., "january2005", "february2005", etc.), or even an individual
+	// user.
+	//
+	// Selector MUST not be empty
+	//
+	// See: https://datatracker.ietf.org/doc/html/rfc6376#section-3.1
+	Selector string
 
-	SignedHeaders []string
-	Oversign      []string
-	Expiration    time.Duration
-	AUID          string
-	BodyLength    int64
+	// Signer is the crypto.Signer used to sign the message.
+	Signer crypto.Signer
 
-	// Now is injectable for deterministic tests, we default to time.Now
-	Now func() time.Time
+	// auid represents the DKIM Agent or User Identifier (auid)
+	// See: https://datatracker.ietf.org/doc/html/rfc6376#section-2.6
+	//
+	// A single identifier that refers to the agent or user on behalf of
+	// whom the Signing Domain Identifier (SDID) has taken responsibility.
+	// The auid comprises a domain name and an optional <local-part>.  The
+	// domain name is the same as that used for the SDID or is a subdomain
+	// of it.  For DKIM processing, the domain name portion of the auid has
+	// only basic domain name semantics; any possible owner-specific
+	// semantics are outside the scope of DKIM.
+	//
+	// auid is optional and can be empty
+	auid string
+
+	// bodyCanonicalization defines the type of Canonicalization used for the
+	// mail.Msg body.
+	//
+	// We default to CanonicalizationRelaxed for the body.
+	//
+	// See: https://datatracker.ietf.org/doc/html/rfc6376#section-3.4
+	bodyCanonicalization Canonicalization
+
+	// expiration is an optional expiration time of the signature.
+	//
+	// Signatures MAY be considered invalid if the verification time at
+	// the verifier is past the expiration date. The verification
+	// time should be the time that the message was first received at
+	// the administrative domain of the verifier if that time is
+	// reliably available; otherwise, the current time should be
+	// used.
+	//
+	// See: https://www.rfc-editor.org/rfc/rfc6376.html#section-3.5
+	expiration time.Duration
+
+	// headerCanonicalization defines the type of Canonicalization used for the
+	// mail.Msg header.
+	//
+	// We default to CanonicalizationRelaxed for the header.
+	//
+	// See: https://datatracker.ietf.org/doc/html/rfc6376#section-3.4
+	headerCanonicalization Canonicalization
+
+	algorithm       SignatureAlgo
+	bodyLength      int64
+	signedHeaders   []string
+	oversignHeaders []string
+
+	// NowFunc represents a function that is used to determine the signature's
+	// time field (t=). It can be overridden for deterministic tests.
+	NowFunc func() time.Time
+}
+
+func NewSigner(domain, selector string, signer crypto.Signer) *Signer {
+	dkimSigner := &Signer{
+		Domain:   domain,
+		Selector: selector,
+		Signer:   signer,
+	}
+	return dkimSigner
+}
+
+func (s *Signer) BodyCanonicalization(mode Canonicalization) {
+	s.bodyCanonicalization = mode
+}
+
+func (s *Signer) HeaderCanonicalization(mode Canonicalization) {
+	s.headerCanonicalization = mode
+}
+
+func (s *Signer) ExpireIn(expiration time.Duration) {
+	s.expiration = expiration
+}
+
+func (s *Signer) SignHeaders(headers ...string) {
+	if len(headers) == 0 {
+		return
+	}
+	s.signedHeaders = headers
+}
+
+func (s *Signer) AUID(auid string) {
+	s.auid = auid
 }
 
 // Validate validates the DKIM configuration for required settings
-func (d *DKIM) ValidateConfig() error {
+func (s *Signer) ValidateConfig() error {
 	switch {
-	case d.Domain == "":
+	case s.Domain == "":
 		return ErrDKIMNoDomain
-	case d.Selector == "":
+	case s.Selector == "":
 		return ErrDKIMNoSelector
-	case d.Signer == nil:
+	case s.Signer == nil:
 		return ErrDKIMNoSigner
 	}
-	for _, h := range d.effectiveHeaders() {
+	for _, h := range s.effectiveHeaders() {
 		if strings.EqualFold(h, "from") {
 			return nil
 		}
@@ -109,47 +201,47 @@ func (d *DKIM) ValidateConfig() error {
 
 // effectiveHeaders returns the list of headers to sign, defaulting to the standard set
 // if none are configured
-func (d *DKIM) effectiveHeaders() []string {
-	if len(d.SignedHeaders) == 0 {
+func (s *Signer) effectiveHeaders() []string {
+	if len(s.signedHeaders) == 0 {
 		return defaultHeader
 	}
-	return d.SignedHeaders
+	return s.signedHeaders
 }
 
 // headerListForTag returns the list of headers to sign for a given tag, including any
 // oversign headers
-func (d *DKIM) headerListForTag() []string {
-	base := d.effectiveHeaders()
-	if len(d.Oversign) == 0 {
+func (s *Signer) headerListForTag() []string {
+	base := s.effectiveHeaders()
+	if len(s.oversignHeaders) == 0 {
 		return base
 	}
-	return append(append([]string{}, base...), d.Oversign...)
+	return append(append([]string{}, base...), s.oversignHeaders...)
 }
 
 // now returns the current time, using the injected Now function if set, or
 // time.Now otherwise as default
-func (d *DKIM) now() time.Time {
-	if d.Now != nil {
-		return d.Now()
+func (s *Signer) now() time.Time {
+	if s.NowFunc != nil {
+		return s.NowFunc()
 	}
 	return time.Now()
 }
 
 // Sign returns the DKIM-Signature header line for the given raw headers and body
-func (d *DKIM) Sign(rawHeaders, body []byte) (string, error) {
-	if err := d.ValidateConfig(); err != nil {
+func (s *Signer) Sign(rawHeaders, body []byte) (string, error) {
+	if err := s.ValidateConfig(); err != nil {
 		return "", err
 	}
 
-	algo := d.Algorithm
+	algo := s.algorithm
 	if algo == "" {
-		if _, ok := d.Signer.Public().(ed25519.PublicKey); ok {
+		if _, ok := s.Signer.Public().(ed25519.PublicKey); ok {
 			algo = SignatureAlgoED25519
 		} else {
 			algo = SignatureAlgoRSA
 		}
 	}
-	hc, bc := d.HeaderCanon, d.BodyCanon
+	hc, bc := s.headerCanonicalization, s.bodyCanonicalization
 	if hc == "" {
 		hc = CanonicalizationRelaxed
 	}
@@ -159,8 +251,8 @@ func (d *DKIM) Sign(rawHeaders, body []byte) (string, error) {
 
 	// Create the body hash (bh=)
 	cb := canonicalizeBody(body, bc)
-	if d.BodyLength > 0 && int64(len(cb)) > d.BodyLength {
-		cb = cb[:d.BodyLength]
+	if s.bodyLength > 0 && int64(len(cb)) > s.bodyLength {
+		cb = cb[:s.bodyLength]
 	}
 	bh := sha256.Sum256(cb)
 
@@ -168,19 +260,19 @@ func (d *DKIM) Sign(rawHeaders, body []byte) (string, error) {
 	tags := []string{
 		"v=1", "a=" + string(algo),
 		"c=" + string(hc) + "/" + string(bc),
-		"d=" + d.Domain, "s=" + d.Selector,
-		fmt.Sprintf("t=%d", d.now().Unix()),
-		"h=" + strings.Join(d.headerListForTag(), ":"),
+		"d=" + s.Domain, "s=" + s.Selector,
+		fmt.Sprintf("t=%d", s.now().Unix()),
+		"h=" + strings.Join(s.headerListForTag(), ":"),
 		"bh=" + base64.StdEncoding.EncodeToString(bh[:]),
 	}
-	if d.Expiration > 0 {
-		tags = append(tags, fmt.Sprintf("x=%d", d.now().Add(d.Expiration).Unix()))
+	if s.expiration > 0 {
+		tags = append(tags, fmt.Sprintf("x=%d", s.now().Add(s.expiration).Unix()))
 	}
-	if d.AUID != "" {
-		tags = append(tags, "i="+d.AUID)
+	if s.auid != "" {
+		tags = append(tags, "i="+s.auid)
 	}
-	if d.BodyLength > 0 {
-		tags = append(tags, fmt.Sprintf("l=%d", d.BodyLength))
+	if s.bodyLength > 0 {
+		tags = append(tags, fmt.Sprintf("l=%d", s.bodyLength))
 	}
 	tags = append(tags, "b=")
 	value := strings.Join(tags, "; ")
@@ -188,7 +280,7 @@ func (d *DKIM) Sign(rawHeaders, body []byte) (string, error) {
 	// Parse headers and assemble the input to signature (with empty b=)
 	store := parseHeaders(rawHeaders)
 	in := bytes.NewBuffer(nil)
-	for _, header := range d.headerListForTag() {
+	for _, header := range s.headerListForTag() {
 		if line, ok := store.pop(header); ok {
 			in.Write(canonicalizeHeader(line, hc))
 			in.WriteString("\r\n")
@@ -216,7 +308,7 @@ func (d *DKIM) Sign(rawHeaders, body []byte) (string, error) {
 	digest := sha256.Sum256(in.Bytes())
 	var signature []byte
 	var err error
-	switch key := d.Signer.(type) {
+	switch key := s.Signer.(type) {
 	case ed25519.PrivateKey:
 		signature = ed25519.Sign(key, digest[:]) // PureEdDSA over the digest
 	default:

--- a/internal/dkim/dkim.go
+++ b/internal/dkim/dkim.go
@@ -65,6 +65,10 @@ var (
 	// ErrDKIMNoSigner is returned when no DKIM crypto signer is provided
 	ErrDKIMNoSigner = errors.New("a DKIM crypto signer must be provided")
 
+	// ErrDKIMInvalidSigner is returned when the provided crypto signer is not
+	// supported by DKIM
+	ErrDKIMInvalidSigner = errors.New("the provided crypto signer is not supported by DKIM")
+
 	// ErrDKIMMissingFrom is returned when the FROM header is missing
 	ErrDKIMMissingFrom = errors.New("FROM is a required DKIM header")
 
@@ -219,11 +223,18 @@ func (s *Signer) ValidateConfig() error {
 		return ErrDKIMNoSigner
 	}
 
+	switch s.Signer.(type) {
+	case ed25519.PrivateKey, *rsa.PrivateKey:
+	default:
+		return ErrDKIMInvalidSigner
+	}
+
 	for _, h := range s.effectiveHeaders() {
 		if strings.EqualFold(h, "from") {
 			return nil
 		}
 	}
+
 	return ErrDKIMMissingFrom
 }
 

--- a/internal/dkim/dkim_canonicalize.go
+++ b/internal/dkim/dkim_canonicalize.go
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: The go-mail Authors
+//
+// SPDX-License-Identifier: MIT
+
+package dkim
+
+import (
+	"bytes"
+	"strings"
+)
+
+// canonicalizeHeader canonicalizes a single header line according to the
+// specified canonicalization mode
+func canonicalizeHeader(line string, mode Canonicalization) []byte {
+	if mode == CanonicalizationSimple {
+		return []byte(line)
+	}
+	name, val, ok := strings.Cut(line, ":")
+	if !ok {
+		return []byte(collapseWSP(unfold(line)))
+	}
+	name = strings.ToLower(strings.TrimSpace(name))
+	val = strings.TrimSpace(collapseWSP(unfold(val)))
+	return []byte(name + ":" + val)
+}
+
+// unfold removes CRLF folding from a header value
+func unfold(s string) string {
+	r := strings.NewReplacer("\r\n", "", "\n", "", "\r", "")
+	return r.Replace(s)
+}
+
+// collapseWSP collapses consecutive whitespace characters into a
+// single space
+func collapseWSP(value string) string {
+	var builder strings.Builder
+	builder.Grow(len(value))
+	in := false
+	for i := 0; i < len(value); i++ {
+		if value[i] == ' ' || value[i] == '\t' {
+			in = true
+			continue
+		}
+		if in {
+			builder.WriteByte(' ')
+			in = false
+		}
+		builder.WriteByte(value[i])
+	}
+	if in {
+		builder.WriteByte(' ')
+	}
+	return builder.String()
+}
+
+// canonicalizeBody canonicalizes the body of a message according to the specified
+// canonicalization method
+func canonicalizeBody(body []byte, mode Canonicalization) []byte {
+	body = normalizeCRLF(body)
+
+	// Simple canonicalization
+	if mode == CanonicalizationSimple {
+		for bytes.HasSuffix(body, []byte("\r\n\r\n")) {
+			body = body[:len(body)-2]
+		}
+		if len(body) == 0 {
+			return []byte("\r\n")
+		}
+		if !bytes.HasSuffix(body, []byte("\r\n")) {
+			body = append(body, '\r', '\n')
+		}
+		return body
+	}
+
+	// Relaxed canonicalization
+	out := bytes.NewBuffer(nil)
+	for line := range bytes.SplitSeq(body, []byte("\r\n")) {
+		cl := bytes.TrimRight(collapseWSPBytes(line), " \t")
+		out.Write(cl)
+		out.WriteString("\r\n")
+	}
+	return trimTrailingEmptyLines(out.Bytes())
+}
+
+// normalizeCRLF normalizes CRLF line endings in the given data to "\r\n"
+func normalizeCRLF(data []byte) []byte {
+	out := bytes.NewBuffer(nil)
+	out.Grow(len(data))
+	for i := 0; i < len(data); i++ {
+		switch data[i] {
+		case '\r':
+			out.WriteString("\r\n")
+			if i+1 < len(data) && data[i+1] == '\n' {
+				i++
+			}
+		case '\n':
+			out.WriteString("\r\n")
+		default:
+			out.WriteByte(data[i])
+		}
+	}
+	return out.Bytes()
+}
+
+// trimTrailingEmptyLines removes only complete trailing CRLF pairs
+// It never touches any lone CRLFs (unlike bytes.TrimRight)
+// It will leave one CRLF for a non-empty body and "" for an empty one.
+func trimTrailingEmptyLines(data []byte) []byte {
+	for len(data) >= 4 &&
+		data[len(data)-4] == '\r' && data[len(data)-3] == '\n' &&
+		data[len(data)-2] == '\r' && data[len(data)-1] == '\n' {
+		data = data[:len(data)-2]
+	}
+	if len(data) == 2 && data[0] == '\r' && data[1] == '\n' {
+		return data[:0]
+	}
+	return data
+}
+
+// collapseWSPBytes collapses consecutive whitespace characters into a single space
+func collapseWSPBytes(data []byte) []byte {
+	out := bytes.NewBuffer(nil)
+	out.Grow(len(data))
+	in := false
+	for i := range len(data) {
+		if data[i] == ' ' || data[i] == '\t' {
+			in = true
+			continue
+		}
+		if in {
+			out.WriteByte(' ')
+			in = false
+		}
+		out.WriteByte(data[i])
+	}
+	if in {
+		out.WriteByte(' ')
+	}
+	return out.Bytes()
+}

--- a/internal/dkim/dkim_header.go
+++ b/internal/dkim/dkim_header.go
@@ -25,7 +25,7 @@ func parseHeaders(raw []byte) *headerStore {
 		if line == "" {
 			continue
 		}
-		if line[0] == ' ' || line[0] == '\t' { // continuation
+		if line[0] == ' ' || line[0] == '\t' {
 			cur.WriteString("\r\n")
 			cur.WriteString(line)
 			continue

--- a/internal/dkim/dkim_header.go
+++ b/internal/dkim/dkim_header.go
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: The go-mail Authors
+//
+// SPDX-License-Identifier: MIT
+
+package dkim
+
+import "strings"
+
+// headerStore holds parsed DKIM headers, keyed by lowercased field name.
+type headerStore struct {
+	byName map[string][]string
+}
+
+// parseHeader parses the raw header block into a headerStore
+func parseHeaders(raw []byte) *headerStore {
+	store := &headerStore{
+		byName: map[string][]string{},
+	}
+	var cur strings.Builder
+	for line := range strings.SplitSeq(string(raw), "\r\n") {
+		if line == "" {
+			continue
+		}
+		if line[0] == ' ' || line[0] == '\t' { // continuation
+			cur.WriteString("\r\n")
+			cur.WriteString(line)
+			continue
+		}
+		store.add(cur.String())
+		cur.Reset()
+		cur.WriteString(line)
+	}
+	store.add(cur.String())
+	return store
+}
+
+// add adds a parsed line to the headerStore
+func (vals *headerStore) add(line string) {
+	if line == "" {
+		return
+	}
+	if key, _, ok := strings.Cut(line, ":"); ok {
+		key = strings.ToLower(strings.TrimSpace(key))
+		vals.byName[key] = append(vals.byName[key], line)
+	}
+}
+
+// pop removes and returns the bottom-most occurrence, enabling oversigning
+// RFC 6376 signs duplicates bottom-up
+//
+// See: https://www.rfc-editor.org/info/rfc6376/#section-4.2
+func (hs *headerStore) pop(name string) (string, bool) {
+	key := strings.ToLower(name)
+	vals := hs.byName[key]
+	if len(vals) == 0 {
+		return "", false
+	}
+	last := vals[len(vals)-1]
+	hs.byName[key] = vals[:len(vals)-1]
+	return last, true
+}
+
+// foldHeader wraps the value on "; " boundaries; verifiers strip folding
+// whitespaces from b=, so any folding is safe
+func foldHeader(value string) string {
+	const limit = 76
+	var builder strings.Builder
+	length := len("DKIM-Signature: ")
+	for _, part := range strings.SplitAfter(value, "; ") {
+		if length+len(part) > limit {
+			builder.WriteString("\r\n\t")
+			length = 1
+		}
+		builder.WriteString(part)
+		length += len(part)
+	}
+	return builder.String()
+}

--- a/internal/dkim/dkim_header.go
+++ b/internal/dkim/dkim_header.go
@@ -60,19 +60,82 @@ func (hs *headerStore) pop(name string) (string, bool) {
 	return last, true
 }
 
-// foldHeader wraps the value on "; " boundaries; verifiers strip folding
-// whitespaces from b=, so any folding is safe
+// foldHeader wraps the value to stay within the ~78-char line limit
+// (RFC 5322 §2.1.1). Tags are broken at "; " boundaries; any single token that
+// is still too long (notably the b= base64 blob) is hard-wrapped mid-string.
+// Verifiers strip folding whitespace from tag values (and b= specifically)
+// before verifying, so folding anywhere is safe.
 func foldHeader(value string) string {
 	const limit = 76
 	var builder strings.Builder
 	length := len("DKIM-Signature: ")
-	for _, part := range strings.SplitAfter(value, "; ") {
-		if length+len(part) > limit {
+
+	// writeFolded writes s, inserting CRLF+HTAB whenever the current line would
+	// exceed limit, so even a single long token (b=...) gets wrapped.
+	writeFolded := func(s string) {
+		for len(s) > 0 {
+			room := limit - length
+			if room < 1 {
+				builder.WriteString("\r\n\t")
+				length = 1 // the tab counts as one column
+				room = limit - length
+			}
+			if len(s) <= room {
+				builder.WriteString(s)
+				length += len(s)
+				return
+			}
+			builder.WriteString(s[:room])
+			builder.WriteString("\r\n\t")
+			length = 1
+			s = s[room:]
+		}
+	}
+
+	for i, part := range strings.SplitAfter(value, "; ") {
+		// Start a new line before a tag if it won't fit and we're not already
+		// at the beginning of a folded line.
+		if i > 0 && length > 1 && length+len(part) > limit {
 			builder.WriteString("\r\n\t")
 			length = 1
 		}
-		builder.WriteString(part)
-		length += len(part)
+		writeFolded(part)
+	}
+	return builder.String()
+}
+
+// appendFoldedBase64 appends the base64 signature immediately after the
+// trailing "b=" of foldedTags, wrapping onto CRLF+HTAB continuation lines as
+// needed. foldedTags is emitted verbatim, so a simple-canon verifier — which
+// strips the b= value (including this folding) before hashing — reconstructs
+// exactly the bytes that were signed.
+func appendFoldedBase64(foldedTags, sig string) string {
+	const limit = 76
+	var builder strings.Builder
+	builder.WriteString(foldedTags)
+
+	// Column of the current (last) line. foldedTags has no "DKIM-Signature: "
+	// prefix, so account for it only when foldedTags is still on line one.
+	col := len("DKIM-Signature: ") + len(foldedTags)
+	if i := strings.LastIndex(foldedTags, "\r\n"); i >= 0 {
+		col = len(foldedTags) - (i + 2) // bytes after last CRLF (tab counts as 1)
+	}
+
+	for len(sig) > 0 {
+		room := limit - col
+		if room < 1 {
+			builder.WriteString("\r\n\t")
+			col = 1
+			room = limit - col
+		}
+		if len(sig) <= room {
+			builder.WriteString(sig)
+			return builder.String()
+		}
+		builder.WriteString(sig[:room])
+		builder.WriteString("\r\n\t")
+		col = 1
+		sig = sig[room:]
 	}
 	return builder.String()
 }

--- a/internal/dkim/dkim_header.go
+++ b/internal/dkim/dkim_header.go
@@ -64,6 +64,30 @@ func (hs *headerStore) pop(name string) (string, bool) {
 	return last, true
 }
 
+// writeFolded writes data to builder, inserting CRLF+SPACE whenever the current
+// line would exceed maxLineLength, so even a single long token (b=...) gets
+// wrapped. It returns the new current line's length
+func writeFolded(builder *strings.Builder, data string, length int) int {
+	for len(data) > 0 {
+		room := maxLineLength - length
+		if room < 1 {
+			builder.WriteString("\r\n ")
+			length = 1
+			room = maxLineLength - length
+		}
+		if len(data) <= room {
+			builder.WriteString(data)
+			length += len(data)
+			return length
+		}
+		builder.WriteString(data[:room])
+		builder.WriteString("\r\n ")
+		length = 1
+		data = data[room:]
+	}
+	return length
+}
+
 // foldHeader wraps the value to stay within the ~78-char line limit
 // (RFC 5322 2.1.1). Tags are broken at "; " boundaries; any single token that
 // is still too long (notably the b= base64 blob) is hard-wrapped mid-string.
@@ -75,28 +99,6 @@ func foldHeader(value string) string {
 	var builder strings.Builder
 	length := len("DKIM-Signature: ")
 
-	// writeFolded writes s, inserting CRLF+HTAB whenever the current line would
-	// exceed limit, so even a single long token (b=...) gets wrapped.
-	writeFolded := func(s string) {
-		for len(s) > 0 {
-			room := maxLineLength - length
-			if room < 1 {
-				builder.WriteString("\r\n ")
-				length = 1 // the tab counts as one column
-				room = maxLineLength - length
-			}
-			if len(s) <= room {
-				builder.WriteString(s)
-				length += len(s)
-				return
-			}
-			builder.WriteString(s[:room])
-			builder.WriteString("\r\n ")
-			length = 1
-			s = s[room:]
-		}
-	}
-
 	for i, part := range strings.SplitAfter(value, "; ") {
 		// Start a new line before a tag if it won't fit and we're not already
 		// at the beginning of a folded line.
@@ -104,7 +106,7 @@ func foldHeader(value string) string {
 			builder.WriteString("\r\n ")
 			length = 1
 		}
-		writeFolded(part)
+		length = writeFolded(&builder, part, length)
 	}
 	return builder.String()
 }

--- a/internal/dkim/dkim_header.go
+++ b/internal/dkim/dkim_header.go
@@ -6,6 +6,10 @@ package dkim
 
 import "strings"
 
+const (
+	maxLineLength = 76
+)
+
 // headerStore holds parsed DKIM headers, keyed by lowercased field name.
 type headerStore struct {
 	byName map[string][]string
@@ -61,12 +65,13 @@ func (hs *headerStore) pop(name string) (string, bool) {
 }
 
 // foldHeader wraps the value to stay within the ~78-char line limit
-// (RFC 5322 §2.1.1). Tags are broken at "; " boundaries; any single token that
+// (RFC 5322 2.1.1). Tags are broken at "; " boundaries; any single token that
 // is still too long (notably the b= base64 blob) is hard-wrapped mid-string.
 // Verifiers strip folding whitespace from tag values (and b= specifically)
 // before verifying, so folding anywhere is safe.
+//
+// See: https://www.rfc-editor.org/info/rfc5322/#section-2.1.1
 func foldHeader(value string) string {
-	const limit = 76
 	var builder strings.Builder
 	length := len("DKIM-Signature: ")
 
@@ -74,11 +79,11 @@ func foldHeader(value string) string {
 	// exceed limit, so even a single long token (b=...) gets wrapped.
 	writeFolded := func(s string) {
 		for len(s) > 0 {
-			room := limit - length
+			room := maxLineLength - length
 			if room < 1 {
-				builder.WriteString("\r\n\t")
+				builder.WriteString("\r\n ")
 				length = 1 // the tab counts as one column
-				room = limit - length
+				room = maxLineLength - length
 			}
 			if len(s) <= room {
 				builder.WriteString(s)
@@ -86,7 +91,7 @@ func foldHeader(value string) string {
 				return
 			}
 			builder.WriteString(s[:room])
-			builder.WriteString("\r\n\t")
+			builder.WriteString("\r\n ")
 			length = 1
 			s = s[room:]
 		}
@@ -95,8 +100,8 @@ func foldHeader(value string) string {
 	for i, part := range strings.SplitAfter(value, "; ") {
 		// Start a new line before a tag if it won't fit and we're not already
 		// at the beginning of a folded line.
-		if i > 0 && length > 1 && length+len(part) > limit {
-			builder.WriteString("\r\n\t")
+		if i > 0 && length > 1 && length+len(part) > maxLineLength {
+			builder.WriteString("\r\n ")
 			length = 1
 		}
 		writeFolded(part)
@@ -110,7 +115,6 @@ func foldHeader(value string) string {
 // strips the b= value (including this folding) before hashing — reconstructs
 // exactly the bytes that were signed.
 func appendFoldedBase64(foldedTags, sig string) string {
-	const limit = 76
 	var builder strings.Builder
 	builder.WriteString(foldedTags)
 
@@ -122,18 +126,18 @@ func appendFoldedBase64(foldedTags, sig string) string {
 	}
 
 	for len(sig) > 0 {
-		room := limit - col
+		room := maxLineLength - col
 		if room < 1 {
-			builder.WriteString("\r\n\t")
+			builder.WriteString("\r\n ")
 			col = 1
-			room = limit - col
+			room = maxLineLength - col
 		}
 		if len(sig) <= room {
 			builder.WriteString(sig)
 			return builder.String()
 		}
 		builder.WriteString(sig[:room])
-		builder.WriteString("\r\n\t")
+		builder.WriteString("\r\n ")
 		col = 1
 		sig = sig[room:]
 	}

--- a/internal/dkim/dkim_test.go
+++ b/internal/dkim/dkim_test.go
@@ -67,6 +67,7 @@ hcSTp1LpV7OWf4eUXzgnZQ==
 -----END PRIVATE KEY-----`)
 
 	testHeaders                           = []byte("Date: Fri, 03 Jul 2026 22:02:09 +0200\r\nMIME-Version: 1.0\r\nMessage-ID: <hCwhmZssh1Pjbj0_iSP9jx@example.com>\r\nPrecedence: bulk\r\nSubject: This is a DKIM test mail\r\nUser-Agent: go-mail v0.7.3 // https://github.com/wneessen/go-mail\r\nX-Auto-Response-Suppress: All\r\nX-Mailer: go-mail v0.7.3 // https://github.com/wneessen/go-mail\r\nFrom: \"Toni Tester\" <toni.tester@example.com>\r\nTo: \"Tina Tester\" <tina.tester@example.com>\r\nContent-Type: text/plain\r\n")
+	testHeadersLineBreak                  = []byte("Date: Fri, 03 Jul 2026 22:02:09 +0200\r\nMIME-Version: 1.0\r\nMessage-ID: <hCwhmZssh1Pjbj0_iSP9jx@example.com>\r\nPrecedence: bulk\r\nSubject: This is a DKIM test mail\r\nUser-Agent: go-mail v0.7.3 //\r\n https://github.com/wneessen/go-mail\r\nX-Auto-Response-Suppress: All\r\nX-Mailer: go-mail v0.7.3 //\r\n https://github.com/wneessen/go-mail\r\nFrom: \"Toni Tester\" <toni.tester@example.com>\r\nTo: \"Tina Tester\" <tina.tester@example.com>\r\nContent-Type: text/plain\r\n")
 	testSignatureRSARelaxedRelaxed        = "DKIM-Signature: v=1; c=relaxed/relaxed; d=example.com; s=2026a; \r\n a=rsa-sha256; t=1735689600; \r\n h=From:To:Subject:Date:Message-ID:Content-Type:MIME-Version; \r\n bh=2mAkmyqm5RGR3nEPPQFq6mUlRBUWmTYQzNyx4qVNL+4=; b=FFSkJLeSbG7bB1orMrGBRCXF\r\n laP8F5sRHa7hpy5uffrW487wOmR0SzuS81nUwTmW37WNs8OCjloiVEPCeSwkHOw8vnGawdoL9x+\r\n iRh2cKuwBmc1aUx31HPGMFynmq+eZ4BogiABxdPNxLSEzoJgcr6PyJ1u7W0ZX8fPNKMJ8fPbxXK\r\n FeQbV3iLr7HQupfOVOuGC7VJG7bW1Nf+e2hmUQlbqTnPOB5hU3sgFf3vDsEb4GfWTRmaZc1xfJG\r\n eDpWe+62K9kWsoycln0Ch+pK1pEAU/+0ricmUsYVs2FDEvLr44cjqqKReA6QzMgd6Z29sb4UoOo\r\n EsMGbcLRd3h/yKVnfA==\r\n"
 	testSignatureRSASimpleRelaxed         = "DKIM-Signature: v=1; c=simple/relaxed; d=example.com; s=2026a; a=rsa-sha256; t=1735689600; h=From:To:Subject:Date:Message-ID:Content-Type:MIME-Version; bh=2mAkmyqm5RGR3nEPPQFq6mUlRBUWmTYQzNyx4qVNL+4=; b=kc+1KwdV74Phm1/ocb3FJa8rEaI6GRq3V6/qZ13qCuhJ+DaG8UEcaajNzuTYO2axAO/EVMpuNDbX/RV5TB7rp15skNFDsyvs4pKUz48vXRBAK6pg3f1l9aisJ8XbPrVmCsreoyxM7PhgJ4oykcmDPU/YjO6sXqHnabW8GTLRNVZ0GC9JX4U5HCQjPJgVWKPqlJ2I30AHQ81CFCoAa8aeSHU6QG8l3FWvOSLwSXZMwrF8l3LFzlTgetVrAGNdI93lNTMoDSiIP0UkbBMYhM5eFlTFFrO2waScKhiYuuqNYxEu4D0HVhnFk071ZTILJqj4+ujBoPlD3CWM/K40SqDANQ==\r\n"
 	testSignatureRSARelaxedSimple         = "DKIM-Signature: v=1; c=relaxed/simple; d=example.com; s=2026a; \r\n a=rsa-sha256; t=1735689600; \r\n h=From:To:Subject:Date:Message-ID:Content-Type:MIME-Version; \r\n bh=2mAkmyqm5RGR3nEPPQFq6mUlRBUWmTYQzNyx4qVNL+4=; b=QYziNCWpxrnscm5zlBcilCrN\r\n 9O35n2EFNOt5XPI1SrW5NJ5OKg9g0HuIavGkm2Ss7khGKBKrbvdFP4K5rOyFCSV+7x73GywbBrg\r\n wkdGJhaflCl3istCQSN6mXezvIjY8Cthj238Hka49Yn3++QorcaNwjSGBVB86x/zt7cxozCbr9M\r\n wFeC7My6wVGuXl2poxdmrOmb33oNdRPWNfcoH65BRoZAtzSqwJSHRwxvwjy+n6zeRxgYjrCRtLZ\r\n 54NbX8Hx9+IcE2nLYK5zODHh8/NJ06FSQDVsmxOZaNKlT7UwzKIT1kBsLI3B21qrz7PPwDEQpb5\r\n xe/zNJNLWPeKGQXLHQ==\r\n"
@@ -76,6 +77,7 @@ hcSTp1LpV7OWf4eUXzgnZQ==
 	testSignatureEd25519RelaxedSimple     = "DKIM-Signature: v=1; c=relaxed/simple; d=example.com; s=2026a; \r\n a=ed25519-sha256; t=1735689600; \r\n h=From:To:Subject:Date:Message-ID:Content-Type:MIME-Version; \r\n bh=2mAkmyqm5RGR3nEPPQFq6mUlRBUWmTYQzNyx4qVNL+4=; b=mMdQWCsbPTLmnQFDEcm/xTbS\r\n 69OLlmwJjmVa++01Up0Vw1A9UdQncaxsynWTfvyb8HdaMX3jrxWxGqlju1lgAA==\r\n"
 	testSignatureEd25519SimpleSimple      = "DKIM-Signature: v=1; c=simple/simple; d=example.com; s=2026a; a=ed25519-sha256; t=1735689600; h=From:To:Subject:Date:Message-ID:Content-Type:MIME-Version; bh=2mAkmyqm5RGR3nEPPQFq6mUlRBUWmTYQzNyx4qVNL+4=; b=wLva31jPps/gZDbz8T93iS/aW0Xf27wOBCCMf4l8zppW4f0hI3xUzlBWybjebN8LMILMYtSz2V8/4/3D1wCuDQ==\r\n"
 	testSignatureRSARelaxedRelaxedAllOpts = "DKIM-Signature: v=1; c=relaxed/relaxed; d=example.com; s=2026a; \r\n a=rsa-sha256; t=1735689600; \r\n h=From:To:Subject:Date:Message-ID:Content-Type:MIME-Version:From:Subject; \r\n bh=nXffKnoOpS7WvIq5EyR20wBzUQYoH5gEEw3eJeAKYus=; x=1735776000; \r\n i=toni.tester@example.com; l=10; b=pCZY4uSwiPIFJqQR/8rtej8sQs2LEh39hp9ex+hx\r\n 75fcFQBA7Xth4UCOUa8mh5TRCx5NaLpWWBztD+U63PXtmyV/UJxK++OFK6olQ+oyKHIhDiM0gdk\r\n 7EUgVzCXUqELDiIyZTJ+GzuKvMR6RV3twCw/WYFziygY+x2mgkAwEs/3pg32+6FMQO4SvcEca/9\r\n AFIdFdReQOxMVDcO466v+SYf79dvk3MIvR9uECIuNBPD3/JIufgdH8EqiZbbNaXLH6ykXCCHO6y\r\n 1GXzR9mtf8EX5n03JB6Az9WDl4bauuf4Orzf+xzULqYBGi8faEM1PQcMifXAgEawiSts0n9l5y1\r\n TQ==\r\n"
+	testSignatureHeaderLineBreak          = "DKIM-Signature: v=1; c=relaxed/relaxed; d=example.com; s=2026a; \r\n a=rsa-sha256; t=1735689600; \r\n h=From:To:Subject:Date:Message-ID:Content-Type:MIME-Version; \r\n bh=2mAkmyqm5RGR3nEPPQFq6mUlRBUWmTYQzNyx4qVNL+4=; b=FFSkJLeSbG7bB1orMrGBRCXF\r\n laP8F5sRHa7hpy5uffrW487wOmR0SzuS81nUwTmW37WNs8OCjloiVEPCeSwkHOw8vnGawdoL9x+\r\n iRh2cKuwBmc1aUx31HPGMFynmq+eZ4BogiABxdPNxLSEzoJgcr6PyJ1u7W0ZX8fPNKMJ8fPbxXK\r\n FeQbV3iLr7HQupfOVOuGC7VJG7bW1Nf+e2hmUQlbqTnPOB5hU3sgFf3vDsEb4GfWTRmaZc1xfJG\r\n eDpWe+62K9kWsoycln0Ch+pK1pEAU/+0ricmUsYVs2FDEvLr44cjqqKReA6QzMgd6Z29sb4UoOo\r\n EsMGbcLRd3h/yKVnfA==\r\n"
 )
 
 func TestNewSigner(t *testing.T) {
@@ -429,6 +431,19 @@ func TestSigner_Sign(t *testing.T) {
 			}
 		})
 	}
+	t.Run("Sign with line-broken headers succeeds", func(t *testing.T) {
+		signer := testSigner(t, testKeyRSA)
+		signer.NowFunc = func() time.Time {
+			return now
+		}
+		signature, err := signer.Sign(testHeadersLineBreak, mailBuffer.Bytes())
+		if err != nil {
+			t.Errorf("failed to sign message: %s", err)
+		}
+		if !strings.EqualFold(signature, testSignatureHeaderLineBreak) {
+			t.Errorf("signature mismatch: got\n%q\nwant\n%q", signature, testSignatureHeaderLineBreak)
+		}
+	})
 	t.Run("Sign with invalid crypto.Signer fails", func(t *testing.T) {
 		privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		if err != nil {
@@ -441,6 +456,141 @@ func TestSigner_Sign(t *testing.T) {
 		_, err = signer.Sign(testHeaders, mailBuffer.Bytes())
 		if err == nil {
 			t.Errorf("expected error when signing with invalid crypto.Signer, got nil")
+		}
+	})
+}
+
+func Test_writeFolded(t *testing.T) {
+	t.Run("writefold on a normal string", func(t *testing.T) {
+		has := "first string "
+		want := "hello world"
+		wantPosition := len(has) + len(want)
+
+		builder := strings.Builder{}
+		builder.WriteString(has)
+		position := writeFolded(&builder, want, len(has))
+		if position != wantPosition {
+			t.Errorf("expected new position to be at %d bytes, got %d", wantPosition, position)
+		}
+		if builder.String() != has+want {
+			t.Errorf("expected folded string %q, got %q", has+want, builder.String())
+		}
+	})
+	t.Run("writefold folds a long string", func(t *testing.T) {
+		has := "the first part is already pretty long- and concatinating it, should fold the "
+		want := "the additional text"
+		wantPosition := len(want) + 1 // the space after the line break
+
+		builder := strings.Builder{}
+		builder.WriteString(has)
+		position := writeFolded(&builder, want, len(has))
+		if position != wantPosition {
+			t.Errorf("expected new position to be at %d bytes, got %d", wantPosition, position)
+		}
+		if builder.String() != has+"\r\n "+want {
+			t.Errorf("expected folded string %q, got %q", has+"\r\n "+want, builder.String())
+		}
+	})
+	t.Run("writefold hard-wraps a token longer than a line", func(t *testing.T) {
+		has := "start here"
+		want := strings.Repeat("x", maxLineLength+20)
+
+		builder := strings.Builder{}
+		builder.WriteString(has)
+		position := writeFolded(&builder, want, len(has))
+
+		room := maxLineLength - len(has)
+		wantOutput := has + want[:room] + "\r\n " + want[room:]
+		wantPosition := 1 + len(want) - room
+
+		if position != wantPosition {
+			t.Errorf("expected new position at %d bytes, got %d", wantPosition, position)
+		}
+		if builder.String() != wantOutput {
+			t.Errorf("expected folded string %q, got %q", wantOutput, builder.String())
+		}
+	})
+	t.Run("writefold with nil data returns the current position", func(t *testing.T) {
+		builder := strings.Builder{}
+		position := writeFolded(&builder, "", 0)
+		if position != 0 {
+			t.Errorf("expected position to be 0, got %d", position)
+		}
+	})
+}
+
+func Test_appendFoldedBase64(t *testing.T) {
+	const prefix = len("DKIM-Signature: ")
+
+	t.Run("appends short base64 without folding", func(t *testing.T) {
+		foldedTags := "v=1; a=rsa-sha256; c=relaxed/relaxed; "
+		sig := "b=shortsig"
+		want := foldedTags + sig
+
+		got := appendFoldedBase64(foldedTags, sig)
+		if got != want {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+	})
+	t.Run("folds base64 when the first line is full", func(t *testing.T) {
+		foldedTags := "v=1; a=rsa-sha256; "
+		col := prefix + len(foldedTags)
+		room := maxLineLength - col
+		sig := strings.Repeat("A", room+10)
+		want := foldedTags + sig[:room] + "\r\n " + sig[room:]
+
+		got := appendFoldedBase64(foldedTags, sig)
+		if got != want {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+	})
+	t.Run("computes column from the last CRLF in foldedTags", func(t *testing.T) {
+		foldedTags := "v=1; a=rsa-sha256;\r\n c=relaxed/relaxed; "
+		i := strings.LastIndex(foldedTags, "\r\n")
+		col := len(foldedTags) - (i + 2)
+		room := maxLineLength - col
+		sig := strings.Repeat("B", room+5)
+		want := foldedTags + sig[:room] + "\r\n " + sig[room:]
+
+		got := appendFoldedBase64(foldedTags, sig)
+		if got != want {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+	})
+	t.Run("hard wraps a long base64 across multiple lines", func(t *testing.T) {
+		foldedTags := "b="
+		col := prefix + len(foldedTags)
+		room := maxLineLength - col
+		sig := strings.Repeat("C", room+maxLineLength)
+
+		want := foldedTags + sig[:room] + "\r\n "
+		rest := sig[room:]
+		for len(rest) > maxLineLength-1 {
+			want += rest[:maxLineLength-1] + "\r\n "
+			rest = rest[maxLineLength-1:]
+		}
+		want += rest
+
+		got := appendFoldedBase64(foldedTags, sig)
+		if got != want {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+	})
+	t.Run("folds immediately when foldedTags already fills the line", func(t *testing.T) {
+		lastLine := strings.Repeat("x", maxLineLength-1)
+		foldedTags := "v=1;\r\n " + lastLine
+		sig := "b=abc"
+		want := foldedTags + "\r\n " + sig
+
+		got := appendFoldedBase64(foldedTags, sig)
+		if got != want {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+	})
+	t.Run("returns foldedTags unchanged for empty signature", func(t *testing.T) {
+		foldedTags := "v=1; a=rsa-sha256; b="
+		if got := appendFoldedBase64(foldedTags, ""); got != foldedTags {
+			t.Errorf("expected %q, got %q", foldedTags, got)
 		}
 	})
 }

--- a/internal/dkim/dkim_test.go
+++ b/internal/dkim/dkim_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The go-mail Authors
+//
+// SPDX-License-Identifier: MIT
+
 package dkim
 
 import (

--- a/internal/dkim/dkim_test.go
+++ b/internal/dkim/dkim_test.go
@@ -1,6 +1,7 @@
 package dkim
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
@@ -10,7 +11,11 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"os"
+	"slices"
+	"strings"
 	"testing"
+	"time"
 )
 
 // equaler is an interface for comparing public keys
@@ -56,14 +61,22 @@ E6IylAS2062WYGJVnSNrcfWn8uO9Z2VSNCwTpsvdTxugpe5e8kLHr2BbLypUyyau
 wJzNCYNbFNw2GX2AE4G9bjGigkRfzOzG465xsZ178EgqW05MFtdNSSSUyvNMdJtb
 hcSTp1LpV7OWf4eUXzgnZQ==
 -----END PRIVATE KEY-----`)
+
+	testHeaders                           = []byte("Date: Fri, 03 Jul 2026 22:02:09 +0200\r\nMIME-Version: 1.0\r\nMessage-ID: <hCwhmZssh1Pjbj0_iSP9jx@example.com>\r\nPrecedence: bulk\r\nSubject: This is a DKIM test mail\r\nUser-Agent: go-mail v0.7.3 // https://github.com/wneessen/go-mail\r\nX-Auto-Response-Suppress: All\r\nX-Mailer: go-mail v0.7.3 // https://github.com/wneessen/go-mail\r\nFrom: \"Toni Tester\" <toni.tester@example.com>\r\nTo: \"Tina Tester\" <tina.tester@example.com>\r\nContent-Type: text/plain\r\n")
+	testSignatureRSARelaxedRelaxed        = "DKIM-Signature: v=1; c=relaxed/relaxed; d=example.com; s=2026a; \r\n a=rsa-sha256; t=1735689600; \r\n h=From:To:Subject:Date:Message-ID:Content-Type:MIME-Version; \r\n bh=2mAkmyqm5RGR3nEPPQFq6mUlRBUWmTYQzNyx4qVNL+4=; b=FFSkJLeSbG7bB1orMrGBRCXF\r\n laP8F5sRHa7hpy5uffrW487wOmR0SzuS81nUwTmW37WNs8OCjloiVEPCeSwkHOw8vnGawdoL9x+\r\n iRh2cKuwBmc1aUx31HPGMFynmq+eZ4BogiABxdPNxLSEzoJgcr6PyJ1u7W0ZX8fPNKMJ8fPbxXK\r\n FeQbV3iLr7HQupfOVOuGC7VJG7bW1Nf+e2hmUQlbqTnPOB5hU3sgFf3vDsEb4GfWTRmaZc1xfJG\r\n eDpWe+62K9kWsoycln0Ch+pK1pEAU/+0ricmUsYVs2FDEvLr44cjqqKReA6QzMgd6Z29sb4UoOo\r\n EsMGbcLRd3h/yKVnfA==\r\n"
+	testSignatureRSASimpleRelaxed         = "DKIM-Signature: v=1; c=simple/relaxed; d=example.com; s=2026a; a=rsa-sha256; t=1735689600; h=From:To:Subject:Date:Message-ID:Content-Type:MIME-Version; bh=2mAkmyqm5RGR3nEPPQFq6mUlRBUWmTYQzNyx4qVNL+4=; b=kc+1KwdV74Phm1/ocb3FJa8rEaI6GRq3V6/qZ13qCuhJ+DaG8UEcaajNzuTYO2axAO/EVMpuNDbX/RV5TB7rp15skNFDsyvs4pKUz48vXRBAK6pg3f1l9aisJ8XbPrVmCsreoyxM7PhgJ4oykcmDPU/YjO6sXqHnabW8GTLRNVZ0GC9JX4U5HCQjPJgVWKPqlJ2I30AHQ81CFCoAa8aeSHU6QG8l3FWvOSLwSXZMwrF8l3LFzlTgetVrAGNdI93lNTMoDSiIP0UkbBMYhM5eFlTFFrO2waScKhiYuuqNYxEu4D0HVhnFk071ZTILJqj4+ujBoPlD3CWM/K40SqDANQ==\r\n"
+	testSignatureRSARelaxedSimple         = "DKIM-Signature: v=1; c=relaxed/simple; d=example.com; s=2026a; \r\n a=rsa-sha256; t=1735689600; \r\n h=From:To:Subject:Date:Message-ID:Content-Type:MIME-Version; \r\n bh=2mAkmyqm5RGR3nEPPQFq6mUlRBUWmTYQzNyx4qVNL+4=; b=QYziNCWpxrnscm5zlBcilCrN\r\n 9O35n2EFNOt5XPI1SrW5NJ5OKg9g0HuIavGkm2Ss7khGKBKrbvdFP4K5rOyFCSV+7x73GywbBrg\r\n wkdGJhaflCl3istCQSN6mXezvIjY8Cthj238Hka49Yn3++QorcaNwjSGBVB86x/zt7cxozCbr9M\r\n wFeC7My6wVGuXl2poxdmrOmb33oNdRPWNfcoH65BRoZAtzSqwJSHRwxvwjy+n6zeRxgYjrCRtLZ\r\n 54NbX8Hx9+IcE2nLYK5zODHh8/NJ06FSQDVsmxOZaNKlT7UwzKIT1kBsLI3B21qrz7PPwDEQpb5\r\n xe/zNJNLWPeKGQXLHQ==\r\n"
+	testSignatureRSASimpleSimple          = "DKIM-Signature: v=1; c=simple/simple; d=example.com; s=2026a; a=rsa-sha256; t=1735689600; h=From:To:Subject:Date:Message-ID:Content-Type:MIME-Version; bh=2mAkmyqm5RGR3nEPPQFq6mUlRBUWmTYQzNyx4qVNL+4=; b=prudIg0nHjZJCwrVi4PCCOKkZpD5vIX4tFS7MNOcOp6IB2WOZx76luotJ5fMSNl54Hkr+dOv2/0V19FdgEc741GC2aHl+g/6vXGlF++ecksmq0a9Gb5mkxuqmZi8bqF4ef7lCEgiw9TST7/9AICVGJ2zXKk5/4ZoFZv+/MNklCj9sr1Ua3lWupMHJ4Szlp4SbCUWNdBQF3KfvvtIhTCgr1BftSuYUxDU4x5QLWIZkzm29crorMxQFyvsXTE/5KpoAHdhbPr6Vgtztdz0vAEabv+ruggeWFM/c6E8zpXmRt1gVr7WjiwuwfeMOtpXbvwgvCUNt2Ifc2E7jn3+9XcOJQ==\r\n"
+	testSignatureEd25519RelaxedRelaxed    = "DKIM-Signature: v=1; c=relaxed/relaxed; d=example.com; s=2026a; \r\n a=ed25519-sha256; t=1735689600; \r\n h=From:To:Subject:Date:Message-ID:Content-Type:MIME-Version; \r\n bh=2mAkmyqm5RGR3nEPPQFq6mUlRBUWmTYQzNyx4qVNL+4=; b=B8QM+ik8Bw/2aLaxpNx1CdyO\r\n L9Dwr2afhXJbD2sqHrdSOHYSZquAH8tFLbwtgAywqGqIVKRDWSknSSvNpWLKAg==\r\n"
+	testSignatureEd25519SimpleRelaxed     = "DKIM-Signature: v=1; c=simple/relaxed; d=example.com; s=2026a; a=ed25519-sha256; t=1735689600; h=From:To:Subject:Date:Message-ID:Content-Type:MIME-Version; bh=2mAkmyqm5RGR3nEPPQFq6mUlRBUWmTYQzNyx4qVNL+4=; b=x94WyMS99YlHYqtMirhl8HLaHPIFbodhDudhIYqUEZPU3i5jyiubOURPkPIiZOm42yvVVAnfy39UJwEf7OmCDQ==\r\n"
+	testSignatureEd25519RelaxedSimple     = "DKIM-Signature: v=1; c=relaxed/simple; d=example.com; s=2026a; \r\n a=ed25519-sha256; t=1735689600; \r\n h=From:To:Subject:Date:Message-ID:Content-Type:MIME-Version; \r\n bh=2mAkmyqm5RGR3nEPPQFq6mUlRBUWmTYQzNyx4qVNL+4=; b=mMdQWCsbPTLmnQFDEcm/xTbS\r\n 69OLlmwJjmVa++01Up0Vw1A9UdQncaxsynWTfvyb8HdaMX3jrxWxGqlju1lgAA==\r\n"
+	testSignatureEd25519SimpleSimple      = "DKIM-Signature: v=1; c=simple/simple; d=example.com; s=2026a; a=ed25519-sha256; t=1735689600; h=From:To:Subject:Date:Message-ID:Content-Type:MIME-Version; bh=2mAkmyqm5RGR3nEPPQFq6mUlRBUWmTYQzNyx4qVNL+4=; b=wLva31jPps/gZDbz8T93iS/aW0Xf27wOBCCMf4l8zppW4f0hI3xUzlBWybjebN8LMILMYtSz2V8/4/3D1wCuDQ==\r\n"
+	testSignatureRSARelaxedRelaxedAllOpts = "DKIM-Signature: v=1; c=relaxed/relaxed; d=example.com; s=2026a; \r\n a=rsa-sha256; t=1735689600; \r\n h=From:To:Subject:Date:Message-ID:Content-Type:MIME-Version:From:Subject; \r\n bh=nXffKnoOpS7WvIq5EyR20wBzUQYoH5gEEw3eJeAKYus=; x=1735776000; \r\n i=toni.tester@example.com; l=10; b=pCZY4uSwiPIFJqQR/8rtej8sQs2LEh39hp9ex+hx\r\n 75fcFQBA7Xth4UCOUa8mh5TRCx5NaLpWWBztD+U63PXtmyV/UJxK++OFK6olQ+oyKHIhDiM0gdk\r\n 7EUgVzCXUqELDiIyZTJ+GzuKvMR6RV3twCw/WYFziygY+x2mgkAwEs/3pg32+6FMQO4SvcEca/9\r\n AFIdFdReQOxMVDcO466v+SYf79dvk3MIvR9uECIuNBPD3/JIufgdH8EqiZbbNaXLH6ykXCCHO6y\r\n 1GXzR9mtf8EX5n03JB6Az9WDl4bauuf4Orzf+xzULqYBGi8faEM1PQcMifXAgEawiSts0n9l5y1\r\n TQ==\r\n"
 )
 
 func TestNewSigner(t *testing.T) {
 	t.Run("a signer is successfully returned", func(t *testing.T) {
-		signer := NewSigner(testDomain, testSelector, nil)
-		if signer == nil {
-			t.Fatal("a nil signer was returned")
-		}
+		signer := testSigner(t, testKeyRSA)
 		if signer.Domain != testDomain {
 			t.Errorf("failed to create DKIM signer, expected domain: %s, got: %s", testDomain, signer.Domain)
 		}
@@ -83,10 +96,7 @@ func TestNewSigner(t *testing.T) {
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
 				privKey := pemToCryptoSigner(t, test.keyData)
-				signer := NewSigner(testDomain, testSelector, privKey)
-				if signer == nil {
-					t.Fatal("a nil signer was returned")
-				}
+				signer := testSigner(t, test.keyData)
 				if signer.Domain != testDomain {
 					t.Errorf("failed to create DKIM signer, expected domain: %s, got: %s", testDomain, signer.Domain)
 				}
@@ -113,15 +123,45 @@ func TestSigner_ValidateConfig(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				privKey := pemToCryptoSigner(t, test.keyData)
-				signer := NewSigner(testDomain, testSelector, privKey)
-				if signer == nil {
-					t.Fatal("a nil signer was returned")
-				}
+				signer := testSigner(t, test.keyData)
 				if err := signer.ValidateConfig(); err != nil {
 					t.Errorf("failed to validate signer config: %s", err)
 				}
 			})
+		}
+	})
+	t.Run("signer config is missing domain", func(t *testing.T) {
+		signer := NewSigner("", testSelector, nil)
+		if signer == nil {
+			t.Fatal("a nil signer was returned")
+		}
+		if err := signer.ValidateConfig(); err == nil {
+			t.Errorf("expected signer config validation to fail with no domain, but got nil")
+		}
+	})
+	t.Run("signer config is missing selector", func(t *testing.T) {
+		signer := NewSigner(testDomain, "", nil)
+		if signer == nil {
+			t.Fatal("a nil signer was returned")
+		}
+		if err := signer.ValidateConfig(); err == nil {
+			t.Errorf("expected signer config validation to fail with no selector, but got nil")
+		}
+	})
+	t.Run("signer config is missing the crypto.Signer", func(t *testing.T) {
+		signer := NewSigner(testDomain, testSelector, nil)
+		if signer == nil {
+			t.Fatal("a nil signer was returned")
+		}
+		if err := signer.ValidateConfig(); err == nil {
+			t.Errorf("expected signer config validation to fail with no signer, but got nil")
+		}
+	})
+	t.Run("signer config is missing the FROM in the headers list", func(t *testing.T) {
+		signer := testSigner(t, testKeyRSA)
+		signer.SignHeaders("Subject", "To")
+		if err := signer.ValidateConfig(); err == nil {
+			t.Errorf("expected signer config validation to fail with no signer, but got nil")
 		}
 	})
 	t.Run("signer config with ecDSA private key fails", func(t *testing.T) {
@@ -143,8 +183,278 @@ func TestSigner_ValidateConfig(t *testing.T) {
 	})
 }
 
+func TestSigner_AUID(t *testing.T) {
+	want := "AUID"
+	signer := testSigner(t, testKeyRSA)
+	signer.AUID(want)
+	if signer.auid != want {
+		t.Errorf("expected AUID to be %s, got %s", want, signer.auid)
+	}
+}
+
+func TestSigner_BodyCanonicalization(t *testing.T) {
+	tests := []struct {
+		name string
+		mode Canonicalization
+		want Canonicalization
+	}{
+		{"relaxed", CanonicalizationRelaxed, CanonicalizationRelaxed},
+		{"simple", CanonicalizationSimple, CanonicalizationSimple},
+		{"invalid", "invalid", CanonicalizationRelaxed},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			signer := testSigner(t, testKeyRSA)
+			signer.BodyCanonicalization(test.mode)
+			if signer.bodyCanonicalization != test.want {
+				t.Errorf("expected body canonicalization to be %s, got %s", test.want, signer.bodyCanonicalization)
+			}
+		})
+	}
+}
+
+func TestSigner_HeaderCanonicalization(t *testing.T) {
+	tests := []struct {
+		name string
+		mode Canonicalization
+		want Canonicalization
+	}{
+		{"relaxed", CanonicalizationRelaxed, CanonicalizationRelaxed},
+		{"simple", CanonicalizationSimple, CanonicalizationSimple},
+		{"invalid", "invalid", CanonicalizationRelaxed},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			signer := testSigner(t, testKeyRSA)
+			signer.HeaderCanonicalization(test.mode)
+			if signer.headerCanonicalization != test.want {
+				t.Errorf("expected header canonicalization to be %s, got %s", test.want, signer.headerCanonicalization)
+			}
+		})
+	}
+}
+
+func TestSigner_ExpiresIn(t *testing.T) {
+	tests := []struct {
+		name       string
+		expiration time.Duration
+		want       time.Duration
+	}{
+		{"valid", 3600, 3600},
+		{"negative", -1, 0},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			signer := testSigner(t, testKeyRSA)
+			signer.ExpiresIn(test.expiration)
+			if signer.expiration != test.want {
+				t.Errorf("expected expiration to be %s, got %s", test.want, signer.expiration)
+			}
+		})
+	}
+}
+
+func TestSigner_OversignHeaders(t *testing.T) {
+	t.Run("valid oversign headers", func(t *testing.T) {
+		signer := testSigner(t, testKeyRSA)
+		signer.OversignHeaders("From", "To", "Subject")
+		if len(signer.oversignHeaders) != 3 {
+			t.Errorf("expected 3 oversign headers, got %d", len(signer.oversignHeaders))
+		}
+		for _, header := range signer.oversignHeaders {
+			if header != "From" && header != "To" && header != "Subject" {
+				t.Errorf("expected oversign header to be one of From, To, Subject, got %s", header)
+			}
+		}
+	})
+	t.Run("empty oversign header list", func(t *testing.T) {
+		signer := testSigner(t, testKeyRSA)
+		signer.OversignHeaders()
+		if len(signer.oversignHeaders) != 0 {
+			t.Errorf("expected 0 oversign headers, got %d", len(signer.oversignHeaders))
+		}
+	})
+}
+
+func TestSigner_SignHeaders(t *testing.T) {
+	t.Run("valid sign headers", func(t *testing.T) {
+		signer := testSigner(t, testKeyRSA)
+		signer.SignHeaders("From", "To", "Subject")
+		if len(signer.signedHeaders) != 3 {
+			t.Errorf("expected 3 sign headers, got %d", len(signer.signedHeaders))
+		}
+		for _, header := range signer.signedHeaders {
+			if header != "From" && header != "To" && header != "Subject" {
+				t.Errorf("expected sign header to be one of From, To, Subject, got %s", header)
+			}
+		}
+	})
+	t.Run("empty sign header list", func(t *testing.T) {
+		signer := testSigner(t, testKeyRSA)
+		signer.SignHeaders()
+		if len(signer.signedHeaders) != 0 {
+			t.Errorf("expected 0 sign headers, got %d", len(signer.signedHeaders))
+		}
+	})
+}
+
+func TestSigner_headerListForTag(t *testing.T) {
+	t.Run("sign headers only", func(t *testing.T) {
+		signer := testSigner(t, testKeyRSA)
+		headers := signer.headerListForTag()
+		for _, header := range defaultHeader {
+			if !slices.Contains(headers, header) {
+				t.Errorf("expected default header %q to be part of the tags, but didn't find it", header)
+			}
+		}
+	})
+	t.Run("sign headers and oversign headers", func(t *testing.T) {
+		signer := testSigner(t, testKeyRSA)
+		signer.OversignHeaders("Cc", "From", "Subject")
+		headers := signer.headerListForTag()
+		for _, header := range append(defaultHeader, "Cc", "From", "Subject") {
+			if !slices.Contains(headers, header) {
+				t.Errorf("expected default header %q to be part of the tags, but didn't find it", header)
+			}
+		}
+		headerCount := make(map[string]int)
+		for _, header := range headers {
+			headerCount[header]++
+		}
+		for _, val := range []string{"From", "Subject"} {
+			count, ok := headerCount[val]
+			if !ok {
+				t.Fatalf("expected header %q to be in the header tags list", val)
+			}
+			if count != 2 {
+				t.Errorf("expected oversign header %q to be in the header tag list twice, got: %d", val, count)
+			}
+		}
+	})
+}
+
+func TestSigner_now(t *testing.T) {
+	t.Run("now with no value set returns time.Now", func(t *testing.T) {
+		signer := testSigner(t, testKeyRSA)
+		now := signer.now()
+		if now.IsZero() {
+			t.Errorf("expected now to be set, got zero value")
+		}
+	})
+	t.Run("nowfunc is set", func(t *testing.T) {
+		want := time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC)
+		signer := testSigner(t, testKeyRSA)
+		signer.NowFunc = func() time.Time {
+			return want
+		}
+		now := signer.now()
+		if !now.Equal(want) {
+			t.Errorf("expected now to be %s, got %s", want, now)
+		}
+	})
+}
+
+func TestSigner_Sign(t *testing.T) {
+	mail, err := os.Open("../../testdata/RFC5322-A1-1.eml")
+	if err != nil {
+		t.Fatalf("failed to open test mail: %s", err)
+	}
+	mailBuffer := bytes.NewBuffer(nil)
+	if _, err := mailBuffer.ReadFrom(mail); err != nil {
+		t.Fatalf("failed reading test mail into memory: %s", err)
+	}
+	if err := mail.Close(); err != nil {
+		t.Errorf("failed to close test mail: %s", err)
+	}
+	now := time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name          string
+		privkKey      []byte
+		headerCanon   Canonicalization
+		bodyCanon     Canonicalization
+		changeFunc    func(*Signer)
+		wantSignature string
+	}{
+		{"RSA relaxed/relaxed", testKeyRSA, CanonicalizationRelaxed, CanonicalizationRelaxed, nil, testSignatureRSARelaxedRelaxed},
+		{"RSA simple/relaxed", testKeyRSA, CanonicalizationSimple, CanonicalizationRelaxed, nil, testSignatureRSASimpleRelaxed},
+		{"RSA relaxed/simple", testKeyRSA, CanonicalizationRelaxed, CanonicalizationSimple, nil, testSignatureRSARelaxedSimple},
+		{"RSA simple/simple", testKeyRSA, CanonicalizationSimple, CanonicalizationSimple, nil, testSignatureRSASimpleSimple},
+		{"Ed25519 relaxed/relaxed", testKeyEd25519, CanonicalizationRelaxed, CanonicalizationRelaxed, nil, testSignatureEd25519RelaxedRelaxed},
+		{"Ed25519 simple/relaxed", testKeyEd25519, CanonicalizationSimple, CanonicalizationRelaxed, nil, testSignatureEd25519SimpleRelaxed},
+		{"Ed25519 relaxed/simple", testKeyEd25519, CanonicalizationRelaxed, CanonicalizationSimple, nil, testSignatureEd25519RelaxedSimple},
+		{"Ed25519 simple/simple", testKeyEd25519, CanonicalizationSimple, CanonicalizationSimple, nil, testSignatureEd25519SimpleSimple},
+		{
+			"RSA relaxed/relaxed with all options", testKeyRSA, CanonicalizationRelaxed, CanonicalizationRelaxed,
+			func(s *Signer) {
+				s.ExpiresIn(time.Hour * 24)
+				s.AUID("toni.tester@example.com")
+				s.OversignHeaders("From", "Subject")
+				s.Bodylength(10)
+			},
+			testSignatureRSARelaxedRelaxedAllOpts,
+		},
+		{
+			"RSA with default canonicalization", testKeyRSA, CanonicalizationRelaxed, CanonicalizationRelaxed,
+			func(s *Signer) {
+				s.headerCanonicalization = ""
+				s.bodyCanonicalization = ""
+			},
+			testSignatureRSARelaxedRelaxed,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			signer := testSigner(t, test.privkKey)
+			signer.NowFunc = func() time.Time {
+				return now
+			}
+			signer.HeaderCanonicalization(test.headerCanon)
+			signer.BodyCanonicalization(test.bodyCanon)
+
+			if test.changeFunc != nil {
+				test.changeFunc(signer)
+			}
+
+			signature, err := signer.Sign(testHeaders, mailBuffer.Bytes())
+			if err != nil {
+				t.Errorf("failed to sign mail: %s", err)
+			}
+			if !strings.EqualFold(signature, test.wantSignature) {
+				t.Errorf("signature mismatch: got\n%q\nwant\n%q", signature, test.wantSignature)
+			}
+		})
+	}
+	t.Run("Sign with invalid crypto.Signer fails", func(t *testing.T) {
+		privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("failed to generate ecDSA private key: %s", err)
+		}
+		signer := NewSigner(testDomain, testSelector, privKey)
+		if signer == nil {
+			t.Fatal("a nil signer was returned")
+		}
+		_, err = signer.Sign(testHeaders, mailBuffer.Bytes())
+		if err == nil {
+			t.Errorf("expected error when signing with invalid crypto.Signer, got nil")
+		}
+	})
+}
+
+func testSigner(t *testing.T, keyData []byte) *Signer {
+	t.Helper()
+
+	privKey := pemToCryptoSigner(t, keyData)
+	signer := NewSigner(testDomain, testSelector, privKey)
+	if signer == nil {
+		t.Fatal("a nil signer was returned")
+	}
+	return signer
+}
+
 func pemToCryptoSigner(t *testing.T, keyBytes []byte) crypto.Signer {
 	t.Helper()
+
 	block, _ := pem.Decode(keyBytes)
 	if block == nil {
 		t.Fatalf("no valid PEM data found")

--- a/internal/dkim/dkim_test.go
+++ b/internal/dkim/dkim_test.go
@@ -1,0 +1,164 @@
+package dkim
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"testing"
+)
+
+// equaler is an interface for comparing public keys
+type equaler interface {
+	Equal(crypto.PublicKey) bool
+}
+
+const (
+	testDomain   = "example.com"
+	testSelector = "2026a"
+)
+
+var (
+	testKeyEd25519 = []byte(`-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIPEZCuuDQ2PIH1RDbMl92DIb8Vsqz2j7B26aHomVq1pU
+-----END PRIVATE KEY-----`)
+
+	testKeyRSA = []byte(`-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCqUtV4PV2kTmkW
+ti9PxJ0atHVu7Jf5zMNMHNy+prWCqSqDlz8Tz6weRiuP7+a7vGliCQHr02etzz0r
+lPJ+tTXw/18/B49+1BWu3ves2d7N67IIziRIOXkxdSjcfgDqzXrUmtnhMp8nVn1V
+YPavr2J1OSuA5sBz3C5GFddurFeR5a3C1BEsqEU0BJtbwX2dreNWGvznK2WgP+nR
+1K78uoAsVsviUEqaYvo8Ipvq7+oP2JQqjj7AKZ6JNaOSl9vc0MY89bveSW7NksyJ
+W2YNAuGxhkbPzjYu/8UwPv7vS/zTZjzZ55d5MDVwafqVWNOqxmqLPKO4D2x6HaQ6
+WVnmkcq7AgMBAAECggEABT0IoFWW1Vbgbliw1NH+h+kZRtqGlSHu+1ploR5GnCAO
+jHJoPDQd0ZF62sbxqy8VUkGqVNP1hFSvJU9/q0S1Ciu0QHTqXyOFUxGzWNqB5YZM
+8H+n59Bb6CnvRFsxeY/LB+NC8Vy7xxtiggl+gzT0uqArif29yCWmfo5Tv4bx4vFL
+bv04dm5JIcWpsmBuXVQcjRI1axmwbBATvMagQ/iwEB5OHxG0Z5Xf/c6ivEDeVkVX
++CIDyMmj2wcqz0Ao98x1IOUtN1c6HTD1FaeLJHFg2l2aj6RBwcTFWfEpjHIQz3Ul
+oe7FJxwi9RefoX/KNGmv46zc0Jssx3ZuPg0KjH00eQKBgQDLu9osJc+MfLw2vKlF
+nwb+V8gf7cYZqw6fFLhbpugKe/Y/8lbvgmBUp19wEcGeD770MtY8NWVqEzqSOYkg
+JQF9sxjOIotqad0ZAwYohVM9hHIcaMCgDfRPFYrrz5s6mSE/PIAr1bnAFO0LLChj
+pcCHPi+dNzvpkPEODBCBui8PAwKBgQDWBMa6w9GXu7l2i64clU6EWgPrymKXxBq2
+2m218r3B5ZJiKet+hHF3wC2w6kv0TAGdi3fj6FizVRqofQrlMgIydT2YvOjTByaJ
+nXYupGvE6KLGQGgfIf1Tv0k+8cv04AlJLI2xnijPc+A2vDpnJU0B5tzcfS2ctsSa
+7dFY/AgL6QKBgH/0Eyn29Ur+bBbUllsrbXEAIKgs5WXpkN1IXiDxynoLMLUotoDm
+GSoRlFcGT9u9d+hWpUZbIr5kJT0A9aZCl5UijkmoWHcU1c+Hnq6ETastK528DH55
+RR8GIKHJWWyMD91vWfAt4uNIQTfrG9K5nxlRbQYIUpB2f26bFSLkk/mRAoGAZtI4
+n/YANkPMYLXO2pCo/lE43QmIwJ1IsFzUpLuQix0+bMbzCv+afAvqZ7rI7v+tLwGY
+gfhY1R+oBRa+K0sRXyiQhVcNDIW88BSkeNgpppqVyWWcIIj16kxWZlVIxcb07yDm
+mlUAClsDd4iLDo8PJkDCD3Rce5QbdMuY7oV3YDECgYA/nf2B5Qo2im4w9GiCMYIr
+E6IylAS2062WYGJVnSNrcfWn8uO9Z2VSNCwTpsvdTxugpe5e8kLHr2BbLypUyyau
+wJzNCYNbFNw2GX2AE4G9bjGigkRfzOzG465xsZ178EgqW05MFtdNSSSUyvNMdJtb
+hcSTp1LpV7OWf4eUXzgnZQ==
+-----END PRIVATE KEY-----`)
+)
+
+func TestNewSigner(t *testing.T) {
+	t.Run("a signer is successfully returned", func(t *testing.T) {
+		signer := NewSigner(testDomain, testSelector, nil)
+		if signer == nil {
+			t.Fatal("a nil signer was returned")
+		}
+		if signer.Domain != testDomain {
+			t.Errorf("failed to create DKIM signer, expected domain: %s, got: %s", testDomain, signer.Domain)
+		}
+		if signer.Selector != testSelector {
+			t.Errorf("failed to create DKIM signer, expected selector: %s, got: %s", testSelector, signer.Selector)
+		}
+	})
+	t.Run("signer with different crypto.Signers", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			keyData []byte
+		}{
+			{"RSA", testKeyRSA},
+			{"Ed25519", testKeyEd25519},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				privKey := pemToCryptoSigner(t, test.keyData)
+				signer := NewSigner(testDomain, testSelector, privKey)
+				if signer == nil {
+					t.Fatal("a nil signer was returned")
+				}
+				if signer.Domain != testDomain {
+					t.Errorf("failed to create DKIM signer, expected domain: %s, got: %s", testDomain, signer.Domain)
+				}
+				if signer.Selector != testSelector {
+					t.Errorf("failed to create DKIM signer, expected selector: %s, got: %s", testSelector, signer.Selector)
+				}
+				if !privKey.Public().(equaler).Equal(signer.Signer.Public()) {
+					t.Errorf("failed to create DKIM signer, expected signer: %v, got: %v", privKey.Public(), signer.Signer.Public())
+				}
+			})
+		}
+	})
+}
+
+func TestSigner_ValidateConfig(t *testing.T) {
+	t.Run("valid signer config succeeds", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			keyData []byte
+		}{
+			{"RSA", testKeyRSA},
+			{"Ed25519", testKeyEd25519},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				privKey := pemToCryptoSigner(t, test.keyData)
+				signer := NewSigner(testDomain, testSelector, privKey)
+				if signer == nil {
+					t.Fatal("a nil signer was returned")
+				}
+				if err := signer.ValidateConfig(); err != nil {
+					t.Errorf("failed to validate signer config: %s", err)
+				}
+			})
+		}
+	})
+	t.Run("signer config with ecDSA private key fails", func(t *testing.T) {
+		privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("failed to generate ecDSA private key: %s", err)
+		}
+		signer := NewSigner(testDomain, testSelector, privKey)
+		if signer == nil {
+			t.Fatal("a nil signer was returned")
+		}
+		err = signer.ValidateConfig()
+		if err == nil {
+			t.Errorf("expected an error, got nil")
+		}
+		if !errors.Is(err, ErrDKIMInvalidSigner) {
+			t.Errorf("expected ErrDKIMInvalidSigner, got %s", err)
+		}
+	})
+}
+
+func pemToCryptoSigner(t *testing.T, keyBytes []byte) crypto.Signer {
+	t.Helper()
+	block, _ := pem.Decode(keyBytes)
+	if block == nil {
+		t.Fatalf("no valid PEM data found")
+	}
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse PKCS8 private key: %s", err)
+	}
+	switch key := key.(type) {
+	case *rsa.PrivateKey:
+		return key
+	case ed25519.PrivateKey:
+		return key
+	}
+	t.Fatalf("invalid key type: %T", key)
+	return nil
+}

--- a/internal/dkim/dkim_test.go
+++ b/internal/dkim/dkim_test.go
@@ -595,6 +595,7 @@ func Test_appendFoldedBase64(t *testing.T) {
 	})
 }
 
+// testSigner returns a Signer for testing purposes.
 func testSigner(t *testing.T, keyData []byte) *Signer {
 	t.Helper()
 
@@ -606,6 +607,7 @@ func testSigner(t *testing.T, keyData []byte) *Signer {
 	return signer
 }
 
+// pemToCryptoSigner converts a PEM-encoded private key to a crypto.Signer.
 func pemToCryptoSigner(t *testing.T, keyBytes []byte) crypto.Signer {
 	t.Helper()
 

--- a/internal/dkim/dkim_test.go
+++ b/internal/dkim/dkim_test.go
@@ -595,6 +595,113 @@ func Test_appendFoldedBase64(t *testing.T) {
 	})
 }
 
+func Test_canonicalizeHeader(t *testing.T) {
+	t.Run("relaxed header canonicalization", func(t *testing.T) {
+		want := []byte(`from:"Toni Tester" <toni.tester@example.com>`)
+		header := `From: "Toni Tester" <toni.tester@example.com>`
+		data := canonicalizeHeader(header, CanonicalizationRelaxed)
+		if !bytes.Equal(data, want) {
+			t.Errorf("expected canonicalized header to be %q, got %q", want, data)
+		}
+	})
+	t.Run("simple header canonicalization", func(t *testing.T) {
+		want := []byte(`From: "Toni Tester" <toni.tester@example.com>`)
+		header := `From: "Toni Tester" <toni.tester@example.com>`
+		data := canonicalizeHeader(header, CanonicalizationSimple)
+		if !bytes.Equal(data, want) {
+			t.Errorf("expected canonicalized header to be %q, got %q", want, data)
+		}
+	})
+	t.Run("relaxed header canonicalization without colon", func(t *testing.T) {
+		header := `From  "Toni Tester" <toni.tester@example.com>`
+		want := []byte(`From "Toni Tester" <toni.tester@example.com>`)
+		data := canonicalizeHeader(header, CanonicalizationRelaxed)
+		if !bytes.Equal(data, want) {
+			t.Errorf("expected canonicalized header to be %q, got %q", want, data)
+		}
+	})
+	t.Run("relaxed header canonicalization without colon and with trailing whitespace", func(t *testing.T) {
+		header := `From  "Toni Tester" <toni.tester@example.com> `
+		want := []byte(`From "Toni Tester" <toni.tester@example.com> `)
+		data := canonicalizeHeader(header, CanonicalizationRelaxed)
+		if !bytes.Equal(data, want) {
+			t.Errorf("expected canonicalized header to be %q, got %q", want, data)
+		}
+	})
+}
+
+func Test_canonicalizeBody(t *testing.T) {
+	t.Run("relaxed body canonicalization", func(t *testing.T) {
+		body := []byte(`This is just some body text`)
+		want := append(body, []byte("\r\n")...)
+		data := canonicalizeBody(body, CanonicalizationRelaxed)
+		if !bytes.Equal(data, want) {
+			t.Errorf("expected canonicalized body to be %q, got %q", want, data)
+		}
+	})
+	t.Run("simple body canonicalization", func(t *testing.T) {
+		body := []byte(`This is just some body text`)
+		want := append(body, []byte("\r\n")...)
+		data := canonicalizeBody(body, CanonicalizationSimple)
+		if !bytes.Equal(data, want) {
+			t.Errorf("expected canonicalized body to be %q, got %q", want, data)
+		}
+	})
+	t.Run(`simple body canonicalization on mail body end removes trailing \r\n`, func(t *testing.T) {
+		body := []byte("This is just some body text\r\n\r\n")
+		want := []byte("This is just some body text\r\n")
+		data := canonicalizeBody(body, CanonicalizationSimple)
+		if !bytes.Equal(data, want) {
+			t.Errorf("expected canonicalized body to be %q, got %q", want, data)
+		}
+	})
+	t.Run(`simple body canonicalization on empty body returns just \r\n`, func(t *testing.T) {
+		want := []byte("\r\n")
+		data := canonicalizeBody(nil, CanonicalizationSimple)
+		if !bytes.Equal(data, want) {
+			t.Errorf("expected canonicalized body to be %q, got %q", want, data)
+		}
+	})
+}
+
+func Test_trimTrailingEmptyLines(t *testing.T) {
+	t.Run("empty body collapses a single CRLF to empty", func(t *testing.T) {
+		got := trimTrailingEmptyLines([]byte("\r\n"))
+		want := []byte("")
+		if !bytes.Equal(got, want) {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+		if len(got) != 0 {
+			t.Errorf("expected empty result, got %d bytes", len(got))
+		}
+	})
+
+	t.Run("all empty lines body reduces to empty", func(t *testing.T) {
+		got := trimTrailingEmptyLines([]byte("\r\n\r\n\r\n"))
+		want := []byte("")
+		if !bytes.Equal(got, want) {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+	})
+}
+func Test_collapseWSPBytes(t *testing.T) {
+	t.Run("collapses trailing whitespace to a single space", func(t *testing.T) {
+		got := collapseWSPBytes([]byte("a  \t "))
+		want := []byte("a ")
+		if !bytes.Equal(got, want) {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+	})
+
+	t.Run("all whitespace collapses to a single space", func(t *testing.T) {
+		got := collapseWSPBytes([]byte("   \t"))
+		want := []byte(" ")
+		if !bytes.Equal(got, want) {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+	})
+}
+
 // testSigner returns a Signer for testing purposes.
 func testSigner(t *testing.T, keyData []byte) *Signer {
 	t.Helper()

--- a/internal/dkim/dkim_test.go
+++ b/internal/dkim/dkim_test.go
@@ -684,6 +684,7 @@ func Test_trimTrailingEmptyLines(t *testing.T) {
 		}
 	})
 }
+
 func Test_collapseWSPBytes(t *testing.T) {
 	t.Run("collapses trailing whitespace to a single space", func(t *testing.T) {
 		got := collapseWSPBytes([]byte("a  \t "))

--- a/internal/ntlm/ntlm_test.go
+++ b/internal/ntlm/ntlm_test.go
@@ -248,7 +248,8 @@ func TestNTLMv2Session_ParseChallengeMessage(t *testing.T) {
 		session.SetUserInfo(testUser, testPassword, testDomain)
 		message, err := CreateChallengeMessage(
 			uint32(ntlmsspNegotiateUnicode|ntlmsspNegotiateAlwaysSign|ntlmsspNegotiateKeyExchange),
-			[]byte(testChallenge), testHost, testDomain)
+			[]byte(testChallenge), testHost, testDomain,
+		)
 		if err != nil {
 			t.Fatalf("failed to create challenge message: %s", err)
 		}
@@ -347,7 +348,8 @@ func TestNTLMv2Session_GenerateAuthenticateMessage(t *testing.T) {
 		session.SetUserInfo(testUser, testPassword, testDomain)
 		message, err := CreateChallengeMessage(
 			uint32(ntlmsspNegotiateUnicode|ntlmsspNegotiateAlwaysSign|ntlmsspNegotiateKeyExchange),
-			[]byte(testChallenge), testHost, testDomain)
+			[]byte(testChallenge), testHost, testDomain,
+		)
 		if err != nil {
 			t.Fatalf("failed to create challenge message: %s", err)
 		}
@@ -425,7 +427,8 @@ func TestNTLMv2Session_GenerateAuthenticateMessage(t *testing.T) {
 				session.SetUserInfo(testUser, testPassword, testDomain)
 				message, err := CreateChallengeMessage(
 					uint32(ntlmsspNegotiateUnicode|ntlmsspNegotiateAlwaysSign|ntlmsspNegotiateKeyExchange),
-					[]byte(testChallenge), testHost, testDomain)
+					[]byte(testChallenge), testHost, testDomain,
+				)
 				if err != nil {
 					t.Fatalf("failed to create challenge message: %s", err)
 				}
@@ -502,7 +505,8 @@ func TestNTLMv2Session_computeEncryptedSessionKey(t *testing.T) {
 		session.SetUserInfo(testUser, testPassword, testDomain)
 		message, err := CreateChallengeMessage(
 			uint32(ntlmsspNegotiateUnicode|ntlmsspNegotiateAlwaysSign|ntlmsspNegotiateKeyExchange),
-			[]byte(testChallenge), testHost, testDomain)
+			[]byte(testChallenge), testHost, testDomain,
+		)
 		if err != nil {
 			t.Fatalf("failed to create challenge message: %s", err)
 		}
@@ -520,7 +524,8 @@ func TestCreateChallengeMessage(t *testing.T) {
 	t.Run("creates challenge message successfully", func(t *testing.T) {
 		_, err := CreateChallengeMessage(
 			uint32(ntlmsspNegotiateUnicode|ntlmsspNegotiateAlwaysSign|ntlmsspNegotiateKeyExchange),
-			[]byte(testChallenge), testHost, testDomain)
+			[]byte(testChallenge), testHost, testDomain,
+		)
 		if err != nil {
 			t.Fatalf("failed to create challenge message: %s", err)
 		}
@@ -529,7 +534,8 @@ func TestCreateChallengeMessage(t *testing.T) {
 		_, err := CreateChallengeMessage(
 			uint32(ntlmsspNegotiateUnicode|ntlmsspNegotiateAlwaysSign|ntlmsspNegotiateKeyExchange|
 				ntlmsspNegotiateExtendedSessionSecurity),
-			[]byte(testChallenge), testHost, testDomain)
+			[]byte(testChallenge), testHost, testDomain,
+		)
 		if err != nil {
 			t.Fatalf("failed to create challenge message: %s", err)
 		}
@@ -537,7 +543,8 @@ func TestCreateChallengeMessage(t *testing.T) {
 	t.Run("challenge message creation with overly long domain fails", func(t *testing.T) {
 		_, err := CreateChallengeMessage(
 			uint32(ntlmsspNegotiateUnicode|ntlmsspNegotiateAlwaysSign|ntlmsspNegotiateKeyExchange),
-			[]byte(testChallenge), testHost, strings.Repeat("x", math.MaxInt16+1))
+			[]byte(testChallenge), testHost, strings.Repeat("x", math.MaxInt16+1),
+		)
 		if err == nil {
 			t.Error("expected challenge message creation to fail, but got nil")
 		}
@@ -545,7 +552,8 @@ func TestCreateChallengeMessage(t *testing.T) {
 	t.Run("challenge message creation with overly long target fails", func(t *testing.T) {
 		_, err := CreateChallengeMessage(
 			uint32(ntlmsspNegotiateUnicode|ntlmsspNegotiateAlwaysSign|ntlmsspNegotiateKeyExchange),
-			[]byte(testChallenge), strings.Repeat("x", math.MaxInt16+1), testDomain)
+			[]byte(testChallenge), strings.Repeat("x", math.MaxInt16+1), testDomain,
+		)
 		if err == nil {
 			t.Error("expected challenge message creation to fail, but got nil")
 		}

--- a/msg.go
+++ b/msg.go
@@ -3123,15 +3123,22 @@ func writeFuncFromBuffer(buffer *bytes.Buffer) func(io.Writer) (int64, error) {
 	return writeFunc
 }
 
+// mailAddressStringWithoutName returns the string representation of a mail address without the name.
 func mailAddressStringWithoutName(addr mail.Address) string {
 	addr.Name = ""
 	return addr.String()
 }
 
+// hasDKIM returns true if the Msg has a DKIM config.
+func (m *Msg) hasDKIM() bool {
+	return m.dkim != nil
+}
+
 // splitMessage returns bytes before, and bytes after, the first blank line.
 func splitMessage(b []byte) (headers, body []byte) {
 	if i := bytes.Index(b, []byte("\r\n\r\n")); i >= 0 {
-		return b[:i+2], b[i+4:] // keep trailing CRLF on the header block
+		// keep trailing CRLF on the header block
+		return b[:i+2], b[i+4:]
 	}
 	return b, nil
 }

--- a/msg.go
+++ b/msg.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/wneessen/go-mail/internal/dkim"
 )
 
 var (
@@ -165,7 +167,7 @@ type Msg struct {
 	sMIME *SMIME
 
 	// dkim holds the DKIM configuration for signing the Msg
-	dkim *DKIMConfig
+	dkim *dkim.Signer
 }
 
 // SendmailPath is the default system path to the sendmail binary - at least on standard Unix-like OS.
@@ -337,6 +339,25 @@ func WithMiddleware(middleware Middleware) MsgOption {
 func WithPGPType(pgptype PGPType) MsgOption {
 	return func(m *Msg) {
 		m.pgptype = pgptype
+	}
+}
+
+// WithDKIM sets the DKIM signer for the Msg during its creation or initialization,
+//
+// This MsgOption function allows you to specify the DKIM signer to be used for digitally
+// signing the message header and body.
+//
+// Parameters:
+//   - signer: The dkim.Signer instance to be used for signing the message.
+//
+// Returns:
+//   - A MsgOption function that can be used to customize the Msg instance.
+//
+// References:
+//   - https://datatracker.ietf.org/doc/html/rfc6376
+func WithDKIM(signer *dkim.Signer) MsgOption {
+	return func(m *Msg) {
+		m.dkim = signer
 	}
 }
 

--- a/msg.go
+++ b/msg.go
@@ -163,6 +163,9 @@ type Msg struct {
 
 	// sMIME holds a SMIME type to sign a Msg using S/MIME
 	sMIME *SMIME
+
+	// dkim holds the DKIM configuration for signing the Msg
+	dkim *DKIMConfig
 }
 
 // SendmailPath is the default system path to the sendmail binary - at least on standard Unix-like OS.
@@ -2213,19 +2216,33 @@ func (m *Msg) applyMiddlewares(msg *Msg) *Msg {
 //
 // References:
 //   - https://datatracker.ietf.org/doc/html/rfc5322
-func (m *Msg) WriteTo(writer io.Writer) (int64, error) {
-	mw := &msgWriter{writer: writer, charset: m.charset, encoder: m.encoder}
-	msg := m.applyMiddlewares(m)
-
-	if m.hasSMIME() {
-		if err := m.signMessage(); err != nil {
-			return 0, err
-		}
+func (m *Msg) WriteTo(w io.Writer) (int64, error) {
+	if !m.hasDKIM() {
+		return m.writeToInner(w)
+	}
+	if err := m.dkim.ValidateConfig(); err != nil {
+		return 0, err
 	}
 
-	mw.writeMsg(msg)
-	m.headerCount = 0
-	return mw.bytesWritten, mw.err
+	buffer := bytes.NewBuffer(nil)
+	if _, err := m.writeToInner(buffer); err != nil {
+		return 0, err
+	}
+
+	headers, body := splitMessage(buffer.Bytes())
+	signature, err := m.dkim.Sign(headers, body)
+	if err != nil {
+		return 0, fmt.Errorf("failed to DKIM sign message: %w", err)
+	}
+
+	var total int64
+	length, err := io.WriteString(w, signature)
+	total += int64(length)
+	if err != nil {
+		return total, err
+	}
+	n2, err := w.Write(buffer.Bytes())
+	return total + int64(n2), err
 }
 
 // WriteToSkipMiddleware writes the formatted Msg into the given io.Writer, but skips the specified
@@ -3030,6 +3047,21 @@ func (m *Msg) signMessage() error {
 	return nil
 }
 
+func (m *Msg) writeToInner(writer io.Writer) (int64, error) {
+	mw := &msgWriter{writer: writer, charset: m.charset, encoder: m.encoder}
+	msg := m.applyMiddlewares(m)
+
+	if m.hasSMIME() {
+		if err := m.signMessage(); err != nil {
+			return 0, err
+		}
+	}
+
+	mw.writeMsg(msg)
+	m.headerCount = 0
+	return mw.bytesWritten, mw.err
+}
+
 // writeFuncFromBuffer converts a byte buffer into a writeFunc, which is commonly required by go-mail.
 //
 // This function wraps a byte buffer into a write function that can be used to write the buffer's content
@@ -3056,4 +3088,12 @@ func writeFuncFromBuffer(buffer *bytes.Buffer) func(io.Writer) (int64, error) {
 func mailAddressStringWithoutName(addr mail.Address) string {
 	addr.Name = ""
 	return addr.String()
+}
+
+// splitMessage returns bytes before, and bytes after, the first blank line.
+func splitMessage(b []byte) (headers, body []byte) {
+	if i := bytes.Index(b, []byte("\r\n\r\n")); i >= 0 {
+		return b[:i+2], b[i+4:] // keep trailing CRLF on the header block
+	}
+	return b, nil
 }

--- a/msg.go
+++ b/msg.go
@@ -459,6 +459,23 @@ func (m *Msg) SetPGPType(pgptype PGPType) {
 	m.pgptype = pgptype
 }
 
+// SetDKIM sets or overrides the currently set DKIM signer for the Msg.
+//
+// This method allows the user to assign a DKIMSigner to a Msg to be used for digitally
+// signing the message header and body.
+//
+// Parameters:
+//   - signer: The dkim.Signer instance to be used for signing the message.
+//
+// Returns:
+//   - A MsgOption function that can be used to customize the Msg instance.
+//
+// References:
+//   - https://datatracker.ietf.org/doc/html/rfc6376
+func (m *Msg) SetDKIM(signer *dkim.Signer) {
+	m.dkim = signer
+}
+
 // Encoding returns the currently set Encoding of the Msg as a string.
 //
 // This method retrieves the encoding type that is currently applied to the message. The

--- a/msg_test.go
+++ b/msg_test.go
@@ -151,10 +151,6 @@ var (
 		{"1@23456789", true},                 // Hypothetically valid, if somebody registers that TLD
 		{"1@[23456789]", false},              // While 23456789 is decimal for 1.101.236.21 it is not RFC5322 compliant
 	}
-
-	testKeyEd25519 = []byte(`-----BEGIN PRIVATE KEY-----
-MC4CAQAwBQYDK2VwBCIEIPEZCuuDQ2PIH1RDbMl92DIb8Vsqz2j7B26aHomVq1pU
------END PRIVATE KEY-----`)
 )
 
 //go:embed testdata/attachment.txt testdata/embed.txt

--- a/msg_test.go
+++ b/msg_test.go
@@ -151,6 +151,10 @@ var (
 		{"1@23456789", true},                 // Hypothetically valid, if somebody registers that TLD
 		{"1@[23456789]", false},              // While 23456789 is decimal for 1.101.236.21 it is not RFC5322 compliant
 	}
+
+	testKeyEd25519 = []byte(`-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIPEZCuuDQ2PIH1RDbMl92DIb8Vsqz2j7B26aHomVq1pU
+-----END PRIVATE KEY-----`)
 )
 
 //go:embed testdata/attachment.txt testdata/embed.txt
@@ -296,6 +300,24 @@ func TestNewMsg(t *testing.T) {
 		if !message.noDefaultUserAgent {
 			t.Errorf("NewMsg(WithNoDefaultUserAgent()) failed. Expected noDefaultUserAgent to be true, got: %t",
 				message.noDefaultUserAgent)
+		}
+	})
+	t.Run("new message with DKIM enabled", func(t *testing.T) {
+		privKey, err := PrivKeyFromPEM(testKeyEd25519)
+		if err != nil {
+			t.Fatalf("failed to parse private key: %s", err)
+		}
+		signer := NewDKIMSigner("example.com", "2026a", privKey)
+		if err := signer.ValidateConfig(); err != nil {
+			t.Errorf("failed to validate DKIM signer: %s", err)
+		}
+
+		message := NewMsg(WithDKIM(signer))
+		if message == nil {
+			t.Fatal("message is nil")
+		}
+		if message.dkim == nil {
+			t.Error("NewMsg(WithDKIM(signer)) failed. Expected dkim to be set, got: nil")
 		}
 	})
 }
@@ -7846,6 +7868,45 @@ func TestMsg_WriteTo(t *testing.T) {
 			{122, "--", false, true, true},
 		}
 		checkMessageContent(t, buffer, wants)
+	})
+	t.Run("WriteTo signs a message using DKIM", func(t *testing.T) {
+		want := "DKIM-Signature: v=1; c=relaxed/relaxed; d=example.com; s=2026a; \r\n a=ed25519-sha256; t=1767225600; \r\n h=From:To:Subject:Date:Message-ID:Content-Type:MIME-Version; \r\n bh=49fo3/jj15NoKm5fLrmLVtMTQ0TyPn74pVKyKx1gvqY=; b=cz3lNOkF/HAk97qyUsguQwJY\r\n DHrH+NVXDJdNQDG9CGUfWm1AkD53ggcU7/MEkE/mZfPiHrA8UBpk3PJyn9uaAA==\r\nDate: Thu, 01 Jan 2026 00:00:00 +0000\r\nMIME-Version: 1.0\r\nMessage-ID: <test-message-id>\r\nSubject: Testmail\r\nUser-Agent: go-mail DKIM test\r\nX-Mailer: go-mail DKIM test\r\nFrom: <valid-from@domain.tld>\r\nTo: <valid-to@domain.tld>\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\nTestmail"
+		now := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+		privKey, err := PrivKeyFromPEM(testKeyEd25519)
+		if err != nil {
+			t.Fatalf("failed to parse private key: %s", err)
+		}
+		signer := NewDKIMSigner("example.com", "2026a", privKey)
+		if err := signer.ValidateConfig(); err != nil {
+			t.Errorf("failed to validate DKIM signer: %s", err)
+		}
+		signer.NowFunc = func() time.Time {
+			return now
+		}
+
+		message := testMessage(t)
+		message.SetMessageIDWithValue("test-message-id")
+		message.SetUserAgent("go-mail DKIM test")
+		message.SetDateWithValue(now)
+		message.SetDKIM(signer)
+
+		buffer := bytes.NewBuffer(nil)
+		if _, err = message.WriteTo(buffer); err != nil {
+			t.Fatalf("failed to write message to buffer: %s", err)
+		}
+		if buffer.String() != want {
+			t.Errorf("DKIM signing failed, expected: %q, got: %q", want, buffer.String())
+		}
+	})
+	t.Run("WriteTo fails to DKIM sign a message with an incomplete config", func(t *testing.T) {
+		signer := NewDKIMSigner("", "2026a", nil)
+		message := testMessage(t)
+		message.SetDKIM(signer)
+
+		buffer := bytes.NewBuffer(nil)
+		if _, err := message.WriteTo(buffer); err == nil {
+			t.Error("expected DKIM signing to fail but didn't")
+		}
 	})
 }
 


### PR DESCRIPTION
This PR adds native DKIM support. 

- It implements DKIM signing according to RFC 6376
- It provides support for both simple and relaxed canonicalization algorithms
- It provides support for RSA and ED25519 signature algorithms.
- It injects natively into go-mail as first class citizen

This implementation only supports RSA-SHA256 and ED25519-SHA256 signature algorithms. RSA-SHA1 is not supported since it's deprecated and prohibited by RFC 8301.

The PR closes #577