### PR TITLE
Fix toUint32 range check and add 64bit tests

### DIFF
--- a/internal/ntlm/ntlm.go
+++ b/internal/ntlm/ntlm.go
@@ -74,7 +74,7 @@ func toUint16(n int) (uint16, error) {
 
 // toUint32 converts an int to a uint16, returning an error if the value is out of range.
 func toUint32(n int) (uint32, error) {
-	if n < 0 || n > math.MaxUint32 {
+	if n < 0 || int64(n) > math.MaxUint32 {
 		return 0, fmt.Errorf("value %d out of uint32 range", n)
 	}
 	return uint32(n), nil

--- a/internal/ntlm/ntlm_64bit_test.go
+++ b/internal/ntlm/ntlm_64bit_test.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: The go-mail Authors
+//
+// SPDX-License-Identifier: MIT
+
+//go:build amd64 || arm64 || ppc64 || ppc64le || mips64 || mips64le || s390x || riscv64 || loong64 || wasm
+
+package ntlm
+
+import (
+	"math"
+	"testing"
+)
+
+func Test_toUint32_64bitonly(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   int
+		want    uint32
+		wantErr bool
+	}{
+		// These test cases only make sense where int is wider than 32 bits
+		// (i.e. 64-bit platforms). On 32-bit, int can't hold these values.
+		// https://github.com/wneessen/go-mail/issues/588
+		{"max uint32 fits", math.MaxUint32, math.MaxUint32, false},
+		{"max uint32 + 1 overflows and fails", math.MaxUint32 + 1, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toUint32(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("failed to convert int to uint16, got: %s", err)
+			}
+			if got != tt.want {
+				t.Errorf("failed to convert int to uint16, got: %d, want: %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ntlm/ntlm_test.go
+++ b/internal/ntlm/ntlm_test.go
@@ -96,8 +96,6 @@ func Test_toUint32(t *testing.T) {
 	}{
 		{"int fits into uint32", 1, 1, false},
 		{"negative int fails", -1, 0, true},
-		{"max uint32 fits", 4294967295, 4294967295, false},
-		{"max uint32 + 1 overflows and fails", 4294967296, 0, true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- Use int64(n) for the range check to avoid overflow on 32-bit platforms
- Add 64-bit only tests for toUint32 and remove tests that assume int can hold MaxUint32

Fixes #588