### PR TITLE
Add option to specify RCPTs directly

### DIFF
--- a/client.go
+++ b/client.go
@@ -1179,16 +1179,16 @@ func (c *Client) SetAlwaysDKIMSign(signer *dkim.Signer) error {
 //   - An Option function that sets the RCPT addresses.
 //   - An error if any address is invalid.
 func (c *Client) SetRCPTs(rcpts ...string) error {
+	resRCPTs := make([]string, 0, len(rcpts))
 	for _, rcpt := range rcpts {
 		address, err := mail.ParseAddress(rcpt)
 		if err != nil {
 			return fmt.Errorf(errParseMailAddr, rcpt, err)
 		}
-		if address.Address != rcpt {
-			return fmt.Errorf("plain address expected: %s", rcpt)
-		}
+		address.Name = ""
+		resRCPTs = append(resRCPTs, "<"+address.Address+">")
 	}
-	c.rcpts = rcpts
+	c.rcpts = resRCPTs
 	return nil
 }
 

--- a/client.go
+++ b/client.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/mail"
 	"os"
 	"slices"
 	"strings"
@@ -234,6 +235,9 @@ type (
 		//
 		// https://datatracker.ietf.org/doc/html/rfc8314
 		useSSL bool
+
+		// rcpts is the list of addresses to send in RCPT commands, instead of those coming from GetRecipients.
+		rcpts []string
 	}
 )
 
@@ -867,6 +871,22 @@ func WithOpportunisticSMTPAuth(preferredMechs ...SMTPAuthType) Option {
 	}
 }
 
+// WithRCPTs sets the list of addresses to send in RCPT commands.
+//
+// If this is set, addresses returned from GetRecipients are not used for RCPT.
+//
+// Parameters:
+//   - rcpts: strings containing addresses passed to the server in RCPT commands.
+//
+// Returns:
+//   - An Option function that sets the RCPT addresses.
+//   - An error if any address is invalid.
+func WithRCPTs(rcpts ...string) Option {
+	return func(c *Client) error {
+		return c.SetRCPTs(rcpts...)
+	}
+}
+
 // TLSPolicy returns the TLSPolicy that is currently set on the Client as a string.
 //
 // This method retrieves the current TLSPolicy configured for the Client and returns it as a string representation.
@@ -1145,6 +1165,30 @@ func (c *Client) SetAlwaysDKIMSign(signer *dkim.Signer) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	c.dkim = signer
+	return nil
+}
+
+// SetRCPTs sets the list of addresses to send in RCPT commands.
+//
+// If this is set, addresses returned from GetRecipients are not used for RCPT.
+//
+// Parameters:
+//   - rcpts: strings containing addresses passed to the server in RCPT commands.
+//
+// Returns:
+//   - An Option function that sets the RCPT addresses.
+//   - An error if any address is invalid.
+func (c *Client) SetRCPTs(rcpts ...string) error {
+	for _, rcpt := range rcpts {
+		address, err := mail.ParseAddress(rcpt)
+		if err != nil {
+			return fmt.Errorf(errParseMailAddr, rcpt, err)
+		}
+		if address.Address != rcpt {
+			return fmt.Errorf("plain address expected: %s", rcpt)
+		}
+	}
+	c.rcpts = rcpts
 	return nil
 }
 
@@ -1687,12 +1731,16 @@ func (c *Client) sendSingleMsg(client *smtp.Client, message *Msg) error {
 			enhancedStatusCode: enhancedStatusCode(err, escSupport),
 		}
 	}
-	rcpts, err := message.GetRecipients()
-	if err != nil {
-		return &SendError{
-			Reason: ErrGetRcpts, errlist: []error{err}, isTemp: isTempError(err),
-			affectedMsg: message, errcode: errorCode(err),
-			enhancedStatusCode: enhancedStatusCode(err, escSupport),
+	rcpts := c.rcpts
+	if len(rcpts) == 0 {
+		var err error
+		rcpts, err = message.GetRecipients()
+		if err != nil {
+			return &SendError{
+				Reason: ErrGetRcpts, errlist: []error{err}, isTemp: isTempError(err),
+				affectedMsg: message, errcode: errorCode(err),
+				enhancedStatusCode: enhancedStatusCode(err, escSupport),
+			}
 		}
 	}
 


### PR DESCRIPTION
When go-mail library is used in MTA scenario to deliver the message to different SMTP servers, it must not send RCPT commands for every address returned by `GoRecipients` method. Instead, it must run RCPT commands only for addresses the SMTP server is responsible for.

To achieve this function `WithRCPTs` and method `SetRCPTs` are added to the SMTP client, to make it possible to set addresses to use in RCPT commands.

Proposed change is backward-compatible. RCPTs set with these functions take precedence over the addresses returned from `GetRecipients`. But if RCPTs are not provided, the previous behavior is preserved.